### PR TITLE
Fix supported Node.js version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8.12.0
     working_directory: ~/cli
     steps:
       - checkout
@@ -18,7 +18,7 @@ jobs:
       - run: npm test
   deploy:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8.12.0
     working_directory: ~/cli
     steps:
       - checkout
@@ -35,7 +35,7 @@ workflows:
   test-n-deploy:
     jobs:
       - test:
-          filters:  # required since `deploy` has tag filters AND requires `build`
+          filters: # required since `deploy` has tag filters AND requires `build`
             tags:
               only: /.*/
       - deploy:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Bret Comnes <bcomnes@gmail.com> (https://bret.io)"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.12.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
**- Summary**

Our `package.json` is showing our supported Node.js version as `8.0.0`. However:
  - we are using object spreads, which are `>=8.3.0`
  - many of our dependencies are not supporting some minor versions of `8.*.*`. For example `execa` is `>=8.12.0` because of the use of `util.getSystemErrorName()`.

I checked dependencies and it seems like the Node.js version we actually support is `>=8.12.0`. We should advertise that one instead.

**- Description for the changelog**

Fix supported Node.js version