### PR TITLE
fix: Don't show broken url if a site is undeployed

### DIFF
--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -19,7 +19,9 @@ class SitesListCommand extends Command {
           id: site.id,
           name: site.name,
           ssl_url: site.ssl_url,
-          account_name: site.account_name
+          account_name: site.account_name,
+          published_deploy: site.published_deploy,
+          admin_url: site.admin_url
         }
 
         if (site.build_settings && site.build_settings.repo_url) {
@@ -49,7 +51,13 @@ class SitesListCommand extends Command {
 
       logSites.forEach(s => {
         console.log(`${chalk.greenBright(s.name)} - ${s.id}`)
-        console.log(`  ${chalk.whiteBright.bold('url:')}  ${chalk.yellowBright(s.ssl_url)}`)
+
+        if (s.published_deploy) {
+          console.log(`  ${chalk.whiteBright.bold('url:')}  ${chalk.yellowBright(s.ssl_url)}`)
+        } else {
+          console.log(`  ${chalk.whiteBright.bold('url:')}  ${chalk.redBright('Site deploy failed')} (${s.admin_url}/deploys)`)
+        }
+
         if (s.repo_url) {
           console.log(`  ${chalk.whiteBright.bold('repo:')} ${chalk.white(s.repo_url)}`)
         }


### PR DESCRIPTION
**- Summary**
`netlify sites:list` shows the wrong URL if a site is undeployed — the URL doesn't contain the hash of the deployment ↓

<img width="663" alt="Screenshot 2019-06-03 at 22 17 17" src="https://user-images.githubusercontent.com/612163/58832506-5d750800-864f-11e9-85da-cd91835ca81f.png">


Todo:

- [x] Show broken status for sites with no successful deployments at all
- [ ] Show status for sites with broken recent deployments(with successful ones in the past)


**- Description for the changelog** ↑

This MR only fixes the client. Instead of using site.ssl_url we will try to use last published deploy to check and display the correct URL.

Otherwise, display error status.

**- Test plan**

1. Create a site that fails to deploy — for example by specifying a wrong build script.
2. Push, wait for the failed build.
3. Run `netlify sites:list`

