### PR TITLE
only show config prompts for addons with config

### DIFF
--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -41,6 +41,7 @@ class AddonsConfigCommand extends Command {
 
     // TODO update getAddonManifest to https://open-api.netlify.com/#/default/showServiceManifest
     const manifest = await getAddonManifest(addonName, accessToken)
+    const hasConfig = manifest.config && Object.keys(manifest.config).length
     // Parse flags
     const rawFlags = parseRawFlags(raw)
     // Get Existing Config
@@ -48,7 +49,7 @@ class AddonsConfigCommand extends Command {
 
     const words = `Current "${addonName} add-on" Settings:`
     console.log(` ${chalk.yellowBright.bold(words)}`)
-    if (manifest.config) {
+    if (hasConfig) {
       render.configValues(addonName, manifest.config, currentConfig)
     } else {
       // For addons without manifest. TODO remove once we enfore manifests
@@ -57,7 +58,7 @@ class AddonsConfigCommand extends Command {
       })
     }
 
-    if (manifest.config) {
+    if (hasConfig) {
       const required = requiredConfigValues(manifest.config)
       const missingValues = missingConfigValues(required, rawFlags)
 

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -56,9 +56,10 @@ class AddonsCreateCommand extends Command {
     }
 
     const manifest = await getAddonManifest(addonName, accessToken)
+     const hasConfig = manifest.config && Object.keys(manifest.config).length
 
     let configValues = rawFlags
-    if (manifest.config && Object.keys(manifest.config).length) {
+    if (hasConfig) {
       const required = requiredConfigValues(manifest.config)
       const missingValues = missingConfigValues(required, rawFlags)
       console.log(`Starting the setup for "${addonName} add-on"`)

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -58,7 +58,7 @@ class AddonsCreateCommand extends Command {
     const manifest = await getAddonManifest(addonName, accessToken)
 
     let configValues = rawFlags
-    if (manifest.config) {
+    if (manifest.config && Object.keys(manifest.config).length) {
       const required = requiredConfigValues(manifest.config)
       const missingValues = missingConfigValues(required, rawFlags)
       console.log(`Starting the setup for "${addonName} add-on"`)


### PR DESCRIPTION
Fix output for addons with no config

Issue:

```
➜  fun-fun-functions git:(master) ✗ netlify addons:create xyz
Starting the setup for "xyz add-on"

 The xyz add-on has the following configurable options:
.
||
|
 |
-|
'
```

Now we check for object keys to show prompts