### PR TITLE
Fix semver issue with `@netlify/build`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -439,9 +439,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.0.34.tgz",
-      "integrity": "sha512-1GIJCFtoQEP5cIXtNGAR6Or8kj5Pko+QdtuaHnGt3sw3TJltfVTDpXiKVvKqL1LFu0sRXAJoRh+7ZOXQjl2vdQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.0.tgz",
+      "integrity": "sha512-8DC5nhYnI0mNZuq8Ex3I3hbKfNAd2kT3qeKSWrlL9KiPuqnv1Dsc9wKPfqDi7WqMmxLWoIikJA0CHLcvz/E9oQ==",
       "requires": {
         "@netlify/config": "^0.0.5",
         "@netlify/zip-it-and-ship-it": "0.4.0-5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
-    "@netlify/build": "^0.0.34",
+    "@netlify/build": "^0.1.0",
     "@netlify/cli-utils": "^1.0.7",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",


### PR DESCRIPTION
**- Summary**

We use use the `^` semver range on `@netlify/build`. However currently `@netlify/build` version starts with `0.0.*`. In such cases, every version increment is [considered a breaking change](https://github.com/npm/node-semver#caret-ranges-123-025-004) according to semver, which makes `^` not pick any new versions.

I have released `@netlify/build` `0.1.0` which since it starts with `0.*.*` instead of `0.0.*` should fix this issue.

**- Description for the changelog**

Upgrade `@netlify/build`