### PR TITLE
Dev: Only pipe stdio when running create-react-app

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -154,8 +154,8 @@ function startDevServer(settings, log) {
     env: { ...settings.env, FORCE_COLOR: 'true' },
     stdio: settings.stdio || 'inherit'
   })
-  if (ps.stdout) ps.stdout.on('data', settings.onStdout || ((buff) => process.stdout.write(buff.toString('utf8'))))
-  if (ps.stderr) ps.stderr.on('data', settings.onStderr || ((buff) => process.stderr.write(buff.toString('utf8'))))
+  if (ps.stdout) ps.stdout.on('data', ((buff) => process.stdout.write(buff.toString('utf8'))))
+  if (ps.stderr) ps.stderr.on('data', ((buff) => process.stderr.write(buff.toString('utf8'))))
   ps.on('close', code => process.exit(code))
   ps.on('SIGINT', process.exit)
   ps.on('SIGTERM', process.exit)

--- a/src/detectors/cra.js
+++ b/src/detectors/cra.js
@@ -33,12 +33,6 @@ module.exports = function() {
     proxyPort: 3000, // the port that create-react-app normally outputs
     env: { ...process.env, BROWSER: "none", PORT: 3000 },
     stdio: ['inherit', 'pipe', 'pipe'],
-    onStdout: function(buffer) {
-      process.stdout.write(buffer.toString('utf8'))
-    },
-    onStderr: function(buffer) {
-      process.stderr.write(buffer.toString('utf8'))
-    },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, "g"),
     dist: "public"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/493

We switched from letting child app server processes inherit the `stdin` and `stdout` to piping them to prevent `create-react-app` from clearing the terminal before we can show Netlify Dev server URL. But this change broke the intended behavior of other app servers like `gatsby`.
This change makes it so that we only pipes the `stdin` and `stdout` when running a `create-react-app` server and `inherit`s for other apps.
cc @tr1s
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
* `netlify dev` in a `create-react-app` project (should show Netlify Dev server URL)
* `netlify dev` in a `gatsby` project (should show things like GraphQL API URL)
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Only pipes the `stdin` and `stdout` when running a `create-react-app` server and `inherit`s for other apps. 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐼