### PR TITLE
Use semver with Netlify Build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -439,9 +439,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.0.30.tgz",
-      "integrity": "sha512-s6WH8C+KOC7CSXV4eE1AWz2wSvscc1iHgrcEDua/459NH48Ba+/Y7kakw1I6NrNHO/VMGfvJaU1wxtu/u38CNw==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.0.34.tgz",
+      "integrity": "sha512-1GIJCFtoQEP5cIXtNGAR6Or8kj5Pko+QdtuaHnGt3sw3TJltfVTDpXiKVvKqL1LFu0sRXAJoRh+7ZOXQjl2vdQ==",
       "requires": {
         "@netlify/config": "^0.0.5",
         "@netlify/zip-it-and-ship-it": "0.4.0-5",
@@ -477,7 +477,7 @@
         "replacestream": "^4.0.3",
         "resolve": "^1.12.0",
         "shell-source": "^1.1.0",
-        "stack-utils": "^1.0.2",
+        "strip-ansi": "^5.2.0",
         "yargs": "^14.2.0"
       },
       "dependencies": {
@@ -12620,7 +12620,8 @@
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
-    "@netlify/build": "0.0.30",
+    "@netlify/build": "^0.0.34",
     "@netlify/cli-utils": "^1.0.7",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",


### PR DESCRIPTION
This enables semver with the Netlify Build dependency. This means `netlify/cli` will automatically pick up new non-breaking versions of `netlify/build`. 

Since `netlify/build` is still in `0.*.*`, this means picking any version that starts with `0.*.*` but not `1.0.0`.

This also upgrades `netlify/build` to the latest version with the following changes:
  - add support for Node 13
  - add support for Windows
  - improve error stack traces