### PR TITLE
[WIP] Add use case instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,31 +68,13 @@ netlify logout
 
 This will remove the access key from the `.netlify/config.json` file in your home folder.
 
-### Obtain a Token in the Netlify UI
-
-You can generate an access token manually in your Netlify account settings under [**OAuth applications**](https://app.netlify.com/applications).
-
-1. Under **Personal access tokens**, select **New access token**.
-2. Enter a description and select **Generate token**.
-3. Copy the generated token to your clipboard. Once you navigate from the page, the token cannot be seen again.
-4. On the computer where you want to run Netlify CLI, create a `.netlify` folder inside the home folder, and a `config.json` file inside of that.
-5. Add the following line to the `config.json` file:
-
-   ```json
-   {
-   "accessToken": "PASTE_YOUR_ACCESS_TOKEN_HERE"
-   }
-   ```
-
-Netlify CLI will use the access token in that location automatically.
-
 ### Revoking Access
 
 To revoke access to your account for Netlify CLI, go to the [**OAuth applications**](https://app.netlify.com/applications) section of your account settings. Find the appropriate token or application, and select **Revoke**.
 
 ## Continuous Deployment
 
-With [continuous deployment](https://www.netlify.com/docs/continuous-deployment), Netlify will automatically deploy new versions of your site when you push commits to your connected Git repository. This also enables features like Deploy Previews, branch deploys, and [split testing](https://www.netlify.com/docs/split-testing). (Some of these features must be enabled in the Netlify UI.)
+With [continuous deployment](https://www.netlify.com/docs/continuous-deployment), Netlify will automatically deploy new versions of your site when you push commits to your connected Git repository. This also enables features like Deploy Previews, branch deploys, and [split testing](https://www.netlify.com/docs/split-testing). (Split testing must be enabled in the Netlify UI.)
 
 ### Automated Setup
 
@@ -131,11 +113,15 @@ A common use case for this command is when you're using a separate Continuous In
 
 ### Create a new site
 
-In order manually deploy, you need to connect to a site on Netlify. You can create a site by dropping a folder into the Netlify UI, or you can create one from the command line with the following command:
+To create a new Netlify site with the CLI, run the `netlify init` command in your site folder.
 
 ```bash
-netlify sites:create
+netlify init
+
+# Then Choose "Create & configure a new site in Netlify"
 ```
+
+Proceed through the prompts to finish configuring your site.
 
 ### Link to a Site
 
@@ -145,7 +131,7 @@ Linking to a site tells Netlify CLI which site the current directory should depl
 netlify link
 ```
 
-This will add a `siteId` field to a new file inside your project folder, at `.netlify/config.json`. To unlink your folder from the site, you can remove this field, or you can run the following command from inside the project folder:
+This will add a `siteId` field to a new file inside your project folder, at `.netlify/state.json`. To unlink your folder from the site, you can remove this field, or you can run the following command from inside the project folder:
 
 ```bash
 netlify unlink

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ netlify login
 
 This will open a browser window, asking you to log in with Netlify and grant access to **Netlify Cli**.
 
-![](/img/docs/cli/authorize-ui.png)
+![](https://www.netlify.com/img/docs/cli/authorize-ui.png)
 
 Once authorized, Netlify CLI will store your access token in your home folder, under `.netlify/config.json`. Netlify CLI will use the token in this location automatically for all future commands.
 
@@ -92,7 +92,7 @@ To revoke access to your account for Netlify CLI, go to the [**OAuth application
 
 ## Continuous Deployment
 
-With [continuous deployment](/docs/continuous-deployment), Netlify will automatically deploy new versions of your site when you push commits to your connected Git repository. This also enables features like Deploy Previews, branch deploys, and [split testing](/docs/split-testing). (Some of these features must be enabled in the Netlify UI.)
+With [continuous deployment](https://www.netlify.com/docs/continuous-deployment), Netlify will automatically deploy new versions of your site when you push commits to your connected Git repository. This also enables features like Deploy Previews, branch deploys, and [split testing](https://www.netlify.com/docs/split-testing). (Some of these features must be enabled in the Netlify UI.)
 
 ### Automated Setup
 
@@ -117,10 +117,10 @@ netlify init --manual
 The tool will prompt you for your deploy settings, then provide you with two items you will need to add to your repository settings with your Git provider:
 
 * **Deploy/access key:** Netlify uses this key to fetch your repository via ssh for building and deploying.
-      ![Sample terminal output reads: 'Give this Netlify SSH public key access to your repository,' and displays a key code.](/img/docs/cli/deploy-key-cli.png)
+      ![Sample terminal output reads: 'Give this Netlify SSH public key access to your repository,' and displays a key code.](https://www.netlify.com/img/docs/cli/deploy-key-cli.png)
   Copy the key printed in the command line, then add it as a deploy key in the repository settings on your Git Provider. The deploy key does not require write access. Note that if you have more than one site connected to a repo, you will need a unique key for each one.
 * **Webhook:** Your Git provider will send a message to this webhook when you push changes to your repository, triggering a new deploy on Netlify.
-      ![Sample terminal output reads: 'Configure the following webhook for your repository,' and displays a URL.](/img/docs/cli/webhook-cli.png)
+      ![Sample terminal output reads: 'Configure the following webhook for your repository,' and displays a URL.](https://www.netlify.com/img/docs/cli/webhook-cli.png)
   Copy the webhook address printed in the command line, then add it as the Payload URL for a new webhook in the repository settings on your Git provider. If available, the **Content type** should be set to `application/json`. When selecting events to trigger the webhook, **Push** events will trigger production and branch deploys on watched branches, and **Pull/Merge request** events will trigger deploy previews.
 
 ## Manual Deploy
@@ -162,7 +162,7 @@ netlify deploy
 This command needs to know which folder to publish, and if your project includes functions, a functions folder to deploy. It will look for this information in three places, in the following order:
 
 * in flags specified in the command itself
-* in a [netlify.toml file](/docs/netlify-toml-reference) stored at the base of your project directory.
+* in a [netlify.toml file](https://www.netlify.com/docs/netlify-toml-reference) stored at the base of your project directory.
 * in your site settings in the Netlify UI.
 
 Here is an example using command flags to set the publish folder and functions folder:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This will remove the access key from the `.netlify/config.json` file in your hom
 
 ### Obtain a Token in the Netlify UI
 
-You can generate an access token manually in your Netlify account settings under [**OAuth applications**](https://app.netlify.com/applications). 
+You can generate an access token manually in your Netlify account settings under [**OAuth applications**](https://app.netlify.com/applications).
 
 1. Under **Personal access tokens**, select **New access token**.
 2. Enter a description and select **Generate token**.
@@ -125,9 +125,9 @@ The tool will prompt you for your deploy settings, then provide you with two ite
 
 ## Manual Deploy
 
-It's also possible to deploy a site manually, without continuous deployment. This method uploads files directly from your local project directory to your site on Netlify, without running a build step. It also works with directories that are not Git repositories. 
+It's also possible to deploy a site manually, without continuous deployment. This method uploads files directly from your local project directory to your site on Netlify, without running a build step. It also works with directories that are not Git repositories.
 
-A common use case for this command is when you're using a separate Contiuous Integration (CI) tool, deploying prebuilt files to Netlify at the end of the CI tool tasks.
+A common use case for this command is when you're using a separate Continuous Integration (CI) tool, deploying prebuilt files to Netlify at the end of the CI tool tasks.
 
 ### Create a new site
 
@@ -168,18 +168,26 @@ This command needs to know which folder to publish, and if your project includes
 Here is an example using command flags to set the publish folder and functions folder:
 
 ```bash
-netlify deploy --publish-folder=_site --functions=functions
+netlify deploy --dir=build-folder --functions=functions
 ```
 
-### Draft Deploys
+By default, `deploy` will publish to draft previews. The draft site URL will display in the command line when the deploy is done.
 
-To preview a manual deploy without changing it in production, use the `--draft` flag:
+### Production Deploys
+
+By default, all `deploys` are set to a draft preview URL.
+
+To do a manual deploy to production, use the `--prod` flag:
 
 ```bash
-netlify deploy --draft
+# Deploy build folder to production
+netlify deploy --prod
+
+# Shorthand -p
+netlify deploy -p
 ```
 
-This will run a deploy just like your production deploy, but at a unique address. The draft site URL will display in the command line when the deploy is done.
+Deploying to production will publish the build directory at the live URL of your Netlify site.
 
 ## Inline Help
 
@@ -192,13 +200,13 @@ netlify help
 For more information about a specific command, run `help` with the name of the command.
 
 ```bash
-netlify help deploy
+netlify deploy help
 ```
 
 This also works for sub-commands.
 
 ```bash
-netlify help sites:create
+netlify sites:create help
 ```
 
 ## Full Command Reference


### PR DESCRIPTION
**- Summary**
Adds context to the available commands, replacing the existing Get Started and intro docs pages.

I couldn't get the `build:docs` command to work for me locally, so we still need to run that to generate the ToC and Command reference with Markdown Magic.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://files.brightside.me/files/news/part_59/596510/4954910-DdartCTV4AACBu5-1526975516-728-937561159f-1536049137.jpg)