### PR TITLE
add alias for addons command

### DIFF
--- a/src/commands/addons/auth.js
+++ b/src/commands/addons/auth.js
@@ -45,7 +45,7 @@ class AddonsAuthCommand extends Command {
     this.exit()
   }
 }
-AddonsAuthCommand.addons = ['addon:auth']
+AddonsAuthCommand.aliases = ['addon:auth']
 AddonsAuthCommand.args = [
   {
     name: 'name',

--- a/src/commands/addons/auth.js
+++ b/src/commands/addons/auth.js
@@ -45,7 +45,7 @@ class AddonsAuthCommand extends Command {
     this.exit()
   }
 }
-
+AddonsAuthCommand.addons = ['addon:auth']
 AddonsAuthCommand.args = [
   {
     name: 'name',

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -181,7 +181,7 @@ AddonsConfigCommand.args = [
     description: 'Add-on namespace'
   }
 ]
-AddonsConfigCommand.addons = ['addon:config']
+AddonsConfigCommand.aliases = ['addon:config']
 AddonsConfigCommand.description = `Configure add-on settings`
 // allow for any flags. Handy for variadic configuration options
 AddonsConfigCommand.strict = false

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -181,7 +181,7 @@ AddonsConfigCommand.args = [
     description: 'Add-on namespace'
   }
 ]
-
+AddonsConfigCommand.addons = ['addon:config']
 AddonsConfigCommand.description = `Configure add-on settings`
 // allow for any flags. Handy for variadic configuration options
 AddonsConfigCommand.strict = false

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -117,7 +117,7 @@ class AddonsCreateCommand extends Command {
       configValues = updateConfigValues(manifest.config, rawFlags, userInput)
       const missingRequiredValues = missingConfigValues(required, configValues)
       if (missingRequiredValues && missingRequiredValues.length) {
-        missingRequiredValues.forEach((val) => {
+        missingRequiredValues.forEach(val => {
           console.log(`Missing required value "${val}". Please run the command again`)
         })
         return false
@@ -156,7 +156,7 @@ AddonsCreateCommand.description = `Add an add-on extension to your site
 ...
 Add-ons are a way to extend the functionality of your Netlify site
 `
-
+AddonsCreateCommand.addons = ['addon:create']
 AddonsCreateCommand.args = [
   {
     name: 'name',

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -156,7 +156,7 @@ AddonsCreateCommand.description = `Add an add-on extension to your site
 ...
 Add-ons are a way to extend the functionality of your Netlify site
 `
-AddonsCreateCommand.addons = ['addon:create']
+AddonsCreateCommand.aliases = ['addon:create']
 AddonsCreateCommand.args = [
   {
     name: 'name',

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -74,7 +74,7 @@ Add-ons are a way to extend the functionality of your Netlify site
 // allow for any flags. Handy for variadic configuration options
 AddonsDeleteCommand.strict = false
 AddonsDeleteCommand.hidden = true
-
+AddonsDeleteCommand.addons = ['addon:delete']
 AddonsDeleteCommand.flags = {
   force: flags.boolean({ char: 'f', description: 'delete without prompting (useful for CI)' })
 }

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -74,7 +74,7 @@ Add-ons are a way to extend the functionality of your Netlify site
 // allow for any flags. Handy for variadic configuration options
 AddonsDeleteCommand.strict = false
 AddonsDeleteCommand.hidden = true
-AddonsDeleteCommand.addons = ['addon:delete']
+AddonsDeleteCommand.aliases = ['addon:delete']
 AddonsDeleteCommand.flags = {
   force: flags.boolean({ char: 'f', description: 'delete without prompting (useful for CI)' })
 }

--- a/src/commands/addons/index.js
+++ b/src/commands/addons/index.js
@@ -17,7 +17,7 @@ class AddonsCommand extends Command {
 AddonsCommand.description = `Handle addon operations
 The addons command will help you manage all your netlify addons
 `
-AddonsCommand.addons = ['addon']
+AddonsCommand.aliases = ['addon']
 AddonsCommand.examples = [
   'netlify addons:create addon-xyz --value foo',
   'netlify addons:update addon-xyz --value bar',

--- a/src/commands/addons/index.js
+++ b/src/commands/addons/index.js
@@ -17,7 +17,7 @@ class AddonsCommand extends Command {
 AddonsCommand.description = `Handle addon operations
 The addons command will help you manage all your netlify addons
 `
-
+AddonsCommand.addons = ['addon']
 AddonsCommand.examples = [
   'netlify addons:create addon-xyz --value foo',
   'netlify addons:update addon-xyz --value bar',

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -57,7 +57,7 @@ AddonsListCommand.description = `list current site add-ons
 ...
 Add-ons are a way to extend the functionality of your Netlify site
 `
-AddonsListCommand.addons = ['addon:list']
+AddonsListCommand.aliases = ['addon:list']
 AddonsListCommand.flags = {
   json: flags.boolean({
     description: 'Output add-on data as JSON'

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -57,7 +57,7 @@ AddonsListCommand.description = `list current site add-ons
 ...
 Add-ons are a way to extend the functionality of your Netlify site
 `
-
+AddonsListCommand.addons = ['addon:list']
 AddonsListCommand.flags = {
   json: flags.boolean({
     description: 'Output add-on data as JSON'


### PR DESCRIPTION
**- Summary**

closes https://github.com/netlify/cli/issues/274

**- Test plan**

locally tested

**- Description for the changelog**

add alias for `netlify addons` command to also work with `netlify addon`

**- A picture of a cute animal (not mandatory but encouraged)**

![https://preview.redd.it/cgjl0vk5nto21.jpg?width=640&crop=smart&auto=webp&s=673dc66274cd8c4c0f595408daabfd520a2016c2](https://preview.redd.it/cgjl0vk5nto21.jpg?width=640&crop=smart&auto=webp&s=673dc66274cd8c4c0f595408daabfd520a2016c2)