### PR TITLE
Remove Github token from browser history

### DIFF
--- a/src/utils/gh-auth.js
+++ b/src/utils/gh-auth.js
@@ -60,7 +60,7 @@ async function getGitHubToken(opts) {
       const parameters = querystring.parse(req.url.slice(req.url.indexOf('?') + 1))
       if (parameters.token) {
         deferredResolve(parameters)
-        res.end("<html><head><style>html{font-family:sans-serif;background:#0e1e25}body{overflow:hidden;position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;width:100vw;}h3{margin:0}.card{position:relative;display:flex;flex-direction:column;width:75%;max-width:364px;padding:24px;background:white;color:rgb(14,30,37);border-radius:8px;box-shadow:0 2px 4px 0 rgba(14,30,37,.16);}</style></head>" +
+        res.end("<html><head><script>if(history.replaceState){history.replaceState({},'','/')}</script><style>html{font-family:sans-serif;background:#0e1e25}body{overflow:hidden;position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;width:100vw;}h3{margin:0}.card{position:relative;display:flex;flex-direction:column;width:75%;max-width:364px;padding:24px;background:white;color:rgb(14,30,37);border-radius:8px;box-shadow:0 2px 4px 0 rgba(14,30,37,.16);}</style></head>" +
           "<body><div class=card><h3>Logged In</h3><p>You're now logged into Netlify CLI with your " +
           parameters.provider + " credentials. Please close this window.</p></div>")
         server.close()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Remove GitHub token from URL (query parameters) by using `history.replaceState`, so that, it won't be stored in browser's history.

**- Test plan**

* Remove your Github credentials from `~/.netlify/config.json`
* Do `netlify init` for a project with Github as remote
* Chose to sign in to Github via app.netlify.com
* Authorize
* Check the browser's URL after you're redirected back to `localhost`

**- Description for the changelog**

* Use `history.replaceState` to remove query parameters from URL on the page we serve from localhost

**- A picture of a cute animal (not mandatory but encouraged)**
![hedgehog-animal-baby-cute-50577](https://user-images.githubusercontent.com/10067728/61557578-0780e600-aa7e-11e9-8756-71946274ea97.jpeg)
