### PR TITLE
Add support for `pnpm` + Fix issue with `gridsome`detector

### DIFF
--- a/src/detectors/gridsome.js
+++ b/src/detectors/gridsome.js
@@ -20,6 +20,6 @@ module.exports = function() {
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
-    dist: 'static'
+    dist: 'dist'
   }
 }

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -19,10 +19,11 @@ function getPkgJSON() {
   return pkgJSON
 }
 
-function getPackageManagerCommand() {
-  return existsSync('yarn.lock') ? 'yarn'
-    : existsSync('pnpm-lock.yaml') ? 'pnpm'
-    : 'npm'
+function getYarnOrNPMCommand() {
+  if (!yarnExists) {
+    yarnExists = existsSync('yarn.lock') ? 'yes' : 'no'
+  }
+  return yarnExists === 'yes' ? 'yarn' : 'npm'
 }
 
 /**
@@ -93,6 +94,6 @@ function scanScripts({ preferredScriptsArr, preferredCommand }) {
 module.exports = {
   hasRequiredDeps,
   hasRequiredFiles,
-  getYarnOrNPMCommand: getPackageManagerCommand,
+  getYarnOrNPMCommand,
   scanScripts
 }

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -18,7 +18,6 @@ function getPkgJSON() {
   pkgJSON = JSON.parse(readFileSync('package.json', { encoding: 'utf8' }))
   return pkgJSON
 }
-
 function getYarnOrNPMCommand() {
   if (!yarnExists) {
     yarnExists = existsSync('yarn.lock') ? 'yes' : 'no'

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -18,11 +18,11 @@ function getPkgJSON() {
   pkgJSON = JSON.parse(readFileSync('package.json', { encoding: 'utf8' }))
   return pkgJSON
 }
-function getYarnOrNPMCommand() {
-  if (!yarnExists) {
-    yarnExists = existsSync('yarn.lock') ? 'yes' : 'no'
-  }
-  return yarnExists === 'yes' ? 'yarn' : 'npm'
+
+function getPackageManagerCommand() {
+  return existsSync('yarn.lock') ? 'yarn'
+    : existsSync('pnpm-lock.yaml') ? 'pnpm'
+    : 'npm'
 }
 
 /**
@@ -93,6 +93,6 @@ function scanScripts({ preferredScriptsArr, preferredCommand }) {
 module.exports = {
   hasRequiredDeps,
   hasRequiredFiles,
-  getYarnOrNPMCommand,
+  getYarnOrNPMCommand: getPackageManagerCommand,
   scanScripts
 }


### PR DESCRIPTION
**- Summary**

This PR fixes an issue with `gridsome`'s detector config and introduces support for `pnpm` as a package manager.

I didn't changed the name of the exported function to avoid touching more files than needed. This should be changed at some point, probably. Let me know if you'd want me to change it myself before merging.

**- Test plan**

Some tests were breaking and they still break at the same spot. Changes are minimal so everything should still work the same.

**- Description for the changelog**

- fixes an issue with `gridsome`'s detector config: [link](https://gridsome.org/docs/how-it-works/#gridsome-build)
- introduces support for `pnpm` as a package manager: [link](https://pnpm.js.org/en/cli/install)

**- A picture of a cute animal (not mandatory but encouraged)**

![cute human tripping on the supermarket](https://media.giphy.com/media/12WjSnRGVC79EA/200w_d.gif)