### PR TITLE
Fix repeated downloads of live-tunnel binary on Windows

### DIFF
--- a/src/utils/live-tunnel.js
+++ b/src/utils/live-tunnel.js
@@ -73,8 +73,9 @@ async function connectTunnel(session, netlifyApiToken, localPort, log) {
 }
 
 async function installTunnelClient(log) {
+  const win = isWindows();
   const binPath = path.join(os.homedir(), ".netlify", "tunnel", "bin");
-  const execName = isWindows() ? "live-tunnel-client.exe" : "live-tunnel-client";
+  const execName = win ? "live-tunnel-client.exe" : "live-tunnel-client";
   const execPath = path.join(binPath, execName);
   const newVersion = await fetchTunnelClient(execPath);
   if (!newVersion) {
@@ -83,7 +84,6 @@ async function installTunnelClient(log) {
 
   log(`${NETLIFYDEVLOG} Installing Live Tunnel Client`);
 
-  const win = isWindows();
   const platform = win ? "windows" : process.platform;
   const extension = win ? "zip" : "tar.gz";
   const release = {

--- a/src/utils/live-tunnel.js
+++ b/src/utils/live-tunnel.js
@@ -74,7 +74,8 @@ async function connectTunnel(session, netlifyApiToken, localPort, log) {
 
 async function installTunnelClient(log) {
   const binPath = path.join(os.homedir(), ".netlify", "tunnel", "bin");
-  const execPath = path.join(binPath, "live-tunnel-client");
+  const execName = isWindows() ? "live-tunnel-client.exe" : "live-tunnel-client";
+  const execPath = path.join(binPath, execName);
   const newVersion = await fetchTunnelClient(execPath);
   if (!newVersion) {
     return;


### PR DESCRIPTION
**- Summary**

Prevents the live-tunnel binary from being redownloaded every time `netlify dev --live` is run. Closes #417.

**- Test plan**

Resolution of #417 was confirmed manually in a Windows 10 VM. `npm run test` results in test failures, but they seem unrelated to this change as an identical test failure occurs on the master branch.

**- Description for the changelog**

Fix repeated downloads of live-tunnel binary on Windows
