### PR TITLE
updates messaging for creating sites and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Welcome to the Netlify CLI! The new 2.0 version was rebuilt from the ground up t
   * [dev](#dev)
   * [functions](#functions)
 - [Contributing](#contributing)
+- [Development](#development)
 - [License](#license)
 
 </details>
@@ -138,6 +139,16 @@ Manage netlify functions
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more info on how to make contributions to this project.
+
+## Development
+
+You'll need to follow these steps to run Netlify CLI locally:
+
+    uninstall any globally installed versions of netlify-cli
+    clone and install deps for https://github.com/netlify/cli
+    npm link from inside the cli folder
+
+Now you're both ready to start testing and to contribute to the project!
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
+    "lodash.sample": "^4.2.1",
     "log-symbols": "^2.2.0",
     "netlify": "^2.4.6",
     "netlify-dev-plugin": "^1.0.22",

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -27,8 +27,7 @@ class SitesCreateCommand extends Command {
         `${userName.slug}-makes-great-sites`,
         `netlify-thinks-${userName.slug}-is-great`,
         `the-great-${userName.slug}-site`,
-        `isnt-${userName.slug}-awesome`,
-        `${userName.slug}-blog`
+        `isnt-${userName.slug}-awesome`
       ]
       const siteSuggestion = sample(suggestions)
 


### PR DESCRIPTION
**- Summary**
Based on feedback from our CLI call. This PR improves the messaging when you create a site through the CLI and when that command fails. 

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
<img width="973" alt="Screen Shot 2019-06-18 at 11 25 19 AM" src="https://user-images.githubusercontent.com/322665/59698326-6fad8500-91bd-11e9-8c95-3c90e51c03b3.png">

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Modifies the messaging to include the idea of a global site creation failure rather than a local one. Users will be confused when the site creation fails based on the name if the name is not outright determined to be a global conflict. 

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/322665/59698596-04b07e00-91be-11e9-8dd9-f4da1af631b0.png)