### PR TITLE
Fix port for proxy redirects

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -251,7 +251,7 @@ class DevCommand extends Command {
 
     let { url, port } = await startProxy(settings, addonUrls)
     if (!url) {
-      url = proxyUrl
+      throw new Error('Unable to start proxy server')
     }
 
     if (flags.live) {

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -170,7 +170,7 @@ module.exports = function(config) {
         if (match.force || notStatic(reqUrl.pathname)) {
           const dest = new url.URL(
             match.to,
-            `${reqUrl.protocol}//${reqUrl.hostname}`
+            `${reqUrl.protocol}//${reqUrl.host}`
           )
           reqUrl.searchParams.forEach((v, k) => {
             dest.searchParams.append(k, v)
@@ -187,7 +187,7 @@ module.exports = function(config) {
           if (isExternal(match)) {
             console.log(`${NETLIFYDEVLOG} Proxying to `, match.to)
             const handler = proxy({
-              target: `${dest.protocol}//${dest.hostname}`,
+              target: `${dest.protocol}//${dest.host}`,
               changeOrigin: true,
               pathRewrite: (path, req) =>
                 match.to.replace(/https?:\/\/[^\/]+/, ''),

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -140,7 +140,7 @@ module.exports = function(config) {
     getMatcher().then(matcher => {
       const reqUrl = new url.URL(
         req.url,
-        `${req.protocol || req.headers.scheme || 'http'}://${req.hostname ||
+        `${req.protocol || (req.headers.scheme && req.headers.scheme + ':') || 'http:'}//${req.hostname ||
         req.headers['host']}`
       )
       const cookies = cookie.parse(req.headers.cookie || '')


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/425

We were not passing the `port` of the configured `to` address when creating a proxy. Which was a proxy to invalid address. This PR fixes that along with another fix for `reqUrl`'s protocol.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Create a redirect in your config. e.g.:
```
[[redirects]]
    from = "/graph"
    to = "http://localhost:34567/hello-world"    # a address for hello-world on functions server
    status = 200
```
Run `netlify dev`
Now visit [http://localhost:8888/graph](http://localhost:8888/graph).
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Fix `protocol` when creating `reqUrl`
* Use `host` instead of `hostname` when creating `target` for proxy
 
**- A picture of a cute animal (not mandatory but encouraged)**
🐨