### PR TITLE
add —json flag for programatic access

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -106,7 +106,7 @@ class DeployCommand extends Command {
       configPath = site.configPath
       pathInfo['Configuration path'] = configPath
     }
-    this.log(prettyjson.render(pathInfo))
+    log(prettyjson.render(pathInfo), this, flags)
 
     ensureDirectory(deployFolder, this.exit)
 
@@ -117,9 +117,9 @@ class DeployCommand extends Command {
     let results
     try {
       if (deployToProduction) {
-        this.log('Deploying to live site URL...')
+        log('Deploying to live site URL...', this, flags)
       } else {
-        this.log('Deploying to draft URL...')
+        log('Deploying to draft URL...', this, flags)
       }
 
       results = await api.deploy(siteId, deployFolder, {
@@ -171,7 +171,15 @@ class DeployCommand extends Command {
       delete msgData['Unique Deploy URL']
       msgData['Live Draft URL'] = deployUrl
     }
-    this.log()
+
+    log('', this, flags)
+
+    // Json response for piping commands
+    if (flags.json) {
+      this.log(JSON.stringify(msgData, null, 2))
+      return false
+    }
+
     this.log(prettyjson.render(msgData))
 
     if (!deployToProduction) {
@@ -186,6 +194,13 @@ class DeployCommand extends Command {
       await openBrowser(urlToOpen)
       this.exit()
     }
+  }
+}
+
+// Hide logs if --json flag used
+function log(message, context, flags) {
+  if (!flags.json) {
+    context.log(message)
   }
 }
 
@@ -299,6 +314,9 @@ DeployCommand.flags = {
     char: 's',
     description: 'A site ID to deploy to',
     env: 'NETLIFY_SITE_ID'
+  }),
+  json: flags.boolean({
+    description: 'Output deployment data as JSON'
   })
 }
 


### PR DESCRIPTION
First part of programatic data from deploy command.

```
netlify deploy --json
✔ Finished hashing 15 files
✔ CDN requesting 0 files
✔ Finished uploading 0 assets
✔ Draft deploy is live!
{
  "Logs": "https://app.netlify.com/sites/1111/deploys/5ccc8b52c8b992018cc60ace",
  "Live Draft URL": "https://5ccc8b52c8b992018cc60ace--1111.netlify.com"
}
```

The `api.deploy` from SDK will need a silent option to kill spinners/messages

```
  results = await api.deploy(siteId, deployFolder, {
        configPath: configPath,
        fnDir: functionsFolder,
        statusCb: deployProgressCb(),
        draft: !deployToProduction,
        message: flags.message
      })
```