### PR TITLE
Improve prompts for `link` command

### DIFF
--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -132,7 +132,7 @@ Run ${chalk.cyanBright('git remote -v')} to see a list of your git remotes.`)
       }
 
       if (isEmpty(matchingSites)) {
-        context.error(`No site names found containing '${searchTerm}'
+        context.error(`No site names found containing '${searchTerm}'.
 
 Run ${chalk.cyanBright('netlify link')} again to try a new search,
 or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -83,27 +83,25 @@ Run ${chalk.cyanBright('git remote -v')} to see a list of your git remotes.`)
       if (matchingSites.length === 1) {
         site = matchingSites[0]
       } else if (matchingSites.length > 1) {
-        // Matches multiple sites. Users much choose which to link.
+        // Matches multiple sites. Users must choose which to link.
         console.log(`Found ${matchingSites.length} matching sites!`)
 
-        const siteChoices = matchingSites.map(site => {
-          return `${site.name} - ${site.ssl_url}`
-        })
-
         // Prompt which options
-        const { siteToConnect } = await inquirer.prompt([
+        const { selectedSite } = await inquirer.prompt([
           {
             type: 'list',
-            name: 'siteToConnect',
+            name: 'selectedSite',
             message: 'Which site do you want to link?',
-            choices: siteChoices
+            choices: matchingSites.map(site => ({ 
+              name: `${site.name} - ${site.ssl_url}`, 
+              value: site 
+            }))
           }
         ])
-
-        const siteName = siteToConnect.split(' ')[0]
-        site = matchingSites.filter(site => {
-          return siteName === site.name
-        })[0]
+        if (!selectedSite) {
+          context.error('No site selected')
+        }
+        site = selectedSite
       }
       break
     }

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -170,20 +170,23 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
         context.error(e)
       }
 
-      if (sites.length === 0) {
+      if (isEmpty(sites)) {
         context.error(`You don't have any sites yet. Run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
       }
 
-      const siteSelection = await inquirer.prompt([
+      const { selectedSite } = await inquirer.prompt([
         {
           type: 'list',
-          name: 'siteName',
+          name: 'selectedSite',
           message: 'Which site do you want to link?',
           paginated: true,
           choices: sites.map(site => ({ name: site.name, value: site }))
         }
       ])
-      site = siteSelection.siteName
+      if (!selectedSite) {
+        context.error('No site selected')
+      }
+      site = selectedSite
       break
     }
     case SITE_ID_PROMPT: {


### PR DESCRIPTION
### Summary
Restores the site name search functionality removed in #335, along with some minor updates to copy and code. Partially addresses #496.

### Test plan
Run the `netlify link` command and try all of the options in the prompt tree:
- Use Git remote
	- with no `origin` set in `git remote` (prompt won't display in choices)
	- with an `origin` set that has no connected sites
	- with an `origin` set that has one connected site (this may still fail due to #498 and https://github.com/netlify/js-client/issues/39)
	- with an `origin` set that has more than one connected site (may also fail for same reasons)
	- from an account with no sites
- Search by name
	- with a string of garbage text that you know won't match anything
	- with a unique site name that isn't also part of another site name
	- with a short string that you know will match multiple site names
	- with an empty input
	- from an account with no sites
- Choose from a list of sites
	- from an account with multiple sites
	- from an account with no sites
- Enter site ID
	- with a valid site ID
	- with an invalid site ID

### Description for the changelog
- Restore site name search functionality in `link` command prompts
- Update `link` command prompt text for greater clarity and consistency
- Refactor `link` command prompt code for consistency between prompts

### Other impacts
This also changes the telemetry data collected for the `kind` field:
- `byName` changed to refer to the "search by name" prompt again as it did in v2.11.23 and before
- "Choose from list" prompt is now referred to as `fromList`

### A picture of a cute animal (not mandatory but encouraged)
![peeking hedgehog](https://ichef.bbci.co.uk/images/ic/1280xn/p06mvpw6.jpg)