### PR TITLE
Validate site name on init command

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -59,7 +59,7 @@ class InitCommand extends Command {
       console.log()
       console.log(`${chalk.redBright('No git remote found. (╯°□°）╯︵ ┻━┻')}`)
       console.log(`
-It is recommended that you initialize a site that has a remote repository in Github.
+It is recommended that you initialize a site that has a remote repository in GitHub.
 
 This will allow for Netlify Continuous deployment to build branch & PR previews.
 
@@ -68,7 +68,7 @@ For more details on Netlify CI checkout the docs: http://bit.ly/2N0Jhy5
       let message
       switch (repo.error) {
         case "Couldn't find origin url": {
-          message = `Unable to find a remote origin url. Please add a git remote.
+          message = `Unable to find a remote origin URL. Please add a git remote.
 
 git remote add origin https://github.com/YourUserName/RepoName.git
 `
@@ -80,13 +80,13 @@ git remote add origin https://github.com/YourUserName/RepoName.git
       }
 
       const NEW_SITE_NO_GIT = 'Yes, create manually deploy site'
-      const NO_ABORT = 'No, I will connect this with directory with github first'
+      const NO_ABORT = 'No, I will connect this with directory with GitHub first'
 
       const { noGitRemoteChoice } = await inquirer.prompt([
         {
           type: 'list',
           name: 'noGitRemoteChoice',
-          message: 'Do you want to create a netlify site without a git repository?',
+          message: 'Do you want to create a Netlify site without a git repository?',
           choices: [NEW_SITE_NO_GIT, NO_ABORT]
         }
       ])
@@ -121,7 +121,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
 
    ${chalk.cyanBright.bold("git commit -m 'initial commit'")}
 
-4. Create a new repo in github ${chalk.cyanBright.bold('https://github.com/new')}
+4. Create a new repo in GitHub ${chalk.cyanBright.bold('https://github.com/new')}
 
 5. Link the remote repo with this local directory
 
@@ -196,7 +196,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
           try {
             await configGithub(this, siteData, repo)
           } catch (e) {
-            this.warn(`Github error: ${e.status}`)
+            this.warn(`GitHub error: ${e.status}`)
             if (e.code === 404) {
               this.error(
                 `Does the repository ${
@@ -225,7 +225,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
     this.log(`Next steps:
 
   ${chalk.cyanBright.bold('git push')}       Push to your git repository to trigger new site builds
-  ${chalk.cyanBright.bold('netlify open')}   Open the netlify admin url of your site
+  ${chalk.cyanBright.bold('netlify open')}   Open the Netlify admin URL of your site
   `)
 
     if (flags.watch) {

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -26,7 +26,8 @@ class SitesCreateCommand extends Command {
           type: 'input',
           name: 'name',
           message: 'Site name (optional):',
-          filter: val => (val === '' ? undefined : val)
+          filter: val => (val === '' ? undefined : val),
+          validate: input => /^[a-zA-Z0-9-]+$/.test(input) || 'Only alphanumeric characters and hyphens are allowed'
         }
       ])
       name = results.name


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

When creating a new site using the web UI, the site name is subject to a validation rule that allows only alphanumeric characters and hyphens. The same doesn't happen when using the `netlify init` command in the CLI. This PR addresses that by introducing a validation rule with the same regular expression used in the web flow.

I've also added a few cosmetic changes to some user-facing messages in the `init` command, to make words like _Netlify_ and _GitHub_ capitalized in a consistent manner. I'm more than happy to make this a different PR (or discard it altogether), if you prefer.

**- Test plan**

I started writing an integration test, but then I saw that there is a big change to the testing architecture underway in #254. I didn't want to create possible merge conflicts, so I've refrained from committing the tests for now. Happy to revisit.

The change makes use of inquirer's [validate method](https://github.com/SBoudrias/Inquirer.js/#input---type-input), which displays an error when the user tries to input an invalid value.

<img width="692" alt="Screenshot 2019-03-11 at 12 58 54" src="https://user-images.githubusercontent.com/4162329/54126569-c3ab0f80-43ff-11e9-819d-c2141820c95f.png">

The error message is consistent with the instructions shown in the web UI.

**- Description for the changelog**

Validates site name on init command. Closes #211.

**- A picture of a cute animal (not mandatory but encouraged)**

![A picture of a cute dog](https://images.unsplash.com/photo-1508609540374-67d1601ba520?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80)
