### PR TITLE
Incorporate some flag design to the deploy command

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -10,7 +10,7 @@ const prettyjson = require('prettyjson')
 class DeployCommand extends Command {
   async run() {
     await this.authenticate()
-    const { args, flags } = this.parse(DeployCommand)
+    const { flags } = this.parse(DeployCommand)
 
     const accessToken = this.global.get('accessToken')
     if (!accessToken) {
@@ -31,7 +31,7 @@ class DeployCommand extends Command {
 
     // TODO: abstract settings lookup
     const deployFolder =
-      args.publishFolder ||
+      flags['publish-folder'] ||
       get(this.site.toml, 'build.publish') ||
       get(await this.netlify.getSite({ siteId }), 'build_settings.dir')
 
@@ -74,20 +74,17 @@ class DeployCommand extends Command {
 
 DeployCommand.description = `${renderShortDesc(`Create a new deploy from the contents of a folder`)}
 
-If the deploy path argument is omitted, then the settings from the netlify.toml file or the settings from the API will be used instead.
+Deploys from the build settings found in the netlify.toml file, or settings from the api.
 `
-
-DeployCommand.args = [
-  {
-    name: 'publishFolder',
-    required: false, // make the arg required with `required: true`
-    description: 'folder to deploy (optional)'
-  }
-]
 
 DeployCommand.flags = {
   functions: flags.string({
-    description: 'Specify a function folder for a deploy'
+    char: 'f',
+    description: 'Specify a functions folder to deploy'
+  }),
+  'publish-folder': flags.string({
+    char: 'p',
+    description: 'Specify a folder to deploy'
   })
 }
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -31,7 +31,7 @@ class DeployCommand extends Command {
 
     // TODO: abstract settings lookup
     const deployFolder =
-      flags['publish-folder'] ||
+      flags['publish'] ||
       get(this.site.toml, 'build.publish') ||
       get(await this.netlify.getSite({ siteId }), 'build_settings.dir')
 
@@ -42,9 +42,11 @@ class DeployCommand extends Command {
 
     if (!deployFolder) {
       this.error(
-        `Can't determine a deploy folder.  Please define one in your site settings, netlift.toml or pass one as an argument.`
+        `Can't determine a deploy folder.  Please define one in your site settings, netlift.toml or pass one as a flag.`
       )
     }
+
+    if (flags.draft) this.error('Draft deploys not implemented (yet)')
 
     // TODO go through the above resolution, and make sure the resolve algorithm makes sense
     const resolvedDeployPath = path.resolve(this.site.root, deployFolder)
@@ -82,9 +84,13 @@ DeployCommand.flags = {
     char: 'f',
     description: 'Specify a functions folder to deploy'
   }),
-  'publish-folder': flags.string({
+  publish: flags.string({
     char: 'p',
     description: 'Specify a folder to deploy'
+  }),
+  draft: flags.string({
+    char: 'd',
+    description: 'Create a draft deploy'
   })
 }
 


### PR DESCRIPTION
Specifying a folder and functions folder during a deploy is now done only by flags.  The reason is, if you omit the flag, you are likely depending on the toml file or the settings you set in the web ui.  This is probably more correct default behavior than deploying the cwd.

```console
bret-netlify:cli bret$ netlify help deploy
Create a new deploy from the contents of a folder

USAGE
  $ netlify deploy
OPTIONS
  -f, --functions=functions            Specify a functions folder to deploy  
  -p, --publish-folder=publish-folder  Specify a folder to deploy

DESCRIPTION
  Deploys from the build settings found in the netlify.toml file, or settings from the api.
```