### PR TITLE
Run prune before shrink-wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:lint": "eslint src",
     "test:deps": "dependency-check ./package.json --entry \"src/**/!(*.test).js\" --unused --missing --no-dev --no-peer -i @oclif/plugin-not-found -i @oclif/config -i @oclif/plugin-help -i @oclif/plugin-plugins",
     "watch": "nyc --reporter=lcov ava --watch",
-    "prepack": "oclif-dev manifest && npm shrinkwrap",
-    "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
+    "prepack": "oclif-dev manifest && npm prune --prod && npm shrinkwrap",
+    "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && npm i",
     "report": "nyc report --reporter=text-lcov | coveralls",
     "version": "node ./scripts/docs.js && auto-changelog -p --template keepachangelog && git add README.md docs CHANGELOG.md",
     "prepublishOnly": "git push && git push --tags && gh-release"


### PR DESCRIPTION
After adding a shrinkwrap I discovered npm stupidly installs devDependencies even when the package is installed as a global dependency.  When is that ever the desired case?  

Either way, this runs a production prune before packing, then undoes it.  Slower publish times, but at least we wont publish devDeps.