### PR TITLE
Allow user to choose another site name if current doesn't exist

### DIFF
--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -35,12 +35,14 @@ class SitesCreateCommand extends Command {
     }
 
     let name = flags.name
+    let userName
     let site
 
     // Allow the user to reenter site name if selected one isn't available
     const inputSiteName = async (name) => {
+      if (!userName) userName = await api.getCurrentUser()
+
       if (!name) {
-        const userName = await api.getCurrentUser()
         const suggestions = [
           `super-cool-site-by-${userName.slug}`,
           `the-awesome-${userName.slug}-site`,
@@ -50,7 +52,6 @@ class SitesCreateCommand extends Command {
           `isnt-${userName.slug}-awesome`
         ]
         const siteSuggestion = sample(suggestions)
-
 
         console.log(`Choose a unique site name (e.g. ${siteSuggestion}.netlify.com) or leave it blank for a random name. You can update the site name later.`)
         const results = await inquirer.prompt([


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

When doing `netlify init` right now, if you choose a `Site name` that is already taken, the process fails and exits. This change allows the user to reenter a new `Site name` for their project without exiting.

**- Test plan**

First attempt with HEAD state:
- Run `netlify init` in a new project
- Choose `Yes, create manually deploy site`
- Enter `test` as `Site name`.
- Choose your team. The command will error out and exit with `Error: test.netlify.com already exists. Please try a different slug.`


Second attempt with this branch:
- Run `netlify init` in a new project
- Choose `Yes, create manually deploy site`
- Choose your team
- Enter `test` as `Site name`. The command will show a warning `Warning: test.netlify.com already exists. Please try a different slug.`. But will prompt you for `Site name` again.
- Enter a new unique name this time.
- The command will succeed

**- Description for the changelog**

* Moved team selection before site name selection
* Move site name selection into an inline function `inputSiteName `
* Call `inputSiteName` again if specified site name already exists

**- A picture of a cute animal (not mandatory but encouraged)**
![golden-retriever-dog-breed-info](https://user-images.githubusercontent.com/10067728/60449648-8a620e00-9c41-11e9-9b13-6f2b1158e1ef.jpg)
