### PR TITLE
Improves `netlify build` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -439,9 +439,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.0.tgz",
-      "integrity": "sha512-8DC5nhYnI0mNZuq8Ex3I3hbKfNAd2kT3qeKSWrlL9KiPuqnv1Dsc9wKPfqDi7WqMmxLWoIikJA0CHLcvz/E9oQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.1.tgz",
+      "integrity": "sha512-7DTo5weyQfRLj85iPT9NMjo10xoO0xoYijS4PdtrFz1u3L2ncEQNI5RHcZiEbIJXnar2qh9kbvWkXl8SV4dBZA==",
       "requires": {
         "@netlify/config": "^0.0.5",
         "@netlify/zip-it-and-ship-it": "0.4.0-5",
@@ -481,6 +481,19 @@
         "yargs": "^14.2.0"
       },
       "dependencies": {
+        "@netlify/config": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.0.5.tgz",
+          "integrity": "sha512-ZfKLq09RlzpVnI3ru2VSXGJTjgljRPLwSyfKyozbS0vCrL6HhvTe8cj5xUxc6XFYxfxOJbjchNDHI3szsB1Tvw==",
+          "requires": {
+            "configorama": "^0.3.6",
+            "find-up": "^4.1.0",
+            "map-obj": "^4.1.0",
+            "minimist": "^1.2.0",
+            "path-exists": "^4.0.0",
+            "resolve": "^1.12.0"
+          }
+        },
         "@netlify/zip-it-and-ship-it": {
           "version": "0.4.0-5",
           "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-5.tgz",
@@ -684,86 +697,16 @@
         }
       }
     },
-    "@netlify/cli-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/cli-utils/-/cli-utils-1.1.0.tgz",
-      "integrity": "sha512-wd4bZEZIpGi7bjflA+mn4AJhDqYJKmykAi3ntRe7SIQkXH9Hp+ObI4g2kuy6SB/6posu1Cnr7jqb1BnVIAgmCQ==",
-      "requires": {
-        "@iarna/toml": "^2.2.1",
-        "@oclif/command": "^1.5.8",
-        "@oclif/parser": "^3.8.3",
-        "chalk": "^2.4.1",
-        "ci-info": "^2.0.0",
-        "cli-ux": "^5.0.0",
-        "configstore": "^4.0.0",
-        "dot-prop": "^4.2.0",
-        "find-up": "^3.0.0",
-        "is-docker": "^1.1.0",
-        "lodash.merge": "^4.6.1",
-        "lodash.snakecase": "^4.1.1",
-        "make-dir": "^1.3.0",
-        "minimist": "^1.2.0",
-        "netlify": "^2.2.1",
-        "node-fetch": "^2.3.0",
-        "uuid": "^3.3.2",
-        "write-file-atomic": "^2.3.0"
-      },
-      "dependencies": {
-        "configstore": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
-          "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        }
-      }
-    },
     "@netlify/config": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.0.5.tgz",
-      "integrity": "sha512-ZfKLq09RlzpVnI3ru2VSXGJTjgljRPLwSyfKyozbS0vCrL6HhvTe8cj5xUxc6XFYxfxOJbjchNDHI3szsB1Tvw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.1.0.tgz",
+      "integrity": "sha512-ZdFSOJgL3F7YYLAXIwMyL6n9tm1098RPg2la5+K9h9nzSt5WVwQ3tnR8gd70L9B+UyzFiE8xnG3t87baWlpA4w==",
       "requires": {
         "configorama": "^0.3.6",
         "find-up": "^4.1.0",
         "map-obj": "^4.1.0",
         "minimist": "^1.2.0",
+        "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
         "resolve": "^1.12.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -439,9 +439,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.0.34.tgz",
-      "integrity": "sha512-1GIJCFtoQEP5cIXtNGAR6Or8kj5Pko+QdtuaHnGt3sw3TJltfVTDpXiKVvKqL1LFu0sRXAJoRh+7ZOXQjl2vdQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.0.tgz",
+      "integrity": "sha512-8DC5nhYnI0mNZuq8Ex3I3hbKfNAd2kT3qeKSWrlL9KiPuqnv1Dsc9wKPfqDi7WqMmxLWoIikJA0CHLcvz/E9oQ==",
       "requires": {
         "@netlify/config": "^0.0.5",
         "@netlify/zip-it-and-ship-it": "0.4.0-5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
-    "@netlify/build": "^0.0.34",
+    "@netlify/build": "^0.1.0",
     "@netlify/cli-utils": "^1.0.7",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.3",
-    "@netlify/build": "^0.1.0",
-    "@netlify/cli-utils": "^1.0.7",
+    "@netlify/build": "^0.1.1",
+    "@netlify/config": "^0.1.0",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",


### PR DESCRIPTION
**- Summary**

This improves the `netlify build` command.

This fixes the following:
  - analytics was not run if an error was thrown inside `netlify/build`
  - the exit code was `0` instead of `1` on Netlify Build errors
  - `@netlify/cli-utils` was used instead of `utils/command.js`. However we've deprecated `@netlify/cli-utils` and move the base command to `utils/command.js`.
  - fix semver issue with `@netlify/build` (see #592)

This adds the following:
  - adds the `--context` CLI flag
  - improves the description for the `--dry` CLI flag
  - improves the error message thrown when `--config` is invalid (it's thrown by `@netlify/config`)

This simplifies the following logic:
  - the `configPath` logic has been moved to `@netlify/config`

**- Description for the changelog**

Improve `netlify build` command.

**- A picture of a cute animal (not mandatory but encouraged)**

![(JPEG Image, 2730 × 1532 pixels) - Scaled (59%)](https://user-images.githubusercontent.com/8136211/67768472-e0f62200-fa52-11e9-9f73-68941dac9cfb.jpeg)
