### PR TITLE
Add command to switch active Netlify account

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,10 +1,12 @@
+const { flags } = require('@oclif/command')
 const Command = require('@netlify/cli-utils')
 const chalk = require('chalk')
 
 class LoginCommand extends Command {
   async run() {
+    const { flags } = this.parse(LoginCommand)
     const [ accessToken, location ] = this.getConfigToken()
-    if (accessToken) {
+    if (accessToken && !flags.new) {
       this.log(`Already logged in ${msg(location)}`)
       this.log()
       this.log(`Run ${chalk.cyanBright('netlify status')} for account details`)
@@ -14,7 +16,7 @@ class LoginCommand extends Command {
       return this.exit()
     }
 
-    await this.authenticate()
+    await this.expensivelyAuthenticate()
 
     return this.exit()
   }
@@ -33,6 +35,11 @@ function msg(location) {
   }
 }
 
+LoginCommand.flags = {
+  new: flags.boolean({
+    description: 'Login to new Netlify account'
+  }),
+}
 LoginCommand.description = `Login to your Netlify account
 
 Opens a web browser to acquire an OAuth token.

--- a/src/commands/switch.js
+++ b/src/commands/switch.js
@@ -1,0 +1,36 @@
+const Command = require('@netlify/cli-utils')
+const chalk = require('chalk')
+const inquirer = require('inquirer')
+const LoginCommand = require('./login')
+
+class SwitchCommand extends Command {
+  async run() {
+    const LOGIN_NEW = 'I would like to login to a new account'
+    const availableUsersChoices = Object.values(this.netlify.globalConfig.get('users')).reduce(
+      (prev, current) => Object.assign(prev, { [current.id]: current.name ? `${current.name} (${current.email})` : current.email }), {})
+
+    const { accountSwitchChoice } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'accountSwitchChoice',
+        message: 'Please select the account you want to use:',
+        choices: [...Object.entries(availableUsersChoices).map(([, val]) => val), LOGIN_NEW],
+      },
+    ])
+
+    if (accountSwitchChoice === LOGIN_NEW) {
+      await LoginCommand.run(['--new'])
+    } else {
+      const selectedAccount = Object.entries(availableUsersChoices).find(([k, v]) => v === accountSwitchChoice)
+      this.netlify.globalConfig.set('userId', selectedAccount[0])
+      this.log('')
+      this.log(`You're now using ${chalk.bold(selectedAccount[1])}.`)
+    }
+
+    return this.exit()
+  }
+}
+
+SwitchCommand.description = `Switch your active Netlify account`
+
+module.exports = SwitchCommand


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Adds a new command (`netlify switch`) to allow you to switch between different Netlify accounts in CLI.
Fixes: https://github.com/netlify/cli/issues/105

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

* `netlify switch`
* Select "I would like to login to a new account". You'll be logged into the new account and your current account in CLI will be updated to reflect the latest.
* `netlify switch`, you can now see both accounts and switch between them

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Adds a new flag to `netlify login` (`--new`), that allows you to login to a new Netlify account even if you're already logged in
* Adds a new command `netlify switch` that allows you to switch between already logged in accounts and login to a new one

**- A picture of a cute animal (not mandatory but encouraged)**

![why-do-i-want-to-crush-cute-animals-1432782372](https://user-images.githubusercontent.com/10067728/62883269-1ab96580-bd4d-11e9-9d76-456ac77f38cf.jpg)