### PR TITLE
Allow configuration of auto launch feature

### DIFF
--- a/docs/netlify-dev.md
+++ b/docs/netlify-dev.md
@@ -117,6 +117,7 @@ Netlify Dev is meant to work with zero config for the majority of users, by usin
   targetPort = 3000 # Port of target app server
   publish = "dist" # If you use a _redirect file, provide the path to your static content folder
   jwtRolePath = "app_metadata.authorization.roles" # Object path we should look for role values for JWT based redirects
+  autoLaunch = true # a Boolean value that determines if Netlify Dev launches the local server address in your browser
 ```
 
 ## Project detection

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -431,11 +431,14 @@ class DevCommand extends Command {
         }
       })
 
-      try {
-        await open(url)
-      } catch (err) {
-        console.warn(NETLIFYDEVWARN, 'Error while opening dev server URL in browser', err.message)
+      if (!isEmpty(config.dev) && (!config.dev.hasOwnProperty('autoLaunch') || config.dev.autoLaunch !== false)) {
+        try {
+          await open(url)
+        } catch (err) {
+          console.warn(NETLIFYDEVWARN, 'Error while opening dev server URL in browser', err.message)
+        }
       }
+
       // boxen doesnt support text wrapping yet https://github.com/sindresorhus/boxen/issues/16
       const banner = require('wrap-ansi')(chalk.bold(`${NETLIFYDEVLOG} Server now ready on ${url}`), 70)
       process.env.URL = url


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Some users have a requested a way to disable the feature in Netlify Dev that automatically launches the local dev server in browser. This change implements a way to disable that feature from `netlify.toml`. Fixes https://github.com/netlify/cli/issues/615

**- Test plan**

Add the following to your `netlify.toml`
```
[dev]
  autoLaunch = false
```
Run `netlify dev`

**- Description for the changelog**

Check for `config.dev.autoLaunch` to determine if we should launch the browser automatically or not.

**- A picture of a cute animal (not mandatory but encouraged)**
🐥