### PR TITLE
Allow no configuration file with `netlify build`

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -25,23 +25,10 @@ class BuildCommand extends Command {
     const { dry = false } = parseRawFlags(raw)
     const [token] = this.getConfigToken()
 
-    const config = await this.getConfig()
+    // Try current directory first, then site root
+    const config = (await getConfigPath()) || (await getConfigPath(undefined, this.netlify.site.root))
 
     return { config, token, dry }
-  }
-
-  // Try current directory first, then site root
-  async getConfig() {
-    try {
-      return await getConfigPath()
-    } catch (error) {
-      try {
-        return await getConfigPath(undefined, this.netlify.site.root)
-      } catch (error) {
-        console.error(error.message)
-        this.exit(1)
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The Netlify configuration file should be optional. At the moment calling `netlify build` without one throw an error. This PR fixes this.

Implementation detail: note that `getConfigPath(undefined)` never throws.

Related: https://github.com/netlify/build/pull/499 and https://github.com/netlify/build/issues/497