### PR TITLE
Update delete addon

### DIFF
--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -39,6 +39,7 @@ class AddonsConfigCommand extends Command {
       return false
     }
 
+    // TODO update getAddonManifest to https://open-api.netlify.com/#/default/showServiceManifest
     const manifest = await getAddonManifest(addonName, accessToken)
     // Parse flags
     const rawFlags = parseRawFlags(raw)
@@ -165,6 +166,7 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
   console.log(`${codeDiff}\n`)
   console.log()
 
+  // TODO update updateAddon to https://open-api.netlify.com/#/default/updateServiceInstance
   const updateAddonResponse = await updateAddon(settings, accessToken)
   if (updateAddonResponse.code === 404) {
     console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -138,8 +138,8 @@ class AddonsCreateCommand extends Command {
 }
 
 async function createSiteAddon({ addonName, settings, accessToken, siteData }) {
+  // TODO update to https://open-api.netlify.com/#/default/createServiceInstance
   const addonResponse = await createAddon(settings, accessToken)
-
   if (addonResponse.code === 404) {
     console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
     return false

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -47,13 +47,20 @@ class AddonsDeleteCommand extends Command {
       addon: addonName,
       instanceId: currentAddon.id
     }
+    // TODO update deleteAddon to https://open-api.netlify.com/#/default/deleteServiceInstance
     const addonResponse = await deleteAddon(settings, accessToken)
 
-    if (addonResponse.code === 404) {
+    if (addonResponse.status === 404) {
       this.log(`No addon "${addonName}" found. Please double check your add-on name and try again`)
       return false
     }
-    this.log(`Addon "${addonName}" deleted`)
+
+    /* Deleting addons must return with 204 status */
+    if (addonResponse.status === 204) {
+      this.log(`Addon "${addonName}" deleted`)
+    } else {
+      this.log(`Addon "${addonName}" was not deleted "${addonName}". Returned status: ${addonResponse.status}. Addon deletion must return status 204 from "${addonName}" provider.`)
+    }
   }
 }
 

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -17,6 +17,7 @@ class AddonsListCommand extends Command {
 
     const siteData = await api.getSite({ siteId })
 
+    // TODO update getAddons to https://open-api.netlify.com/#/default/getServices
     const addons = await getAddons(siteId, accessToken)
     if (!addons || !addons.length) {
       this.log(`No addons currently installed for ${siteData.name}`)


### PR DESCRIPTION
**- Summary**

Add-ons were registering as deleted if addon provider returned status other than 204.

This PR fixes that and only logs "deleted" when deletion successful

https://github.com/netlify/cli/pull/265/files#diff-1afb28914604869c18bfbc1b8b844178R58