### PR TITLE
Add global --json, --auth, && --silent flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Handle various site operations
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`sites:create`](/docs/commands/sites.md#sitescreate) | Create an empty site (advanced)  |
+| [`sites:delete`](/docs/commands/sites.md#sitesdelete) | Delete a site  |
 | [`sites:list`](/docs/commands/sites.md#siteslist) | List all sites you have access to  |
 
 

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -89,7 +89,7 @@ netlify deploy
 - `prod` (*boolean*) - Deploy to production
 - `open` (*boolean*) - Open site after deploy
 - `message` (*option*) - A short message to include in the deploy log
-- `auth` (*option*) - An auth token to log in with
+- `auth` (*option*) - Netlify auth token to deploy with
 - `site` (*option*) - A site ID to deploy to
 - `json` (*boolean*) - Output deployment data as JSON
 
@@ -100,6 +100,7 @@ netlify deploy
 netlify deploy --prod
 netlify deploy --prod --open
 netlify deploy --message "A message with an $ENV_VAR"
+netlify deploy --auth $NETLIFY_AUTH_TOKEN
 ```
 
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -51,6 +51,12 @@ Runs a command within the netlify dev environment, e.g. with env variables from 
 netlify dev:exec
 ```
 
+**Examples**
+
+```bash
+$ netlify exec npm run bootstrap
+```
+
 ---
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -7,7 +7,7 @@ description: Run netlify dev locally
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
 Manage netlify functions
-The [92m`functions`[39m command will help you manage the functions in this site
+The `functions` command will help you manage the functions in this site
 
 
 **Usage**
@@ -67,6 +67,14 @@ netlify functions:create
 - `name` (*option*) - function name
 - `url` (*option*) - pull template from URL
 
+**Examples**
+
+```bash
+netlify functions:create
+netlify functions:create hello-world
+netlify functions:create --name hello-world
+```
+
 ---
 ## `functions:invoke`
 
@@ -88,7 +96,20 @@ netlify functions:invoke
 - `functions` (*option*) - Specify a functions folder to parse, overriding netlify.toml
 - `querystring` (*option*) - Querystring to add to your function invocation
 - `payload` (*option*) - Supply POST payload in stringified json, or a path to a json file
-- `auth` (*boolean*) - simulate Netlify Identity authentication JWT. pass --no-auth to affirm unauthenticated request
+- `identity` (*boolean*) - simulate Netlify Identity authentication JWT. pass --no-identity to affirm unauthenticated request
+
+**Examples**
+
+```bash
+$ netlify functions:invoke
+$ netlify functions:invoke myfunction
+$ netlify functions:invoke --name myfunction
+$ netlify functions:invoke --name myfunction --identity
+$ netlify functions:invoke --name myfunction --no-identity
+$ netlify functions:invoke myfunction --payload "{"foo": 1}"
+$ netlify functions:invoke myfunction --querystring "foo=1
+$ netlify functions:invoke myfunction --payload "./pathTo.json"
+```
 
 ---
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -54,6 +54,7 @@ Handle various site operations
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`sites:create`](/commands/sites#sitescreate) | Create an empty site (advanced)  |
+| [`sites:delete`](/commands/sites#sitesdelete) | Delete a site  |
 | [`sites:list`](/commands/sites#siteslist) | List all sites you have access to  |
 
 

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -13,6 +13,11 @@ Open settings for the site linked to the current folder
 netlify open
 ```
 
+**Flags**
+
+- `site` (*boolean*) - Open site
+- `admin` (*boolean*) - Open Netlify site
+
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`open:admin`](/commands/open#openadmin) | Opens current site admin UI in Netlify  |
@@ -22,6 +27,8 @@ netlify open
 **Examples**
 
 ```bash
+netlify open --site
+netlify open --admin
 netlify open:admin
 netlify open:site
 ```
@@ -37,12 +44,24 @@ Opens current site admin UI in Netlify
 netlify open:admin
 ```
 
+**Examples**
+
+```bash
+netlify open:admin
+```
+
 ---
 ## `open:site`
 
 Opens current site url in browser
 
 **Usage**
+
+```bash
+netlify open:site
+```
+
+**Examples**
 
 ```bash
 netlify open:site

--- a/docs/commands/sites.md
+++ b/docs/commands/sites.md
@@ -19,6 +19,7 @@ netlify sites
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`sites:create`](/commands/sites#sitescreate) | Create an empty site (advanced)  |
+| [`sites:delete`](/commands/sites#sitesdelete) | Delete a site  |
 | [`sites:list`](/commands/sites#siteslist) | List all sites you have access to  |
 
 
@@ -49,6 +50,34 @@ netlify sites:create
 - `account-slug` (*option*) - account slug to create the site under
 - `with-ci` (*boolean*) - initialize CI hooks during site creation
 - `manual` (*boolean*) - Force manual CI setup.  Used --with-ci flag
+
+---
+## `sites:delete`
+
+Delete a site
+
+This command will permanently delete the site on Netlify. Use with caution.
+
+
+**Usage**
+
+```bash
+netlify sites:delete {site-id}
+```
+
+**Arguments**
+
+- siteId - Site ID to delete. `netlify delete 1234-5678-890`
+
+**Flags**
+
+- `force` (*boolean*) - delete without prompting (useful for CI)
+
+**Examples**
+
+```bash
+netlify site:delete 1234-3262-1211
+```
 
 ---
 ## `sites:list`

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Handle various site operations
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`sites:create`](/commands/sites#sitescreate) | Create an empty site (advanced)  |
+| [`sites:delete`](/commands/sites#sitesdelete) | Delete a site  |
 | [`sites:list`](/commands/sites#siteslist) | List all sites you have access to  |
 
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -879,9 +879,9 @@
       "integrity": "sha512-CFLSALoE+93+Hcb5pFjp0J1uMrrbLRe+L1+gFwerJ776R3TACSF0kTVRQ7AvRa7aFx70nqYHAc7wQPlt9kY2Mg=="
     },
     "@types/node-fetch": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.3.7.tgz",
-      "integrity": "sha512-+bKtuxhj/TYSSP1r4CZhfmyA0vm/aDRQNo7vbAgf6/cZajn0SAniGGST07yvI4Q+q169WTa2/x9gEHfJrkcALw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==",
       "requires": {
         "@types/node": "*"
       }
@@ -7031,11 +7031,11 @@
       }
     },
     "netlify-dev-plugin": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/netlify-dev-plugin/-/netlify-dev-plugin-1.0.24.tgz",
-      "integrity": "sha512-zEYvEJKacSVYIJ0eUQ9sEEddvWvZ3elDhfvgJ1XV0mEhPkdJZg9OT6WispQryhgU+r82Z+Auz/DWyCI7lSFQFA==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/netlify-dev-plugin/-/netlify-dev-plugin-1.0.25.tgz",
+      "integrity": "sha512-yTjgg2kwAMJynAe+VNRtzgFJQE6s9QH533cp1yMHMNGBLCKm3tmwViM1Qt+t+GnmEfoTNphkFSeFdfB+3P+tbw==",
       "requires": {
-        "@netlify/cli-utils": "^1.0.1",
+        "@netlify/cli-utils": "^1.0.7",
         "@netlify/rules-proxy": "^0.1.3",
         "@netlify/zip-it-and-ship-it": "^0.3.0",
         "@oclif/command": "^1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -448,12 +448,13 @@
       }
     },
     "@netlify/cli-utils": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@netlify/cli-utils/-/cli-utils-1.0.6.tgz",
-      "integrity": "sha512-Y+hAPDuJn1CV05vSNSb0os8uNwnqEXEzONc5a40RggYNxQ7b7UdKn6hWbhDeT10UgYM4EwxKKxgGDTYF0TAIYQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@netlify/cli-utils/-/cli-utils-1.0.7.tgz",
+      "integrity": "sha512-Tt7vVjutcuW9a4QxQ9CmJ38uaGqffk1zd6wJg6TMcy6/x/3bW4J1BdEiz7ZZ5OGidvtx5QaLv51ExNHtEFsZ8g==",
       "requires": {
         "@iarna/toml": "^2.2.1",
         "@oclif/command": "^1.5.8",
+        "@oclif/parser": "^3.8.3",
         "chalk": "^2.4.1",
         "ci-info": "^2.0.0",
         "cli-ux": "^5.0.0",
@@ -469,6 +470,18 @@
         "node-fetch": "^2.3.0",
         "uuid": "^3.3.2",
         "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "@oclif/parser": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.3.tgz",
+          "integrity": "sha512-zN+3oGuv9Lg8NjFvxZTDKFEmhAMfAvd/JWeQp3Ri8pDezoyJQi4OSHHLM8sdHjBh8sePewfWI7+fDUXdrVbrqg==",
+          "requires": {
+            "@oclif/linewrap": "^1.0.0",
+            "chalk": "^2.4.2",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@netlify/open-api": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7018,9 +7018,9 @@
       }
     },
     "netlify-dev-plugin": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/netlify-dev-plugin/-/netlify-dev-plugin-1.0.23.tgz",
-      "integrity": "sha512-6C3qd71e/eXJvbkmw7g99MaM6btWdkuwVTGPQKKjRgMJtoyyNE8SrN3Ki218e57puTeSdioSWAv5vezCNC6dLg==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/netlify-dev-plugin/-/netlify-dev-plugin-1.0.24.tgz",
+      "integrity": "sha512-zEYvEJKacSVYIJ0eUQ9sEEddvWvZ3elDhfvgJ1XV0mEhPkdJZg9OT6WispQryhgU+r82Z+Auz/DWyCI7lSFQFA==",
       "requires": {
         "@netlify/cli-utils": "^1.0.1",
         "@netlify/rules-proxy": "^0.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6977,9 +6977,9 @@
       "dev": true
     },
     "netlify": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-2.4.6.tgz",
-      "integrity": "sha512-p/Uad5WxS6q+QeJwxGT8P2GPL8x7oUYJSaimsmRYHTuP+qMyvS0ff5jufd41WT9P+lyT9CaFjcH5UgPOcW/6CA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-2.4.7.tgz",
+      "integrity": "sha512-6UkqQM8Qmr0Nm5gExNDgEzzUydZHImhPGKf1EZ0n5eodG6mw7dvoXDAJtTHy9HXbEuhZvgkYPv0rOX6KgkrXHQ==",
       "requires": {
         "@netlify/open-api": "^0.9.0",
         "@netlify/zip-it-and-ship-it": "^0.3.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3042,7 +3042,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3054,7 +3054,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -4272,8 +4272,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4291,13 +4290,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4310,18 +4307,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4424,8 +4418,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4435,7 +4428,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4448,20 +4440,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4478,7 +4467,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4551,8 +4539,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4562,7 +4549,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4638,8 +4624,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4669,7 +4654,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4687,7 +4671,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4726,13 +4709,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -4796,7 +4777,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4892,7 +4873,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4914,7 +4895,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4944,7 +4925,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -4981,7 +4962,7 @@
       "dependencies": {
         "bl": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
           "dev": true,
           "requires": {
@@ -4996,7 +4977,7 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
@@ -5010,7 +4991,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -5463,7 +5444,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -5475,13 +5456,13 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -6906,7 +6887,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -8532,7 +8513,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -9490,7 +9471,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9877,7 +9858,7 @@
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.sample": "^4.2.1",
     "log-symbols": "^2.2.0",
-    "netlify": "^2.4.6",
+    "netlify": "^2.4.7",
     "netlify-dev-plugin": "^1.0.23",
     "node-fetch": "^2.6.0",
     "open": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,32 @@
     "David Wells <david.wells@netlify.com> (https://davidwells.io/)",
     "Bret Comnes <bcomnes@gmail.com> (https://bret.io)"
   ],
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "/bin",
+    "/npm-shrinkwrap.json",
+    "/oclif.manifest.json",
+    "/src/**/*.js"
+  ],
+  "homepage": "https://github.com/netlify/cli",
+  "keywords": [
+    "api",
+    "cli",
+    "netlify",
+    "static"
+  ],
+  "license": "MIT",
+  "repository": "netlify/cli",
+  "main": "src/index.js",
+  "bin": {
+    "ntl": "./bin/run",
+    "netlify": "./bin/run"
+  },
+  "bugs": {
+    "url": "https://github.com/netlify/cli/issues"
+  },
   "scripts": {
     "build": "run-s build:*",
     "build:site": "cd site && npm install && npm run build",
@@ -30,25 +56,6 @@
     "prepublishOnly": "git push && git push --tags && gh-release",
     "update-semver": "npm --depth 9999 update",
     "postinstall": "node ./scripts/postinstall.js"
-  },
-  "ava": {
-    "files": [
-      "src/**/*.test.js"
-    ],
-    "cache": true,
-    "concurrency": 5,
-    "failFast": false,
-    "failWithoutAssertions": false,
-    "tap": false,
-    "compileEnhancements": false,
-    "babel": false
-  },
-  "bin": {
-    "ntl": "./bin/run",
-    "netlify": "./bin/run"
-  },
-  "bugs": {
-    "url": "https://github.com/netlify/cli/issues"
   },
   "dependencies": {
     "@netlify/cli-utils": "^1.0.7",
@@ -110,24 +117,18 @@
     "prettier": "^1.16.4",
     "strip-ansi": "^5.2.0"
   },
-  "engines": {
-    "node": ">=8.0.0"
+  "ava": {
+    "files": [
+      "src/**/*.test.js"
+    ],
+    "cache": true,
+    "concurrency": 5,
+    "failFast": false,
+    "failWithoutAssertions": false,
+    "tap": false,
+    "compileEnhancements": false,
+    "babel": false
   },
-  "files": [
-    "/bin",
-    "/npm-shrinkwrap.json",
-    "/oclif.manifest.json",
-    "/src/**/*.js"
-  ],
-  "homepage": "https://github.com/netlify/cli",
-  "keywords": [
-    "api",
-    "cli",
-    "netlify",
-    "static"
-  ],
-  "license": "MIT",
-  "main": "src/index.js",
   "oclif": {
     "bin": "netlify",
     "commands": "./src/commands",
@@ -145,6 +146,5 @@
         "./src/hooks/analytics"
       ]
     }
-  },
-  "repository": "netlify/cli"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash.sample": "^4.2.1",
     "log-symbols": "^2.2.0",
     "netlify": "^2.4.7",
-    "netlify-dev-plugin": "^1.0.23",
+    "netlify-dev-plugin": "^1.0.24",
     "node-fetch": "^2.6.0",
     "open": "^6.4.0",
     "ora": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash.sample": "^4.2.1",
     "log-symbols": "^2.2.0",
     "netlify": "^2.4.7",
-    "netlify-dev-plugin": "^1.0.24",
+    "netlify-dev-plugin": "^1.0.25",
     "node-fetch": "^2.6.0",
     "open": "^6.4.0",
     "ora": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/netlify/cli/issues"
   },
   "dependencies": {
-    "@netlify/cli-utils": "^1.0.6",
+    "@netlify/cli-utils": "^1.0.7",
     "@oclif/command": "^1.5.14",
     "@oclif/errors": "^1.1.2",
     "@oclif/plugin-help": "^2.2.0",

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -22,7 +22,7 @@ const config = {
         let md = ''
         // Parent Command
         md += formatDescription(info.description)
-        md += formatUsage(command)
+        md += formatUsage(command, info)
         md += formatArgs(info.args)
         md += formatFlags(info.flags)
         md += commandListSubCommandDisplay(info.commands)
@@ -33,9 +33,10 @@ const config = {
             // Child Commands
             md += formatSubCommandTitle(subCmd.name)
             md += formatDescription(subCmd.description)
-            md += formatUsage(subCmd.name)
+            md += formatUsage(subCmd.name, subCmd)
             md += formatArgs(subCmd.args)
             md += formatFlags(subCmd.flags)
+            md += commandExamples(subCmd.examples)
             md += `---\n`
           })
         }
@@ -126,11 +127,18 @@ function commandListSubCommandDisplay(commands, context) {
   })
   return `${table}${newLine}`
 }
-function formatUsage(commandName) {
+function formatUsage(commandName, info) {
+  const defaultUsage = `netlify ${commandName}`
+
+  if (commandName === 'sites:delete') {
+    console.log(info)
+  }
+
+  const usageString = info.usage || defaultUsage
   return `**Usage**
 
 \`\`\`bash
-netlify ${commandName}
+${usageString}
 \`\`\`\n\n`
 }
 

--- a/scripts/generateCommandData.js
+++ b/scripts/generateCommandData.js
@@ -34,6 +34,7 @@ module.exports = function generateCommandData() {
     if (curr.commandGroup === curr.command) {
       acc[curr.commandGroup] = {
         name: curr.command,
+        usage: curr.data.usage,
         description: curr.data.description,
         flags: curr.data.flags,
         args: curr.data.args,
@@ -51,6 +52,7 @@ module.exports = function generateCommandData() {
       if (acc[curr.commandGroup] && acc[curr.commandGroup].commands) {
         acc[curr.commandGroup].commands = acc[curr.commandGroup].commands.concat({
           name: curr.command,
+          usage: curr.data.usage,
           description: curr.data.description,
           flags: curr.data.flags,
           args: curr.data.args,

--- a/src/commands/addons/auth.js
+++ b/src/commands/addons/auth.js
@@ -5,7 +5,6 @@ const openBrowser = require('../../utils/open-browser')
 class AddonsAuthCommand extends Command {
   async run() {
     let accessToken = await this.authenticate()
-
     const { args } = this.parse(AddonsAuthCommand)
 
     const addonName = args.name
@@ -13,7 +12,7 @@ class AddonsAuthCommand extends Command {
     const siteId = this.netlify.site.id
 
     if (!siteId) {
-      console.log('No site id found, please run inside a site folder or `netlify link`')
+      this.log('No site id found, please run inside a site folder or `netlify link`')
       return false
     }
 
@@ -21,7 +20,7 @@ class AddonsAuthCommand extends Command {
     const addons = await getAddons(siteId, accessToken)
 
     if (typeof addons === 'object' && addons.error) {
-      console.log('API Error', addons)
+      this.log('API Error', addons)
       return false
     }
 
@@ -29,7 +28,7 @@ class AddonsAuthCommand extends Command {
     const currentAddon = addons.find(addon => addon.service_path === `/.netlify/${addonName}`)
 
     if (!currentAddon || !currentAddon.id) {
-      console.log(`Addon ${addonName} doesn't exist for ${site.name}`)
+      this.log(`Addon ${addonName} doesn't exist for ${site.name}`)
       return false
     }
 
@@ -37,11 +36,11 @@ class AddonsAuthCommand extends Command {
       console.log(`No Admin URL found for the "${addonName} add-on"`)
       return false
     }
-    console.log()
-    console.log(`Opening ${addonName} add-on admin URL:`)
-    console.log()
-    console.log(currentAddon.auth_url)
-    console.log()
+    this.log()
+    this.log(`Opening ${addonName} add-on admin URL:`)
+    this.log()
+    this.log(currentAddon.auth_url)
+    this.log()
     await openBrowser(currentAddon.auth_url)
     this.exit()
   }

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -18,7 +18,7 @@ class AddonsConfigCommand extends Command {
     const siteId = this.netlify.site.id
 
     if (!siteId) {
-      console.log('No site id found, please run inside a site folder or `netlify link`')
+      this.log('No site id found, please run inside a site folder or `netlify link`')
       return false
     }
 
@@ -26,7 +26,7 @@ class AddonsConfigCommand extends Command {
     const addons = await getAddons(siteId, accessToken)
 
     if (typeof addons === 'object' && addons.error) {
-      console.log('API Error', addons)
+      this.log('API Error', addons)
       return false
     }
 
@@ -34,8 +34,8 @@ class AddonsConfigCommand extends Command {
     const currentAddon = addons.find(addon => addon.service_path === `/.netlify/${addonName}`)
 
     if (!currentAddon || !currentAddon.id) {
-      console.log(`Add-on ${addonName} doesn't exist for ${site.name}`)
-      console.log(`> Run \`netlify addons:create ${addonName}\` to create an instance for this site`)
+      this.log(`Add-on ${addonName} doesn't exist for ${site.name}`)
+      this.log(`> Run \`netlify addons:create ${addonName}\` to create an instance for this site`)
       return false
     }
 
@@ -48,13 +48,15 @@ class AddonsConfigCommand extends Command {
     const currentConfig = currentAddon.config || {}
 
     const words = `Current "${addonName} add-on" Settings:`
-    console.log(` ${chalk.yellowBright.bold(words)}`)
+    this.log(` ${chalk.yellowBright.bold(words)}`)
     if (hasConfig) {
-      render.configValues(addonName, manifest.config, currentConfig)
+      if (!rawFlags.silent) {
+        render.configValues(addonName, manifest.config, currentConfig)
+      }
     } else {
       // For addons without manifest. TODO remove once we enfore manifests
       Object.keys(currentConfig).forEach(key => {
-        console.log(`${key} - ${currentConfig[key]}`)
+        this.log(`${key} - ${currentConfig[key]}`)
       })
     }
 
@@ -78,7 +80,7 @@ class AddonsConfigCommand extends Command {
           },
           accessToken,
           error: this.error
-        })
+        }, this.log)
         return false
       }
 
@@ -91,16 +93,16 @@ class AddonsConfigCommand extends Command {
         }
       ])
       if (!updatePrompt.updateNow) {
-        console.log('Sounds good! Exiting configuration...')
+        this.log('Sounds good! Exiting configuration...')
         return false
       }
-      console.log()
-      console.log(` - Hit ${chalk.white.bold('enter')} to keep the existing value in (parentheses)`)
-      console.log(` - Hit ${chalk.white.bold('down arrow')} to remove the value`)
-      console.log(` - Hit ${chalk.white.bold('ctrl + C')} to cancel & exit configuration`)
-      console.log()
-      console.log(` You will need to verify the changed before we push them to your live site!`)
-      console.log()
+      this.log()
+      this.log(` - Hit ${chalk.white.bold('enter')} to keep the existing value in (parentheses)`)
+      this.log(` - Hit ${chalk.white.bold('down arrow')} to remove the value`)
+      this.log(` - Hit ${chalk.white.bold('ctrl + C')} to cancel & exit configuration`)
+      this.log()
+      this.log(` You will need to verify the changed before we push them to your live site!`)
+      this.log()
       const prompts = generatePrompts({
         config: manifest.config,
         configValues: currentConfig
@@ -110,20 +112,20 @@ class AddonsConfigCommand extends Command {
       const newConfig = updateConfigValues(manifest.config, currentConfig, userInput)
 
       const diffs = compare(currentConfig, newConfig)
-      // console.log('compare', diffs)
+      // this.log('compare', diffs)
       if (diffs.isEqual) {
-        console.log(`No changes. exiting early`)
+        this.log(`No changes. exiting early`)
         return false
       }
-      console.log()
-      console.log(`${chalk.yellowBright.bold.underline('Confirm your updates:')}`)
-      console.log()
+      this.log()
+      this.log(`${chalk.yellowBright.bold.underline('Confirm your updates:')}`)
+      this.log()
       diffs.keys.forEach(key => {
         const { newValue, oldValue } = diffs.diffs[key]
         const oldVal = oldValue || 'NO VALUE'
-        console.log(`${chalk.cyan(key)} changed from ${chalk.whiteBright(oldVal)} to ${chalk.green(newValue)}`)
+        this.log(`${chalk.cyan(key)} changed from ${chalk.whiteBright(oldVal)} to ${chalk.green(newValue)}`)
       })
-      console.log()
+      this.log()
 
       const confirmPrompt = await inquirer.prompt([
         {
@@ -135,7 +137,7 @@ class AddonsConfigCommand extends Command {
       ])
 
       if (!confirmPrompt.confirmChange) {
-        console.log('Canceling changes... You are good to go!')
+        this.log('Canceling changes... You are good to go!')
         return false
       }
 
@@ -151,23 +153,23 @@ class AddonsConfigCommand extends Command {
         },
         accessToken,
         error: this.error
-      })
+      }, this.log)
     }
   }
 }
 
-async function update({ addonName, currentConfig, newConfig, settings, accessToken, error }) {
+async function update({ addonName, currentConfig, newConfig, settings, accessToken, error }, logger) {
   const codeDiff = diffValues(currentConfig, newConfig)
   if (!codeDiff) {
-    console.log('No changes, exiting early')
+    logger('No changes, exiting early')
     return false
   }
-  console.log()
+  logger()
   const msg = `Updating ${addonName} add-on config values...`
-  console.log(`${chalk.white.bold(msg)}`)
-  console.log()
-  console.log(`${codeDiff}\n`)
-  console.log()
+  logger(`${chalk.white.bold(msg)}`)
+  logger()
+  logger(`${codeDiff}\n`)
+  logger()
 
   let updateAddonResponse
   try {
@@ -177,10 +179,10 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
     error(e.message)
   }
   if (updateAddonResponse.code === 404) {
-    console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
+    logger(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
     return false
   }
-  console.log(`Add-on "${addonName}" successfully updated`)
+  logger(`Add-on "${addonName}" successfully updated`)
   return updateAddonResponse
 }
 

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -28,9 +28,7 @@ class AddonsCreateCommand extends Command {
       return false
     }
 
-    const siteData = await api.getSite({
-      siteId
-    })
+    const siteData = await api.getSite({ siteId })
     const addons = await getAddons(siteId, accessToken)
 
     if (typeof addons === 'object' && addons.error) {
@@ -62,25 +60,25 @@ class AddonsCreateCommand extends Command {
     if (hasConfig) {
       const required = requiredConfigValues(manifest.config)
       const missingValues = missingConfigValues(required, rawFlags)
-      console.log(`Starting the setup for "${addonName} add-on"`)
-      console.log()
+      this.log(`Starting the setup for "${addonName} add-on"`)
+      this.log()
 
       if (Object.keys(rawFlags).length) {
         const newConfig = updateConfigValues(manifest.config, {}, rawFlags)
 
         if (missingValues.length) {
           /* Warn user of missing required values */
-          console.log(
+          this.log(
             `${chalk.redBright.underline.bold(`Error: Missing required configuration for "${addonName} add-on"`)}`
           )
-          console.log()
+          this.log()
           render.missingValues(missingValues, manifest)
-          console.log()
+          this.log()
           const msg = `netlify addons:create ${addonName}`
-          console.log(`Please supply the configuration values as CLI flags`)
-          console.log()
-          console.log(`Alternatively, you can run ${chalk.cyan(msg)} with no flags to walk through the setup steps`)
-          console.log()
+          this.log(`Please supply the configuration values as CLI flags`)
+          this.log()
+          this.log(`Alternatively, you can run ${chalk.cyan(msg)} with no flags to walk through the setup steps`)
+          this.log()
           return false
         }
 
@@ -94,20 +92,20 @@ class AddonsCreateCommand extends Command {
           accessToken,
           siteData,
           error: this.error
-        })
+        }, this.log)
         return false
       }
 
       const words = `The ${addonName} add-on has the following configurable options:`
-      console.log(` ${chalk.yellowBright.bold(words)}`)
+      this.log(` ${chalk.yellowBright.bold(words)}`)
       render.configValues(addonName, manifest.config)
-      console.log()
-      console.log(` ${chalk.greenBright.bold('Lets configure those!')}`)
+      this.log()
+      this.log(` ${chalk.greenBright.bold('Lets configure those!')}`)
 
-      console.log()
-      console.log(` - Hit ${chalk.white.bold('enter')} to confirm value or set empty value`)
-      console.log(` - Hit ${chalk.white.bold('ctrl + C')} to cancel & exit configuration`)
-      console.log()
+      this.log()
+      this.log(` - Hit ${chalk.white.bold('enter')} to confirm value or set empty value`)
+      this.log(` - Hit ${chalk.white.bold('ctrl + C')} to cancel & exit configuration`)
+      this.log()
 
       const prompts = generatePrompts({
         config: manifest.config,
@@ -120,7 +118,7 @@ class AddonsCreateCommand extends Command {
       const missingRequiredValues = missingConfigValues(required, configValues)
       if (missingRequiredValues && missingRequiredValues.length) {
         missingRequiredValues.forEach(val => {
-          console.log(`Missing required value "${val}". Please run the command again`)
+          this.log(`Missing required value "${val}". Please run the command again`)
         })
         return false
       }
@@ -136,11 +134,11 @@ class AddonsCreateCommand extends Command {
       accessToken,
       siteData,
       error: this.error
-    })
+    }, this.log)
   }
 }
 
-async function createSiteAddon({ addonName, settings, accessToken, siteData, error }) {
+async function createSiteAddon({ addonName, settings, accessToken, siteData, error }, logger) {
   let addonResponse
   try {
     // TODO update to https://open-api.netlify.com/#/default/createServiceInstance
@@ -150,13 +148,13 @@ async function createSiteAddon({ addonName, settings, accessToken, siteData, err
   }
 
   if (addonResponse.code === 404) {
-    console.log(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
+    logger(`No add-on "${addonName}" found. Please double check your add-on name and try again`)
     return false
   }
-  console.log(`Add-on "${addonName}" created for ${siteData.name}`)
+  logger(`Add-on "${addonName}" created for ${siteData.name}`)
   if (addonResponse.config && addonResponse.config.message) {
-    console.log()
-    console.log(`${addonResponse.config.message}`)
+    logger()
+    logger(`${addonResponse.config.message}`)
   }
   return addonResponse
 }

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -7,7 +7,7 @@ const { flags } = require('@oclif/command')
 class AddonsDeleteCommand extends Command {
   async run() {
     const accessToken = await this.authenticate()
-    const { args, flags } = this.parse(AddonsDeleteCommand)
+    const { args, flags, raw } = this.parse(AddonsDeleteCommand)
     const { site } = this.netlify
 
     const addonName = args.name

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -7,7 +7,7 @@ const { flags } = require('@oclif/command')
 class AddonsDeleteCommand extends Command {
   async run() {
     const accessToken = await this.authenticate()
-    const { args, flags, raw } = this.parse(AddonsDeleteCommand)
+    const { args, raw } = this.parse(AddonsDeleteCommand)
     const { site } = this.netlify
 
     const addonName = args.name

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -1,4 +1,5 @@
 const Command = require('@netlify/cli-utils')
+const inquirer = require('inquirer')
 const { getAddons, deleteAddon } = require('netlify/src/addons')
 const { flags } = require('@oclif/command')
 
@@ -29,15 +30,18 @@ class AddonsDeleteCommand extends Command {
       current => current.service_path && current.service_path.replace('/.netlify/', '') === addonName
     ) || {}
 
-    if (!flags.force) {
-      const inquirer = require('inquirer')
+
+    const { force, f } = parseRawFlags(raw)
+    if (!force && !f) {
       const { wantsToDelete } = await inquirer.prompt({
         type: 'confirm',
         name: 'wantsToDelete',
         message: `Are you sure you want to delete the ${addonName} add-on? (to skip this prompt, pass a --force flag)`,
         default: false
       })
-      if (!wantsToDelete) this.exit()
+      if (!wantsToDelete) {
+        this.exit()
+      }
     }
 
     if (!currentAddon.id) {
@@ -87,7 +91,10 @@ AddonsDeleteCommand.strict = false
 AddonsDeleteCommand.hidden = true
 AddonsDeleteCommand.aliases = ['addon:delete']
 AddonsDeleteCommand.flags = {
-  force: flags.boolean({ char: 'f', description: 'delete without prompting (useful for CI)' })
+  force: flags.boolean({
+    char: 'f',
+    description: 'delete without prompting (useful for CI)'
+  })
 }
 AddonsDeleteCommand.args = [
   {

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -1,6 +1,7 @@
 const Command = require('@netlify/cli-utils')
 const inquirer = require('inquirer')
 const { getAddons, deleteAddon } = require('netlify/src/addons')
+const { parseRawFlags } = require('../../utils/parse-raw-flags')
 const { flags } = require('@oclif/command')
 
 class AddonsDeleteCommand extends Command {

--- a/src/commands/addons/index.js
+++ b/src/commands/addons/index.js
@@ -14,7 +14,7 @@ class AddonsCommand extends Command {
   }
 }
 
-AddonsCommand.description = `Handle addon operations
+AddonsCommand.description = `Handle Netlify add-on operations
 The addons command will help you manage all your netlify addons
 `
 AddonsCommand.aliases = ['addon']

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -22,7 +22,7 @@ class AddonsListCommand extends Command {
 
     // Return json response for piping commands
     if (flags.json) {
-      this.log(JSON.stringify(addons, null, 2))
+      this.logJson(addons)
       return false
     }
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -106,7 +106,7 @@ class DeployCommand extends Command {
       configPath = site.configPath
       pathInfo['Configuration path'] = configPath
     }
-    log(prettyjson.render(pathInfo), this, flags)
+    this.log(prettyjson.render(pathInfo))
 
     ensureDirectory(deployFolder, this.exit)
 
@@ -117,9 +117,9 @@ class DeployCommand extends Command {
     let results
     try {
       if (deployToProduction) {
-        log('Deploying to live site URL...', this, flags)
+        this.log('Deploying to live site URL...')
       } else {
-        log('Deploying to draft URL...', this, flags)
+        this.log('Deploying to draft URL...')
       }
 
       results = await api.deploy(siteId, deployFolder, {
@@ -173,14 +173,14 @@ class DeployCommand extends Command {
       msgData['Live Draft URL'] = deployUrl
     }
 
-    log('', this, flags)
+    // Spacer
+    this.log()
 
     // Json response for piping commands
     if (flags.json && results) {
-
       const jsonData = {
         name: results.deploy.deployId,
-        // site_id: results.deploy.deployId,
+        site_id: results.deploy.site_id,
         deploy_id: results.deployId,
         deploy_url: deployUrl,
         logs: logsUrl,
@@ -189,17 +189,17 @@ class DeployCommand extends Command {
         jsonData.url = siteUrl
       }
 
-      this.log(JSON.stringify(jsonData, null, 2))
+      this.logJson(jsonData)
       return false
     }
 
     this.log(prettyjson.render(msgData))
 
     if (!deployToProduction) {
-      console.log()
-      console.log('If everything looks good on your draft URL, take it live with the --prod flag.')
-      console.log(`${chalk.cyanBright.bold('netlify deploy --prod')}`)
-      console.log()
+      this.log()
+      this.log('If everything looks good on your draft URL, take it live with the --prod flag.')
+      this.log(`${chalk.cyanBright.bold('netlify deploy --prod')}`)
+      this.log()
     }
 
     if (flags['open']) {
@@ -207,13 +207,6 @@ class DeployCommand extends Command {
       await openBrowser(urlToOpen)
       this.exit()
     }
-  }
-}
-
-// Hide logs if --json flag used
-function log(message, context, flags) {
-  if (!flags.json) {
-    context.log(message)
   }
 }
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -285,7 +285,8 @@ DeployCommand.examples = [
   'netlify deploy',
   'netlify deploy --prod',
   'netlify deploy --prod --open',
-  'netlify deploy --message "A message with an $ENV_VAR"'
+  'netlify deploy --message "A message with an $ENV_VAR"',
+  'netlify deploy --auth $NETLIFY_AUTH_TOKEN',
 ]
 
 DeployCommand.flags = {
@@ -313,7 +314,7 @@ DeployCommand.flags = {
   }),
   auth: flags.string({
     char: 'a',
-    description: 'An auth token to log in with',
+    description: 'Netlify auth token to deploy with',
     env: 'NETLIFY_AUTH_TOKEN'
   }),
   site: flags.string({

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -125,7 +125,7 @@ class DeployCommand extends Command {
       results = await api.deploy(siteId, deployFolder, {
         configPath: configPath,
         fnDir: functionsFolder,
-        statusCb: (flags.json) ? () => {} : deployProgressCb(),
+        statusCb: (flags.json || flags.silent) ? () => {} : deployProgressCb(),
         draft: !deployToProduction,
         message: flags.message
       })

--- a/src/commands/open/index.js
+++ b/src/commands/open/index.js
@@ -1,5 +1,7 @@
 const Command = require('@netlify/cli-utils')
+const { flags } = require('@oclif/command')
 const OpenAdminCommand = require('./admin')
+const OpenSiteCommand = require('./site')
 const showHelp = require('../../utils/show-help')
 const { isEmptyCommand } = require('../../utils/check-command-inputs')
 
@@ -10,13 +12,31 @@ class OpenCommand extends Command {
     if (isEmptyCommand(flags, args)) {
       showHelp(this.id)
     }
+
+    if (flags.site) {
+    	await OpenSiteCommand.run()
+    }
     // Default open netlify admin
     await OpenAdminCommand.run()
   }
 }
 
+OpenCommand.flags = {
+  site: flags.boolean({
+    description: 'Open site'
+  }),
+  admin: flags.boolean({
+    description: 'Open Netlify site'
+  })
+}
+
 OpenCommand.description = `Open settings for the site linked to the current folder`
 
-OpenCommand.examples = ['netlify open:admin', 'netlify open:site']
+OpenCommand.examples = [
+	'netlify open --site',
+	'netlify open --admin',
+	'netlify open:admin',
+	'netlify open:site'
+]
 
 module.exports = OpenCommand

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -1,30 +1,90 @@
-const { Command, flags } = require('@oclif/command')
-// const {parseRawFlags} = require('../../utils/parse-raw-flags')
+const inquirer = require('inquirer')
+const chalk = require('chalk')
+const Command = require('@netlify/cli-utils')
+const { flags } = require('@oclif/command')
+const { parseRawFlags } = require('../../utils/parse-raw-flags')
 
 class SitesDeleteCommand extends Command {
   async run() {
-    const { args } = this.parse(SitesDeleteCommand)
-
-    this.log(`delete a site id:`, args.siteID)
-    this.log(`Implementation coming soon`)
+    const { args, flags, raw } = this.parse(SitesDeleteCommand)
+    const { api, site } = this.netlify
+    const { siteId } = args
+    const cwdSiteId = site.id
 
     // 1. Prompt user for verification
+    await this.authenticate(flags.auth)
 
-    // const {force, f} = parseRawFlags(raw)
-    // if (!force || !f) {
-    //   const inquirer = require('inquirer')
-    //   const {wantsToDelete} = await inquirer.prompt({
-    //     type: 'confirm',
-    //     name: 'wantsToDelete',
-    //     message: `Are you sure you want to delete the ${addonName} add-on? (to skip this prompt, pass a --force flag)`,
-    //     default: false
-    //   })
-    //   if (!wantsToDelete) this.exit()
-    // }
+    let siteData
+    try {
+      siteData = await api.getSite({ siteId })
+    } catch (err) {
+      if (err.status === 404) {
+        this.warn(`No site with id ${siteId} found. Please verify the siteId & try again.`)
+        this.exit()
+      }
+    }
 
-    // 2. delete site
+    if (!siteData) {
+      this.warn(`Unable to process site`)
+      this.exit()
+    }
 
-    // 3. --force flag to skip prompts
+    const { force, f } = parseRawFlags(raw)
+    const noForce = !force && !f
+
+    /* Verify the user wants to delete the site */
+    if (noForce) {
+      this.log(`${chalk.redBright('Warning')}: You are about to permanently delete "${chalk.bold(siteData.name)}"`)
+      this.log(`         Verify this siteID "${cwdSiteId}" supplied is correct and proceed.`)
+      this.log('         To skip this prompt, pass a --force flag to the delete command')
+      this.log()
+      this.log(`${chalk.bold('Be careful here. There is no undo!')}`)
+      this.log()
+      const { wantsToDelete } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'wantsToDelete',
+        message: `WARNING: Are you sure you want to delete the "${siteData.name}" site?`,
+        default: false
+      })
+      this.log()
+      if (!wantsToDelete) {
+        this.exit()
+      }
+    }
+
+    /* Validation logic if siteId passed in does not match current site ID */
+    if (noForce && (cwdSiteId && (cwdSiteId !== siteId))) {
+      this.log(`${chalk.redBright('Warning')}: The siteId supplied does not match the current working directory siteId`)
+      this.log()
+      this.log(`Supplied:       "${siteId}"`)
+      this.log(`Current Site:   "${cwdSiteId}"`)
+      this.log()
+      this.log(`Verify this siteID "${cwdSiteId}" supplied is correct and proceed.`)
+      this.log('To skip this prompt, pass a --force flag to the delete command')
+      const { wantsToDelete } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'wantsToDelete',
+        message: `Verify & Proceed with deletion of site "${siteId}"?`,
+        default: false
+      })
+      if (!wantsToDelete) {
+        this.exit()
+      }
+    }
+
+    this.log(`Deleting site "${siteId}"...`)
+
+    try {
+      await api.deleteSite({ site_id: siteId })
+    } catch (error) {
+      if (error.status === 404) {
+        this.warn(`No site with id ${siteId} found. Please verify the siteId & try again.`)
+        this.exit()
+      } else {
+        this.error(`Delete Site error: ${error.status}: ${error.message}`)
+      }
+    }
+    this.log(`Site "${siteId}" successfully deleted!`)
   }
 }
 
@@ -32,18 +92,21 @@ SitesDeleteCommand.description = `delete a site`
 
 SitesDeleteCommand.args = [
   {
-    name: 'siteID',
+    name: 'siteId',
     required: true,
-    description: 'Site ID to delete'
+    description: 'Site ID to delete. `netlify delete 1234-5678-890`'
   }
 ]
+
 SitesDeleteCommand.flags = {
-  force: flags.boolean({ char: 'f', description: 'delete without prompting (useful for CI)' })
+  force: flags.boolean({
+    char: 'f',
+    description: 'delete without prompting (useful for CI)'
+  })
 }
 
-SitesDeleteCommand.examples = ['netlify site:delete 123-432621211']
-
-// TODO implement logic
-SitesDeleteCommand.hidden = true
+SitesDeleteCommand.examples = [
+  'netlify site:delete 123-432621211'
+]
 
 module.exports = SitesDeleteCommand

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -19,14 +19,12 @@ class SitesDeleteCommand extends Command {
       siteData = await api.getSite({ siteId })
     } catch (err) {
       if (err.status === 404) {
-        this.warn(`No site with id ${siteId} found. Please verify the siteId & try again.`)
-        this.exit()
+        this.error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
       }
     }
 
     if (!siteData) {
-      this.warn(`Unable to process site`)
-      this.exit()
+      this.error(`Unable to process site`)
     }
 
     const { force, f } = parseRawFlags(raw)
@@ -78,8 +76,7 @@ class SitesDeleteCommand extends Command {
       await api.deleteSite({ site_id: siteId })
     } catch (error) {
       if (error.status === 404) {
-        this.warn(`No site with id ${siteId} found. Please verify the siteId & try again.`)
-        this.exit()
+        this.error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
       } else {
         this.error(`Delete Site error: ${error.status}: ${error.message}`)
       }

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -85,7 +85,12 @@ class SitesDeleteCommand extends Command {
   }
 }
 
-SitesDeleteCommand.description = `delete a site`
+SitesDeleteCommand.usage = `netlify sites:delete {site-id}`
+
+SitesDeleteCommand.description = `Delete a site
+
+This command will permanently delete the site on Netlify. Use with caution.
+`
 
 SitesDeleteCommand.args = [
   {
@@ -103,7 +108,7 @@ SitesDeleteCommand.flags = {
 }
 
 SitesDeleteCommand.examples = [
-  'netlify site:delete 123-432621211'
+  'netlify site:delete 1234-3262-1211'
 ]
 
 module.exports = SitesDeleteCommand

--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -54,15 +54,15 @@ Count: ${logSites.length}
 `)
 
       logSites.forEach(s => {
-        console.log(`${chalk.greenBright(s.name)} - ${s.id}`)
-        console.log(`  ${chalk.whiteBright.bold('url:')}  ${chalk.yellowBright(s.ssl_url)}`)
+        this.log(`${chalk.greenBright(s.name)} - ${s.id}`)
+        this.log(`  ${chalk.whiteBright.bold('url:')}  ${chalk.yellowBright(s.ssl_url)}`)
         if (s.repo_url) {
-          console.log(`  ${chalk.whiteBright.bold('repo:')} ${chalk.white(s.repo_url)}`)
+          this.log(`  ${chalk.whiteBright.bold('repo:')} ${chalk.white(s.repo_url)}`)
         }
         if (s.account_name) {
-          console.log(`  ${chalk.whiteBright.bold('account:')} ${chalk.white(s.account_name)}`)
+          this.log(`  ${chalk.whiteBright.bold('account:')} ${chalk.white(s.account_name)}`)
         }
-        console.log(`─────────────────────────────────────────────────`)
+        this.log(`─────────────────────────────────────────────────`)
       })
     }
   }

--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -7,11 +7,15 @@ class SitesListCommand extends Command {
   async run() {
     const { flags } = this.parse(SitesListCommand)
     const { api } = this.netlify
-    cli.action.start('Loading your sites')
+    if (!flags.json) {
+      cli.action.start('Loading your sites')
+    }
     await this.authenticate()
 
     const sites = await api.listSites({ filter: 'all' })
-    cli.action.stop()
+    if (!flags.json) {
+      cli.action.stop()
+    }
 
     if (sites && sites.length) {
       const logSites = sites.map(site => {
@@ -37,7 +41,7 @@ class SitesListCommand extends Command {
           }
           return site
         })
-        console.log(JSON.stringify(redactedSites, null, 2))
+        this.logJson(redactedSites)
         return false
       }
 
@@ -45,6 +49,8 @@ class SitesListCommand extends Command {
 ────────────────────────────┐
    Current Netlify Sites    │
 ────────────────────────────┘
+
+Count: ${logSites.length}
 `)
 
       logSites.forEach(s => {

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -85,10 +85,12 @@ class StatusCommand extends Command {
     }
 
     // Json only logs out if --json flag is passed
-    this.logJson({
-      account: cleanAccountData,
-      siteData: statusData,
-    })
+    if (flags.json) {
+      this.logJson({
+        account: cleanAccountData,
+        siteData: statusData,
+      })
+    }
 
     this.log(prettyjson.render(statusData))
   }

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -7,6 +7,7 @@ const clean = require('clean-deep')
 class StatusCommand extends Command {
   async run() {
     const { globalConfig, api, site } = this.netlify
+    const { flags } = this.parse(StatusCommand)
     const current = globalConfig.get('userId')
     const [ accessToken ] = this.getConfigToken()
 
@@ -43,8 +44,16 @@ class StatusCommand extends Command {
 
     accountData.Teams = teamsData
 
+    const cleanAccountData = clean(accountData)
 
-    this.log(prettyjson.render(clean(accountData)))
+    this.log(prettyjson.render(cleanAccountData))
+
+    if (!site.configPath) {
+      this.logJson({
+        account: cleanAccountData
+      })
+      this.exit()
+    }
 
     this.log(`────────────────────┐
  Netlify Site Info  │
@@ -74,6 +83,12 @@ class StatusCommand extends Command {
       'Admin URL': chalk.magentaBright(siteData.admin_url),
       'Site URL': chalk.cyanBright(siteData.ssl_url || siteData.url)
     }
+
+    // Json only logs out if --json flag is passed
+    this.logJson({
+      account: cleanAccountData,
+      siteData: statusData,
+    })
 
     this.log(prettyjson.render(statusData))
   }

--- a/src/tests/addons.test.js
+++ b/src/tests/addons.test.js
@@ -5,8 +5,6 @@ const cliPath = require('./utils/cliPath')
 const exec = require('./utils/exec')
 const sitePath = path.join(__dirname, 'dummy-site')
 
-let siteId
-
 const execOptions = {
   stdio: [0, 1, 2],
   cwd: sitePath,
@@ -31,8 +29,6 @@ test.before(async t => {
   t.truthy(matches)
   t.truthy(matches.hasOwnProperty(1))
   t.truthy(matches[1])
-
-  siteId = matches[1]
   // Set the site id
   execOptions.env.NETLIFY_SITE_ID = matches[1]
 })

--- a/src/tests/addons.test.js
+++ b/src/tests/addons.test.js
@@ -72,5 +72,5 @@ test.after('cleanup', async t => {
   await deleteAddon('demo')
 
   console.log(`deleting test site "${siteName}". ${execOptions.env.NETLIFY_SITE_ID}`)
-  await exec(`${cliPath} sites:delete ${execOptions.env.NETLIFY_SITE_ID}`, execOptions)
+  await exec(`${cliPath} sites:delete ${execOptions.env.NETLIFY_SITE_ID} --force`, execOptions)
 })

--- a/src/tests/addons.test.js
+++ b/src/tests/addons.test.js
@@ -5,6 +5,8 @@ const cliPath = require('./utils/cliPath')
 const exec = require('./utils/exec')
 const sitePath = path.join(__dirname, 'dummy-site')
 
+let siteId
+
 const execOptions = {
   stdio: [0, 1, 2],
   cwd: sitePath,
@@ -30,6 +32,7 @@ test.before(async t => {
   t.truthy(matches.hasOwnProperty(1))
   t.truthy(matches[1])
 
+  siteId = matches[1]
   // Set the site id
   execOptions.env.NETLIFY_SITE_ID = matches[1]
 })
@@ -71,6 +74,8 @@ test.after('cleanup', async t => {
   console.log('Performing cleanup')
   // Run cleanup
   await deleteAddon('demo')
-  console.log('deleting test site: '+ siteName)
-  await exec(`${cliPath} sites:delete ${siteName}`, execOptions)
+  console.log(`deleting test site "${siteName}". ${siteId}`)
+  if (siteId) {
+    await exec(`${cliPath} sites:delete ${siteId} --force`, execOptions)
+  }
 })


### PR DESCRIPTION
To better support programatic use cases, this PR adds `--json` flag support for relevant commands.

This will disable normal CLI logging and only output `json` for the user to parse and use elsewhere

Example:

![image](https://user-images.githubusercontent.com/532272/61659761-27cac380-ac7d-11e9-8546-41e13a0b846e.png)

Depends on https://github.com/netlify/netlify-dev-plugin/pull/224 & https://github.com/netlify/cli-utils/pull/13