### PR TITLE
Fix renamed GitHub method

### DIFF
--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -78,7 +78,7 @@ async function configGithub(ctx, site, repo) {
 
   site = await api.updateSite({ siteId: site.id, body: { repo } })
 
-  const hooks = await octokit.repos.getHooks({
+  const hooks = await octokit.repos.listHooks({
     owner: parsedURL.owner,
     repo: parsedURL.name,
     per_page: 100


### PR DESCRIPTION
After updating to @octokit/rest@16.1.0, some of the methods were renamed.  This addresses that.  

Related to https://github.com/netlify/cli/pull/184
