### PR TITLE
Ignore .idea dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 misc
 coverage
 .netlify
+.idea
 
 # node sdk
 vendor


### PR DESCRIPTION
**- Summary**

I'm working with IntelliJ Idea IDE and this is a IDE config directory that doesn't need to be shared.

**- Test plan**

* Open the CLI project in any IntelliJ Idea IDE.
* `.idea` wont show up as untracked files in your `git status`

**- Description for the changelog**

This small change adds `.idea` directory to `gitignore`

**- A picture of a cute animal (not mandatory but encouraged)**
