### PR TITLE
Catch error and finish with error upon create/update/delte of addons

### DIFF
--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -76,7 +76,8 @@ class AddonsConfigCommand extends Command {
             addon: addonName,
             config: newConfig
           },
-          accessToken
+          accessToken,
+          error: this.error
         })
         return false
       }
@@ -148,13 +149,14 @@ class AddonsConfigCommand extends Command {
           addon: addonName,
           config: newConfig
         },
-        accessToken
+        accessToken,
+        error: this.error
       })
     }
   }
 }
 
-async function update({ addonName, currentConfig, newConfig, settings, accessToken }) {
+async function update({ addonName, currentConfig, newConfig, settings, accessToken, error }) {
   const codeDiff = diffValues(currentConfig, newConfig)
   if (!codeDiff) {
     console.log('No changes, exiting early')
@@ -167,8 +169,13 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
   console.log(`${codeDiff}\n`)
   console.log()
 
-  // TODO update updateAddon to https://open-api.netlify.com/#/default/updateServiceInstance
-  const updateAddonResponse = await updateAddon(settings, accessToken)
+  let updateAddonResponse
+  try {
+    // TODO update updateAddon to https://open-api.netlify.com/#/default/updateServiceInstance
+    updateAddonResponse = await updateAddon(settings, accessToken)
+  } catch (e) {
+    error(e.message)
+  }
   if (updateAddonResponse.code === 404) {
     console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
     return false

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -92,7 +92,8 @@ class AddonsCreateCommand extends Command {
             config: newConfig
           },
           accessToken,
-          siteData
+          siteData,
+          error: this.error
         })
         return false
       }
@@ -133,14 +134,21 @@ class AddonsCreateCommand extends Command {
         config: configValues
       },
       accessToken,
-      siteData
+      siteData,
+      error: this.error
     })
   }
 }
 
-async function createSiteAddon({ addonName, settings, accessToken, siteData }) {
-  // TODO update to https://open-api.netlify.com/#/default/createServiceInstance
-  const addonResponse = await createAddon(settings, accessToken)
+async function createSiteAddon({ addonName, settings, accessToken, siteData, error }) {
+  let addonResponse
+  try {
+    // TODO update to https://open-api.netlify.com/#/default/createServiceInstance
+    addonResponse = await createAddon(settings, accessToken)
+  } catch (e) {
+    error(e.message)
+  }
+
   if (addonResponse.code === 404) {
     console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
     return false

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -53,8 +53,13 @@ class AddonsDeleteCommand extends Command {
       addon: addonName,
       instanceId: currentAddon.id
     }
-    // TODO update deleteAddon to https://open-api.netlify.com/#/default/deleteServiceInstance
-    const addonResponse = await deleteAddon(settings, accessToken)
+    let addonResponse
+    try {
+      // TODO update deleteAddon to https://open-api.netlify.com/#/default/deleteServiceInstance
+      addonResponse = await deleteAddon(settings, accessToken)
+    } catch (e) {
+      this.error(e.message)
+    }
 
     if (addonResponse.status === 404) {
       this.log(`No addon "${addonName}" found. Please double check your add-on name and try again`)


### PR DESCRIPTION
**- Summary**

It's really about the cosmetics so that we can show error and exit the CLI nicely whenever we get an error response from API. Paring PR of this is: https://github.com/netlify/js-client/pull/51.
This can be resolved many other ways and this is not the most efficient or so, happy to tweak if there is a better alternative.

**- Test plan**

I tested out several locally. Example:

From:

```
$ netlify addons:create large-media
Creating addon
Error: Error {"error":"Large Media addon doesn't support the repo linked to multiple sites"}
    at createAddon (~/.npm-packages/lib/node_modules/netlify-cli/node_modules/netlify/src/addons.js:24:11)
```

To:

```
$ ~/dev/netlify/cli/bin/run addons:create large-media 
Creating addon                                       
 ›   Error: Large Media addon doesn't support the repo linked to multiple sites
```

**- Description for the changelog**

Handle errors from API well upon create/update/delte of addons

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/911433/58984197-42a8ad80-878d-11e9-985d-b9acbb6a40eb.png)
