### PR TITLE
Update API documentation URLs

### DIFF
--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -186,7 +186,7 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
 
   let updateAddonResponse
   try {
-    // TODO update updateAddon to https://open-api.netlify.com/#/operation/updateServiceInstance
+    // TODO update updateAddon to https://open-api.netlify.com/#operation/updateServiceInstance
     updateAddonResponse = await updateAddon(settings, accessToken)
   } catch (e) {
     error(e.message)

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -39,7 +39,7 @@ class AddonsConfigCommand extends Command {
       return false
     }
 
-    // TODO update getAddonManifest to https://open-api.netlify.com/#/default/showServiceManifest
+    // TODO update getAddonManifest to https://open-api.netlify.com/#/operation/showServiceManifest
     const manifest = await getAddonManifest(addonName, accessToken)
     const hasConfig = manifest.config && Object.keys(manifest.config).length
     // Parse flags
@@ -186,7 +186,7 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
 
   let updateAddonResponse
   try {
-    // TODO update updateAddon to https://open-api.netlify.com/#/default/updateServiceInstance
+    // TODO update updateAddon to https://open-api.netlify.com/#/operation/updateServiceInstance
     updateAddonResponse = await updateAddon(settings, accessToken)
   } catch (e) {
     error(e.message)

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -39,7 +39,7 @@ class AddonsConfigCommand extends Command {
       return false
     }
 
-    // TODO update getAddonManifest to https://open-api.netlify.com/#/operation/showServiceManifest
+    // TODO update getAddonManifest to https://open-api.netlify.com/#operation/showServiceManifest
     const manifest = await getAddonManifest(addonName, accessToken)
     const hasConfig = manifest.config && Object.keys(manifest.config).length
     // Parse flags

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -155,7 +155,7 @@ class AddonsCreateCommand extends Command {
 async function createSiteAddon({ addonName, settings, accessToken, siteData, error }, logger) {
   let addonResponse
   try {
-    // TODO update to https://open-api.netlify.com/#/operation/createServiceInstance
+    // TODO update to https://open-api.netlify.com/#operation/createServiceInstance
     addonResponse = await createAddon(settings, accessToken)
   } catch (e) {
     error(e.message)

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -155,7 +155,7 @@ class AddonsCreateCommand extends Command {
 async function createSiteAddon({ addonName, settings, accessToken, siteData, error }, logger) {
   let addonResponse
   try {
-    // TODO update to https://open-api.netlify.com/#/default/createServiceInstance
+    // TODO update to https://open-api.netlify.com/#/operation/createServiceInstance
     addonResponse = await createAddon(settings, accessToken)
   } catch (e) {
     error(e.message)

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -63,7 +63,7 @@ class AddonsDeleteCommand extends Command {
     }
     let addonResponse
     try {
-      // TODO update deleteAddon to https://open-api.netlify.com/#/default/deleteServiceInstance
+      // TODO update deleteAddon to https://open-api.netlify.com/#/operation/deleteServiceInstance
       addonResponse = await deleteAddon(settings, accessToken)
     } catch (e) {
       this.error(e.message)

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -63,7 +63,7 @@ class AddonsDeleteCommand extends Command {
     }
     let addonResponse
     try {
-      // TODO update deleteAddon to https://open-api.netlify.com/#/operation/deleteServiceInstance
+      // TODO update deleteAddon to https://open-api.netlify.com/#operation/deleteServiceInstance
       addonResponse = await deleteAddon(settings, accessToken)
     } catch (e) {
       this.error(e.message)

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -17,7 +17,7 @@ class AddonsListCommand extends Command {
 
     const siteData = await api.getSite({ siteId })
 
-    // TODO update getAddons to https://open-api.netlify.com/#/operation/getServices
+    // TODO update getAddons to https://open-api.netlify.com/#operation/getServices
     const addons = await getAddons(siteId, accessToken)
 
     // Return json response for piping commands

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -17,7 +17,7 @@ class AddonsListCommand extends Command {
 
     const siteData = await api.getSite({ siteId })
 
-    // TODO update getAddons to https://open-api.netlify.com/#/default/getServices
+    // TODO update getAddons to https://open-api.netlify.com/#/operation/getServices
     const addons = await getAddons(siteId, accessToken)
 
     // Return json response for piping commands

--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -24,7 +24,7 @@ class APICommand extends Command {
       table.setHeading('API Method', 'Docs Link')
       methods.forEach(method => {
         const { operationId } = method
-        table.addRow(operationId, `https://open-api.netlify.com/#/default/${operationId}`)
+        table.addRow(operationId, `https://open-api.netlify.com/#/operation/${operationId}`)
       })
       this.log(table.toString())
       this.log()


### PR DESCRIPTION
**- Summary**

The API documentation URLs are about to change due to https://github.com/netlify/open-api/pull/182.

Note: this PR should be merged at the same time as https://github.com/netlify/open-api/pull/182, otherwise links will be broken.

**- Description for the changelog**

Update API documentation URLs.