### PR TITLE
Dev: Respect the dir flag for serving directory

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -184,9 +184,15 @@ class DevCommand extends Command {
 
     let settings = await serverSettings(Object.assign({}, config.dev, flags))
 
-    if (!(settings && settings.command)) {
-      this.log(`${NETLIFYDEVWARN} No dev server detected, using simple static server`)
-      let dist = (config.dev && config.dev.publish) || (config.build && config.build.publish)
+    if (flags.dir || !(settings && settings.command)) {
+      let dist
+      if (flags.dir) {
+        this.log(`${NETLIFYDEVWARN} Using simple static server because --dir flag was specified`)
+        dist = flags.dir
+      } else {
+        this.log(`${NETLIFYDEVWARN} No dev server detected, using simple static server`)
+        dist = (config.dev && config.dev.publish) || (config.build && config.build.publish)
+      }
       if (!dist) {
         this.log(`${NETLIFYDEVLOG} Using current working directory`)
         this.log(`${NETLIFYDEVWARN} Unable to determine public folder to serve files from.`)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/530
`dir` flag was specified but its value was not being used. This change makes it so that if `dir` flag is specified, it ignores the detected server.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
* `npx create-react-app my-project`
* `cd my-project`
* `yarn build`
* `netlify dev --dir=./build`
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Makes it so that if `dir` flag is specified, it ignores the detected server and using a static server.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🦁