### PR TITLE
Jekyll detector: Remove -l param

### DIFF
--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -11,7 +11,7 @@ module.exports = function() {
     proxyPort: 4000,
     env: { ...process.env },
     command: "bundle",
-    possibleArgsArrs: [["exec", "jekyll", "serve", "-w", "-l"]],
+    possibleArgsArrs: [["exec", "jekyll", "serve", "-w"]],
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, "g"),
     dist: "_site"
   };


### PR DESCRIPTION
My GH pages Jekyll setup fails without this change.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Remove `-l` param from `possibleArgsArrs` option.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**