### PR TITLE
Allow CI setup without a local clone from sites:create command

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -93,7 +93,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
       // create site or search for one
       if (noGitRemoteChoice === NEW_SITE_NO_GIT) {
         // run site:create command
-        siteData = await SitesCreateCommand.run(['--no-manual'])
+        siteData = await SitesCreateCommand.run([])
 
         console.log(`"${siteData.name}" site was created`)
         console.log()
@@ -161,7 +161,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
         type: 'new site'
       })
       // run site:create command
-      siteData = await SitesCreateCommand.run(['--no-manual'])
+      siteData = await SitesCreateCommand.run([])
     } else if (initChoice === EXISTING_SITE) {
       // run link command
       siteData = await LinkCommand.run([], false)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -93,7 +93,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
       // create site or search for one
       if (noGitRemoteChoice === NEW_SITE_NO_GIT) {
         // run site:create command
-        siteData = await SitesCreateCommand.run([])
+        siteData = await SitesCreateCommand.run(['--no-manual'])
 
         console.log(`"${siteData.name}" site was created`)
         console.log()
@@ -161,7 +161,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
         type: 'new site'
       })
       // run site:create command
-      siteData = await SitesCreateCommand.run([])
+      siteData = await SitesCreateCommand.run(['--no-manual'])
     } else if (initChoice === EXISTING_SITE) {
       // run link command
       siteData = await LinkCommand.run([], false)

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -1,6 +1,5 @@
 const { flags } = require('@oclif/command')
 const inquirer = require('inquirer')
-const isEmpty = require('lodash.isempty')
 const prettyjson = require('prettyjson')
 const chalk = require('chalk')
 const Command = require('../../base')
@@ -18,7 +17,7 @@ class SitesCreateCommand extends Command {
     let name = flags.name
     const accounts = await api.listAccountsForUser()
     const personal = accounts.find(account => account.type === 'PERSONAL')
-    if (isEmpty(flags)) {
+    if (!name || !accountSlug) {
       console.log('Choose a site name or leave blank for a random name. You can update later.')
       const results = await inquirer.prompt([
         {

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -6,6 +6,7 @@ const chalk = require('chalk')
 const Command = require('../../base')
 const renderShortDesc = require('../../utils/renderShortDescription')
 const { track } = require('../../utils/telemetry')
+const configManual = require("../../utils/init/config-manual");
 
 class SitesCreateCommand extends Command {
   async run() {
@@ -78,6 +79,19 @@ class SitesCreateCommand extends Command {
       siteUrl: url
     })
 
+    if (flags.manual) {
+        const { manualConfig } = await inquirer.prompt([
+            {
+                type: 'confirm',
+                name: 'manualConfig',
+                message: 'Would you like to configure this site\'s git repository manually?',
+                default: true
+            }
+        ]);
+
+        if (manualConfig) await configManual(this, site, {});
+    }
+
     return site
   }
 }
@@ -95,6 +109,12 @@ SitesCreateCommand.flags = {
   'account-slug': flags.string({
     char: 'a',
     description: 'account slug to create the site under'
+  }),
+  'manual': flags.boolean({
+    char: 'm',
+    default: true,
+    description: 'enable the option to configure git manually',
+    allowNo: true
   })
 }
 

--- a/src/utils/init/config-manual.js
+++ b/src/utils/init/config-manual.js
@@ -24,7 +24,7 @@ async function configManual(ctx, site, repo) {
   repo.deploy_key_id = key.id
 
   // TODO: Look these up and default to the lookup order
-  const { buildCmd, buildDir, repoPath } = await inquirer.prompt([
+  const { buildCmd, buildDir } = await inquirer.prompt([
     {
       type: 'input',
       name: 'buildCmd',
@@ -36,17 +36,23 @@ async function configManual(ctx, site, repo) {
       name: 'buildDir',
       message: 'Directory to deploy (blank for current dir):',
       default: '.'
-    },
-    {
-      type: 'input',
-      name: 'repoPath',
-      message: 'The SSH URL of the remote git repo:',
-      default: repo.repo_path,
-      validate: url => !!url.match(/(ssh:\/\/|[a-zA-Z]*@|[a-zA-Z.].*:(?!\/\/))/) || "The URL provided does not use the SSH protocol"
-     }
+    }
   ])
   repo.dir = buildDir
-  repo.repo_path = repoPath
+
+  if (!repo.repo_path) {
+    const { repoPath } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'repoPath',
+        message: 'The SSH URL of the remote git repo:',
+        default: repo.repo_path,
+        validate: url =>
+          !!url.match(/(ssh:\/\/|[a-zA-Z]*@|[a-zA-Z.].*:(?!\/\/))/) || 'The URL provided does not use the SSH protocol'
+      }
+    ])
+    repo.repo_path = repoPath
+  }
 
   if (buildCmd) {
     repo.cmd = buildCmd

--- a/src/utils/init/config-manual.js
+++ b/src/utils/init/config-manual.js
@@ -24,7 +24,7 @@ async function configManual(ctx, site, repo) {
   repo.deploy_key_id = key.id
 
   // TODO: Look these up and default to the lookup order
-  const { buildCmd, buildDir } = await inquirer.prompt([
+  const { buildCmd, buildDir, repoPath } = await inquirer.prompt([
     {
       type: 'input',
       name: 'buildCmd',
@@ -36,9 +36,17 @@ async function configManual(ctx, site, repo) {
       name: 'buildDir',
       message: 'Directory to deploy (blank for current dir):',
       default: '.'
-    }
+    },
+    {
+      type: 'input',
+      name: 'repoPath',
+      message: 'The SSH URL of the remote git repo:',
+      default: repo.repo_path,
+      validate: url => !!url.match(/(ssh:\/\/|[a-zA-Z]*@|[a-zA-Z.].*:(?!\/\/))/) || "The URL provided does not use the SSH protocol"
+     }
   ])
   repo.dir = buildDir
+  repo.repo_path = repoPath
 
   if (buildCmd) {
     repo.cmd = buildCmd


### PR DESCRIPTION
**- Summary**

This PR attempts to offer some solutions to #177. Therefore it does two things:

1. When performing manual configuration, there is now an additional step that offers the option to change the remote repository (while defaulting to the one that it could read locally) and also validates against non-SSH URL's

2. When using `sites:create`, it now gives the option to set up Continuous Integration using all of the available methods in `configManual`, including the new option to set the remote git URL. My favourite new feature here is that this command can now be used to entirely configure manual CI without needing to have the repository local at all

**- Test plan**

The following is the output when using the `sites:create` with my default team and a random name:

<img width="682" alt="screenshot 2018-11-09 at 02 12 46" src="https://user-images.githubusercontent.com/8385528/48239172-ca7c3400-e3c5-11e8-831d-43ebdc81f768.png">

This did not require me to have any local git repository, and all of the details provided were used correctly. I've been able to verify this as the site deployment says it "deploys from 'manual'" and when hovering over that link, I am greeted with this hyperlink:

```
https://app.netlify.com/sites/clever-curran-7704a4/git@code.samholmes.net:sam/test.git
```

Thus showing that the remote git URL has been set correctly on the `repo` object. Having set up my personal GitLab instance with the webhook and deploy key, I can confirm that `git push` deploys are working as expected without needing to have a local repo instance on hand.

---

Now, when using the `netlify init --manual`, you can see that I have the option pre-filled in my local repo for the git deployment information:

<img width="682" alt="screenshot 2018-11-09 at 02 08 50" src="https://user-images.githubusercontent.com/8385528/48239377-8ccbdb00-e3c6-11e8-889e-48d4e5370a5c.png">

If this does not conform to the following regex (to verify that it is an ssh URL):

```regex
/(ssh:\/\/|[a-zA-Z]*@|[a-zA-Z.].*:(?!\/\/))/
```

([testing of this regex](https://regexr.com/42pg4))

Then the following error will occur:

<img width="682" alt="screenshot 2018-11-09 at 02 09 03" src="https://user-images.githubusercontent.com/8385528/48239446-d4eafd80-e3c6-11e8-8075-bceb2b67b391.png">

Thus preventing the user from continuing unless a correct URL is provided. This has the added benefit of safe-guarding against any potential incorrect automatic parsing of the URL from HTTPS to SSH, and ensuring that `repo` information cannot be updated unless the remote repository is _definitely_ using SSH (which, all going according to plan, should mean that the user can simply just press return to use the default without a hitch).

**- Description for the changelog**

Add the ability to set up Continuous Integration from `sites:create`, and the option to manually configure the remote repo that CI uses

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/8385528/48239627-8427d480-e3c7-11e8-9d9c-93f345911e9e.png)

He's such a good boy.
