### PR TITLE
Update to netlify@2.0.1-beta.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lodash.snakecase": "^4.1.1",
     "log-symbols": "^2.2.0",
     "make-dir": "^1.3.0",
-    "netlify": "^2.0.1-beta.5",
+    "netlify": "2.0.1-beta.8",
     "node-fetch": "^2.2.0",
     "ora": "^3.0.0",
     "p-wait-for": "^2.0.0",


### PR DESCRIPTION
Update to `netlify@2.0.1-beta.8` to improve cli characteristics when creating very large deploys. 