### PR TITLE
Automatically Ignore .netlify folder on init/link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ vendor
 # osx
 .DS_STORE
 .vscode
-.netlify
 coverage
 test-site
 site/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -9274,6 +9274,11 @@
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
     },
+    "parse-gitignore": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-1.0.1.tgz",
+      "integrity": "sha512-UGyowyjtx26n65kdAMWhm6/3uy5uSrpcuH7tt+QEVudiBoVS+eqHxD5kbi9oWVRwj7sCzXqwuM+rUGw7earl6A=="
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "ora": "^3.4.0",
     "p-wait-for": "^2.0.0",
     "parse-github-url": "^1.0.2",
+    "parse-gitignore": "^1.0.1",
     "prettyjson": "^1.2.1",
     "random-item": "^1.0.0",
     "update-notifier": "^2.5.0"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -6,6 +6,7 @@ const SitesWatchCommand = require('./watch')
 const configManual = require('../utils/init/config-manual')
 const configGithub = require('../utils/init/config-github')
 const getRepoData = require('../utils/get-repo-data')
+const { ensureNetlifyIgnore } = require('../utils/gitignore')
 const inquirer = require('inquirer')
 const SitesCreateCommand = require('./sites/create')
 const LinkCommand = require('./link')
@@ -31,6 +32,9 @@ class InitCommand extends Command {
       // Throw unexpected ones
     }
 
+    // Add .netlify to .gitignore file
+    await ensureNetlifyIgnore(site.root)
+
     if (siteId && siteData && get(siteData, 'build_settings.repo_url') && !flags.force) {
       const repoUrl = get(siteData, 'build_settings.repo_url')
       this.log()
@@ -49,6 +53,7 @@ class InitCommand extends Command {
       this.log(`1. Run ${chalk.cyanBright.bold('netlify unlink')}`)
       this.log(`2. Then run ${chalk.cyanBright.bold('netlify init')} again`)
       // TODO remove this.log(`Or delete the siteId from ${this.siteData.path}`)
+
       this.exit()
     }
 

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -2,6 +2,7 @@ const Command = require('@netlify/cli-utils')
 const { flags } = require('@oclif/command')
 const path = require('path')
 const chalk = require('chalk')
+const { ensureNetlifyIgnore } = require('../utils/gitignore')
 const linkPrompt = require('../utils/link/link-by-prompt')
 const { track } = require('../utils/telemetry')
 
@@ -57,6 +58,9 @@ class LinkCommand extends Command {
         kind: 'byId'
       })
 
+      // Add .netlify to .gitignore file
+      await ensureNetlifyIgnore(site.root)
+
       return this.exit()
     }
 
@@ -80,6 +84,7 @@ class LinkCommand extends Command {
       }
       siteData = results[0]
       state.set('siteId', siteData.id)
+
       this.log(`Linked to ${siteData.name} in ${path.relative(path.join(process.cwd(), '..'), state.path)}`)
 
       await track('sites_linked', {
@@ -87,6 +92,9 @@ class LinkCommand extends Command {
         linkType: 'manual',
         kind: 'byName'
       })
+
+      // Add .netlify to .gitignore file
+      await ensureNetlifyIgnore(site.root)
 
       return this.exit()
     }

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -21,6 +21,9 @@ class LinkCommand extends Command {
       // silent api error
     }
 
+    // Add .netlify to .gitignore file
+    await ensureNetlifyIgnore(site.root)
+
     // Site id is incorrect
     if (siteId && !siteData) {
       console.log(`"${siteId}" was not found in your Netlify account.`)
@@ -58,9 +61,6 @@ class LinkCommand extends Command {
         kind: 'byId'
       })
 
-      // Add .netlify to .gitignore file
-      await ensureNetlifyIgnore(site.root)
-
       return this.exit()
     }
 
@@ -92,9 +92,6 @@ class LinkCommand extends Command {
         linkType: 'manual',
         kind: 'byName'
       })
-
-      // Add .netlify to .gitignore file
-      await ensureNetlifyIgnore(site.root)
 
       return this.exit()
     }

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -103,7 +103,11 @@ class LinkCommand extends Command {
 
 LinkCommand.description = `Link a local repo or project folder to an existing site on Netlify`
 
-LinkCommand.examples = ['netlify link', 'netlify link --id 123-123-123-123', 'netlify link --name my-site-name']
+LinkCommand.examples = [
+  'netlify link',
+  'netlify link --id 123-123-123-123',
+  'netlify link --name my-site-name'
+]
 
 LinkCommand.flags = {
   id: flags.string({

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -1,0 +1,116 @@
+const path = require('path')
+const fs = require('fs')
+const parseIgnore = require('parse-gitignore')
+const { promisify } = require('util')
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+
+function fileExists(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.access(filePath, fs.F_OK, (err) => {
+      if (err) return resolve(false)
+      return resolve(true)
+    })
+  })
+}
+
+async function hasGitIgnore(dir) {
+  const gitIgnorePath = path.join(dir, '.gitignore')
+  const hasIgnore = await fileExists(gitIgnorePath)
+  return hasIgnore
+}
+
+function parser(input, fn = line => line) {
+  let lines = input.toString().split(/\r?\n/)
+  let section = { name: 'default', patterns: [] }
+  let state = { patterns: [], sections: [section] }
+
+  for (let line of lines) {
+    if (line.charAt(0) === '#') {
+      section = { name: line.slice(1).trim(), patterns: [] }
+      state.sections.push(section)
+      continue
+    }
+
+    if (line.trim() !== '') {
+      let pattern = fn(line, section, state)
+      section.patterns.push(pattern)
+      state.patterns.push(pattern)
+    }
+  }
+  return state
+}
+
+function stringify(state) {
+  return parseIgnore.stringify(state.sections, (section) => {
+    if (!section.patterns.length) {
+      return ''
+    }
+
+    return `# ${section.name}\n${section.patterns.join('\n')}\n\n`
+  })
+}
+
+function parse(input, fn) {
+  const state = parser(input, fn)
+
+  state.concat = (i) => {
+    const newState = parser(i, fn)
+
+    for (let s2 in newState.sections) {
+      const sec2 = newState.sections[s2]
+
+      let sectionExists = false
+      for (let s1 in state.sections) {
+        const sec1 = state.sections[s1]
+
+        // Join sections under common name
+        if (sec1.name === sec2.name) {
+          sectionExists = true
+          sec1.patterns = Array.from(new Set(sec1.patterns.concat(sec2.patterns)))
+        }
+      }
+
+      // Add new section
+      if (!sectionExists) {
+        state.sections.push(sec2)
+      }
+    }
+
+    return state
+  }
+
+  return state
+}
+
+async function ensureNetlifyIgnore(dir) {
+  const gitIgnorePath = path.join(dir, '.gitignore')
+  const ignoreContent = '# Local Netlify folder\n.netlify'
+
+  /* No .gitignore file. Create one and ignore .netlify folder */
+  if (!await hasGitIgnore(dir)) {
+    await writeFile(gitIgnorePath, ignoreContent, 'utf8')
+    return false
+  }
+
+  let gitIgnoreContents
+  let ignorePatterns
+  try {
+    gitIgnoreContents = await readFile(gitIgnorePath, 'utf8')
+    ignorePatterns = parseIgnore.parse(gitIgnoreContents)
+  } catch (e) {
+    // ignore
+  }
+  /* Not ignoring .netlify folder. Add to .gitignore */
+  if (!ignorePatterns || !ignorePatterns.patterns.includes('.netlify')) {
+    const newContents = `${gitIgnoreContents}\n${ignoreContent}`
+    await writeFile(gitIgnorePath, newContents, 'utf8')
+  }
+}
+
+module.exports = {
+  parse: parse,
+  stringify: stringify,
+  format: parseIgnore.format,
+  ensureNetlifyIgnore
+}

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -3,7 +3,6 @@ const inquirer = require('inquirer')
 const chalk = require('chalk')
 const isEmpty = require('lodash.isempty')
 const getRepoData = require('../get-repo-data')
-const { ensureNetlifyIgnore } = require('../gitignore')
 const { track } = require('../telemetry')
 
 module.exports = async function linkPrompts(context) {
@@ -163,9 +162,6 @@ Run ${chalk.cyanBright('`git remote -v`')} to see a list of your git remotes.`)
 
   // Save site ID to config
   state.set('siteId', site.id)
-
-  // Add .netlify to .gitignore file
-  await ensureNetlifyIgnore(site.root)
 
   await track('sites_linked', {
     siteId: site.id,

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -3,6 +3,7 @@ const inquirer = require('inquirer')
 const chalk = require('chalk')
 const isEmpty = require('lodash.isempty')
 const getRepoData = require('../get-repo-data')
+const { ensureNetlifyIgnore } = require('../gitignore')
 const { track } = require('../telemetry')
 
 module.exports = async function linkPrompts(context) {
@@ -162,6 +163,9 @@ Run ${chalk.cyanBright('`git remote -v`')} to see a list of your git remotes.`)
 
   // Save site ID to config
   state.set('siteId', site.id)
+
+  // Add .netlify to .gitignore file
+  await ensureNetlifyIgnore(site.root)
 
   await track('sites_linked', {
     siteId: site.id,


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/282 & https://github.com/netlify/cli/issues/219

This will automatically add `.netlify` folder to gitignore folder of folder.

It will ignore `.gitignores` that already contain `.netlify`

Runs whenever `netlify init` or `netlify link` is ran