### PR TITLE
Restore original package-lock.json after packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:deps": "dependency-check ./package.json --entry \"src/**/!(*.test).js\" --unused --missing --no-dev --no-peer -i @oclif/plugin-not-found -i @oclif/config -i @oclif/plugin-help -i @oclif/plugin-plugins",
     "watch": "nyc --reporter=lcov ava --watch",
     "prepack": "oclif-dev manifest && npm prune --prod && npm shrinkwrap",
-    "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && npm i",
+    "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && git checkout -- package-lock.json && npm i",
     "report": "nyc report --reporter=text-lcov | coveralls",
     "version": "node ./scripts/docs.js && auto-changelog -p --template keepachangelog && git add README.md docs CHANGELOG.md",
     "prepublishOnly": "git push && git push --tags && gh-release"


### PR DESCRIPTION
This restores the original package-lock file after packing.  Before you may accumulate transient dependency changes without restoring.
