### PR TITLE
chore: remove unused deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10214,14 +10214,6 @@
         }
       }
     },
-    "netlify-cli-logo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/netlify-cli-logo/-/netlify-cli-logo-1.0.0.tgz",
-      "integrity": "sha512-+lTytTFc1y6RRN1UCmYcbBn+km0C66q2Qjzbz8/vFfMyyY1LbLVWBThbVgv1KVUxZDeciY9G8oOoiRKcSKyovA==",
-      "requires": {
-        "chalk": "^2.4.2"
-      }
-    },
     "netlify-redirect-parser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@iarna/toml": "^2.2.3",
     "@netlify/build": "^0.1.7",
     "@netlify/config": "^0.1.7",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
@@ -117,7 +116,6 @@
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
     "netlify": "^2.4.8",
-    "netlify-cli-logo": "^1.0.0",
     "netlify-redirect-parser": "^1.0.3",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -5,7 +5,7 @@ const redirector = require('netlify-redirector')
 const chokidar = require('chokidar')
 const cookie = require('cookie')
 const redirectParser = require('netlify-redirect-parser')
-const { NETLIFYDEVWARN } = require('netlify-cli-logo')
+const { NETLIFYDEVWARN } = require('../utils/logo')
 
 function parseFile(parser, name, data) {
   const result = parser(data)


### PR DESCRIPTION
Remove toml parser ref b/c @netlify/config is handing this now.

Remove `netlify-cli-logo` package. It's inlined here