### PR TITLE
Fix: Fixing the relative path in test

### DIFF
--- a/src/utils/redirect-parser/line-parser.test.js
+++ b/src/utils/redirect-parser/line-parser.test.js
@@ -276,7 +276,7 @@ test('complicated _redirects file', t => {
 })
 
 test('long _redirects file', t => {
-  const source = fs.readFileSync('./test-files/redirects', {
+  const source = fs.readFileSync(__dirname + '/test-files/redirects', {
     encoding: 'utf-8',
   })
 


### PR DESCRIPTION
**- Summary**

This PR fix the failed test. The test trying read file by relative path, and it is failed. I've add global variable `__dirname`__dirname` to path.

**- Test plan**

Please run the command:
```
$ yarn test:ava
```
and make sure that the test `src/utils/redirect-parser/line-parser.test.js` not failed.

**- Description for the changelog**

Fix the test, use absolute path to path in `fs.readFileSync`
