### PR TITLE
Update links to netlify dev documentation

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -197,7 +197,7 @@ class DevCommand extends Command {
         this.log(
           `${NETLIFYDEVWARN} Setup a netlify.toml file with a [dev] section to specify your dev server settings.`
         )
-        this.log(`${NETLIFYDEVWARN} See docs at: https://github.com/netlify/netlify-dev-plugin#project-detection`)
+        this.log(`${NETLIFYDEVWARN} See docs at: https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection`)
         this.log(`${NETLIFYDEVWARN} Using current working directory for now...`)
         dist = process.cwd()
       }
@@ -230,7 +230,7 @@ class DevCommand extends Command {
           )} detected: Running npm script ${chalk.yellow(functionBuilder.npmScript)}`
         )
         this.warn(
-          `${NETLIFYDEVWARN} This is a beta feature, please give us feedback on how to improve at https://github.com/netlify/netlify-dev-plugin/`
+          `${NETLIFYDEVWARN} This is a beta feature, please give us feedback on how to improve at https://github.com/netlify/cli/`
         )
         await functionBuilder.build()
         const functionWatcher = chokidar.watch(functionBuilder.src)

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -320,7 +320,7 @@ async function scaffoldFromTemplate(flags, args, functionsDir) {
     }
   } else if (chosentemplate === "report") {
     this.log(
-      `${NETLIFYDEVLOG} Open in browser: https://github.com/netlify/netlify-dev-plugin/issues/new`
+      `${NETLIFYDEVLOG} Open in browser: https://github.com/netlify/cli/issues/new`
     );
   } else {
     const {

--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -19,7 +19,7 @@
 
 ## things to note
 
-- Dev block overrides will supercede anything you write in your detector: https://github.com/netlify/netlify-dev-plugin#project-detection
+- Dev block overrides will supercede anything you write in your detector: https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection
 - detectors are language agnostic. don't assume npm or yarn.
 - if default args (like 'develop') are missing, that means the user has configured it, best to tell them to use the -c flag.
 

--- a/src/utils/init/netlify-toml-template.js
+++ b/src/utils/init/netlify-toml-template.js
@@ -12,7 +12,7 @@ const makeNetlifyTOMLtemplate = ({ command = '# no build command', publish = '.'
   #  status = 200
   
   ## (optional) Settings for Netlify Dev
-  ## https://github.com/netlify/netlify-dev-plugin#project-detection
+  ## https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection
   #[dev] 
   #  command = "yarn start" # Command to start your dev server
   #  port = 3000 # Port that the dev server will be listening on


### PR DESCRIPTION
**- Summary**

Hello! I was playing with the local `dev` feature (which I see that you *just* moved here) and a link popped up in the output that still goes to the readme in the old repo (specifically the Project Detection section of the docs).

<img width="689" alt="Screen Shot 2019-09-11 at 2 21 15 PM" src="https://user-images.githubusercontent.com/1703673/64724393-6cfebb00-d4a0-11e9-9056-b5af5afccc9b.png">

**- Test plan**

Ran the same commands after making my changes and all seems fine, but this is my first time contributing here so please let me know if I missed anything!

**- Description for the changelog**

I've replaced links to the appropriate equivalent file in this repo. Left old links intact that referenced issues that have been closed over there. 

https://github.com/netlify/netlify-dev-plugin#project-detection => https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection

https://github.com/netlify/netlify-dev-plugin/issues/new => https://github.com/netlify/cli/issues/new

etc...

**- A picture of a cute animal (not mandatory but encouraged)**

My coding buddies. Hope more than one cute animal is allowed. ;)

![](https://user-images.githubusercontent.com/1703673/64724330-4ccefc00-d4a0-11e9-96e2-6b0bd9f75380.jpg)
