### PR TITLE
Dev: Add git pre-commit hook to prettifing only changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,17 @@
     "prettier": "^1.18.2",
     "strip-ansi": "^5.2.0"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "npm run test:prettier",
+      "git add"
+    ]
+  },
   "ava": {
     "files": [
       "src/**/*.test.js"


### PR DESCRIPTION
**- Summary**

As far in the repository, we have packages `husky` and `lint-staged` I've added the git-hook that run prettier.

**- Test plan**

Change file with non-prettier config (for example add many new lines in some part of a file) and add some another changes. Make commit with these changes and check with `git diff HEAD^` what was added. This many new lines should disappear.

**- Description for the changelog**

Add git-hook to run prettier automatically

