### PR TITLE
use a list of sites to chose from rather than entering the name manually

### DIFF
--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -8,10 +8,10 @@ const { track } = require('../telemetry')
 module.exports = async function linkPrompts(context) {
   const { api, state } = context.netlify
 
-  const SITE_NAME_PROMPT = 'Site Name'
-  const SITE_ID_PROMPT = 'Site ID'
+  const SITE_NAME_PROMPT = 'Choose from a list of your sites'
+  const SITE_ID_PROMPT = `Use a site ID`
 
-  let GIT_REMOTE_PROMPT = `Use current git remote URL`
+  let GIT_REMOTE_PROMPT = `Use a current git remote URL`
   let site
   // Get git remote data if exists
   const repoInfo = await getRepoData()
@@ -110,19 +110,10 @@ Run ${chalk.cyanBright('`git remote -v`')} to see a list of your git remotes.`)
     }
     case SITE_NAME_PROMPT: {
       kind = 'byName'
-      const { siteName } = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'siteName',
-          message: 'What is the name of the site?'
-        }
-      ])
+
       let sites
       try {
-        sites = await api.listSites({
-          name: siteName,
-          filter: 'all'
-        })
+        sites = await api.listSites()
       } catch (e) {
         if (e.status === 404) {
           context.error(`${siteName} not found`)
@@ -132,25 +123,19 @@ Run ${chalk.cyanBright('`git remote -v`')} to see a list of your git remotes.`)
       }
 
       if (sites.length === 0) {
-        context.error(`No sites found named ${siteName}`)
+        context.error(`You don't have any sites. Use netlify 'sites:create' to create a site.`)
       }
 
-      if (sites.length > 1) {
-        const { selectedSite } = await inquirer.prompt([
-          {
-            type: 'list',
-            name: 'selectedSite',
-            paginated: true,
-            choices: sites.map(site => ({ name: site.name, value: site }))
-          }
-        ])
-        if (!selectedSite) {
-          context.error('No site selected')
+      const siteSelection = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'siteName',
+          message: 'What is the name of the site?',
+          paginated: true,
+          choices: sites.map(site => ({ name: site.name, value: site }))
         }
-        site = selectedSite
-      } else {
-        site = sites[0]
-      }
+      ])
+      site = siteSelection.siteName
       break
     }
     case SITE_ID_PROMPT: {

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -115,11 +115,7 @@ Run ${chalk.cyanBright('`git remote -v`')} to see a list of your git remotes.`)
       try {
         sites = await api.listSites()
       } catch (e) {
-        if (e.status === 404) {
-          context.error(`${siteName} not found`)
-        } else {
-          context.error(e)
-        }
+        context.error(e)
       }
 
       if (sites.length === 0) {


### PR DESCRIPTION
**- Summary**
`netlify link` makes you manually enter the name of your site, which may result in human error and a tedious process. I wanted to give users a list of sites so there's no human error involved.

**- Test plan**
<img width="606" alt="Screen Shot 2019-06-18 at 1 56 06 PM" src="https://user-images.githubusercontent.com/322665/59707689-223b1300-91d1-11e9-9f74-a6217024d908.png">

<img width="609" alt="Screen Shot 2019-06-18 at 1 58 47 PM" src="https://user-images.githubusercontent.com/322665/59707739-3bdc5a80-91d1-11e9-9e87-5829b0aa17c1.png">

<img width="400" alt="Screen Shot 2019-06-18 at 1 59 38 PM" src="https://user-images.githubusercontent.com/322665/59707780-544c7500-91d1-11e9-848a-cebadb085be6.png">


**- Description for the changelog**
Better DX for linking sites in `netlify link`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/322665/59707879-8f4ea880-91d1-11e9-83d8-0855658b1099.png)

