### PR TITLE
Fix tests when run in a path containing spaces

### DIFF
--- a/src/tests/utils/cliPath.js
+++ b/src/tests/utils/cliPath.js
@@ -1,5 +1,6 @@
 const path = require('path')
 
-const cliPath = path.join(__dirname, '..', '..', '..', 'bin/run')
+// Quoted so that commands work in paths with spaces
+const cliPath = '"' + path.join(__dirname, '..', '..', '..', 'bin/run') + '"'
 
 module.exports = cliPath


### PR DESCRIPTION
**- Summary**

Small testing fix I noticed while working on changes for #566. I've hit similar issues with my own CLI tools often, so I've moved all my code checkouts into a folder with a space in the name, it's great for catching these bugs :smiley:

**- Test plan**

* Check out the codebase in a path containing spaces
* `npm install`
* `npm test`
* `addons.test.js` fails because broken paths mean that it can't run the CLI

**- Description for the changelog**

Stop tests from failing when run from a path containing spaces.

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute otter](https://media.giphy.com/media/1xlGfZ07Dq62jqKT9t/giphy.gif)
