### PR TITLE
make netlify init work with netlify.toml, see #210 #267

### DIFF
--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -44,20 +44,45 @@ async function configGithub(ctx, site, repo) {
 
   // read netlify toml
 
+  let defaultBuildCmd,
+    defaultBuildDir = '.'
+  const { build } = ctx.netlify.config // read from netlify toml
+  if (build && build.command) defaultBuildCmd = build.command
+  if (build && build.publish) defaultBuildDir = build.publish
+  if (build && build.functions) console.log('Netlify functions folder is ' + build.functions)
   const { buildCmd, buildDir } = await inquirer.prompt([
     {
       type: 'input',
       name: 'buildCmd',
       message: 'Your build command (hugo build/yarn run build/etc):',
-      filter: val => (val === '' ? undefined : val)
+      filter: val => (val === '' ? '# no build command' : val),
+      default: defaultBuildCmd
     },
     {
       type: 'input',
       name: 'buildDir',
       message: 'Directory to deploy (blank for current dir):',
-      default: '.'
+      default: defaultBuildDir
     }
   ])
+
+  const tomlpath = path.join(ctx.netlify.site.root, 'netlify.toml')
+  const tomlDoesNotExist = !fs.existsSync(tomlpath)
+  if (tomlDoesNotExist && (!ctx.netlify.config || Object.keys(ctx.netlify.config).length === 0)) {
+    const { makeNetlifyTOML } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'makeNetlifyTOML',
+        message: 'No netlify.toml detected. Would you like to create one with these build settings?',
+        default: true
+      }
+    ])
+    if (makeNetlifyTOML && ctx.netlify.site && ctx.netlify.site.root) {
+      fs.writeFileSync(tomlpath, makeNetlifyTOMLtemplate({ command: buildCmd, publish: buildDir }))
+    } else {
+      throw new Error('NetlifyCLIError: expected there to be a Netlify site root, please investigate', ctx.netlify.site)
+    }
+  }
 
   repo.dir = buildDir
 

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -42,8 +42,6 @@ async function configGithub(ctx, site, repo) {
 
   // TODO: Look these up and default to the lookup order
 
-  // read netlify toml
-
   let defaultBuildCmd,
     defaultBuildDir = '.'
   const { build } = ctx.netlify.config // read from netlify toml

--- a/src/utils/init/netlify-toml-template.js
+++ b/src/utils/init/netlify-toml-template.js
@@ -5,11 +5,11 @@ const makeNetlifyTOMLtemplate = ({ command, publish }) => `# example netlify.tom
   publish = "${publish}"
 
 
-# COMMENT: This a rule for Single Page Applications
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+## COMMENT: This a redirect often used for Single Page Applications
+#[[redirects]]
+#  from = "/*"
+#  to = "/index.html"
+#  status = 200
 
 ## more info https://www.netlify.com/docs/netlify-toml-reference/
 `

--- a/src/utils/init/netlify-toml-template.js
+++ b/src/utils/init/netlify-toml-template.js
@@ -1,7 +1,7 @@
-const makeNetlifyTOMLtemplate = ({ command, publish }) => `# example netlify.toml
+const makeNetlifyTOMLtemplate = ({ command = '# no build command', publish = '.' }) => `# example netlify.toml
 [build]
   command = "${command}"
-  functions = "lambda" #  netlify-lambda reads this
+  functions = "functions" #  netlify-lambda reads this
   publish = "${publish}"
 
 

--- a/src/utils/init/netlify-toml-template.js
+++ b/src/utils/init/netlify-toml-template.js
@@ -1,11 +1,11 @@
 const makeNetlifyTOMLtemplate = ({ command = '# no build command', publish = '.' }) => `# example netlify.toml
 [build]
   command = "${command}"
-  functions = "functions" #  netlify-lambda reads this
+  functions = "functions"
   publish = "${publish}"
 
-
-## COMMENT: This a redirect often used for Single Page Applications
+## Uncomment to use this redirect for Single Page Applications. 
+## Not needed for static site generators.
 #[[redirects]]
 #  from = "/*"
 #  to = "/index.html"

--- a/src/utils/init/netlify-toml-template.js
+++ b/src/utils/init/netlify-toml-template.js
@@ -1,0 +1,16 @@
+const makeNetlifyTOMLtemplate = ({ command, publish }) => `# example netlify.toml
+[build]
+  command = "${command}"
+  functions = "lambda" #  netlify-lambda reads this
+  publish = "${publish}"
+
+
+# COMMENT: This a rule for Single Page Applications
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+## more info https://www.netlify.com/docs/netlify-toml-reference/
+`
+module.exports = { makeNetlifyTOMLtemplate }


### PR DESCRIPTION
**- Summary**

closes #210 and #267

**- Test plan**

https://netlify.slack.com/archives/CEV26F3FF/p1552942688000100

**- Description for the changelog**

when doing `netlify init`:

- if netlify.toml doesn't exist: offer to create one with the given settings
- if netlify.toml exists: use settings from netlify.toml as defaults

**- A picture of a cute animal (not mandatory but encouraged)**

https://twitter.com/HumansOfLate/status/1107013958207238145