### PR TITLE
Don’t throw on state lookup in a missing folder

### DIFF
--- a/src/base/state/index.js
+++ b/src/base/state/index.js
@@ -18,7 +18,7 @@ class StateConfig {
       return JSON.parse(fs.readFileSync(this.path, 'utf8'))
     } catch (err) {
       // Don't create if it doesn't exist
-      if (err.code === 'ENOENT') {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
         return {}
       }
 


### PR DESCRIPTION
Catch missing folder errors as well as missing file errors on state lookup.