### PR TITLE
Improve init flow in various manual depoy states

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -27,6 +27,8 @@ class InitCommand extends Command {
       siteData = await api.getSite({ siteId })
     } catch (e) {
       // silent api error
+      // TODO handle expected errors
+      // Throw unexpected ones
     }
 
     if (siteId && siteData && get(siteData, 'build_settings.repo_url') && !flags.force) {
@@ -170,7 +172,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
 
     // Check for existing CI setup
     const remoteBuildRepo = get(siteData, 'build_settings.repo_url')
-    if (remoteBuildRepo) {
+    if (remoteBuildRepo && !flags.force) {
       this.log()
       this.log(chalk.underline.bold(`Existing Repo detected`))
       const siteName = get(siteData, 'name')

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -29,7 +29,7 @@ class InitCommand extends Command {
       // silent api error
     }
 
-    if (siteId && siteData) {
+    if (siteId && siteData && get(siteData, 'build_settings.repo_url') && !flags.force) {
       const repoUrl = get(siteData, 'build_settings.repo_url')
       this.log()
       this.log(`${chalk.yellow('Warning:')} It looks like this site has already been initialized.`)
@@ -140,30 +140,32 @@ git remote add origin https://github.com/YourUserName/RepoName.git
       this.error(repo.error)
     }
 
-    const NEW_SITE = '+  Create & configure a new site'
-    const EXISTING_SITE = '⇄  Link this directory to an existing site'
+    if (!siteData) {
+      const NEW_SITE = '+  Create & configure a new site'
+      const EXISTING_SITE = '⇄  Link this directory to an existing site'
 
-    const initializeOpts = [EXISTING_SITE, NEW_SITE]
+      const initializeOpts = [EXISTING_SITE, NEW_SITE]
 
-    const { initChoice } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'initChoice',
-        message: 'What would you like to do?',
-        choices: initializeOpts
+      const { initChoice } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'initChoice',
+          message: 'What would you like to do?',
+          choices: initializeOpts
+        }
+      ])
+
+      // create site or search for one
+      if (initChoice === NEW_SITE) {
+        await track('sites_initStarted', {
+          type: 'new site'
+        })
+        // run site:create command
+        siteData = await SitesCreateCommand.run([])
+      } else if (initChoice === EXISTING_SITE) {
+        // run link command
+        siteData = await LinkCommand.run([], false)
       }
-    ])
-
-    // create site or search for one
-    if (initChoice === NEW_SITE) {
-      await track('sites_initStarted', {
-        type: 'new site'
-      })
-      // run site:create command
-      siteData = await SitesCreateCommand.run([])
-    } else if (initChoice === EXISTING_SITE) {
-      // run link command
-      siteData = await LinkCommand.run([], false)
     }
 
     // Check for existing CI setup
@@ -239,6 +241,9 @@ InitCommand.flags = {
   watch: flags.boolean({
     char: 'w',
     description: 'Make the CLI wait for the first deploy to complete after setting up CI'
+  }),
+  force: flags.boolean({
+    description: 'Reinitialize CI hooks if the linked site is already configured to use CI'
   })
 }
 


### PR DESCRIPTION
This makes init work when you made a deploy to a site manually and want to upgrade to using CI.  It also adds a force flag so you can re-init a site that is already using CI.
