### PR TITLE
Add .md to broken function subcommand links

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -18,9 +18,9 @@ netlify functions
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`functions:build`](/commands/functions#functionsbuild) | Build functions locally  |
-| [`functions:create`](/commands/functions#functionscreate) | Create a new function locally  |
-| [`functions:invoke`](/commands/functions#functionsinvoke) | Trigger a function while in netlify dev with simulated data, good for testing function calls including Netlify's Event Triggered Functions  |
+| [`functions:build`](/commands/functions.md#functionsbuild) | Build functions locally  |
+| [`functions:create`](/commands/functions.md#functionscreate) | Create a new function locally  |
+| [`functions:invoke`](/commands/functions.md#functionsinvoke) | Trigger a function while in netlify dev with simulated data, good for testing function calls including Netlify's Event Triggered Functions  |
 
 
 **Examples**

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,9 +70,9 @@ Manage netlify functions
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`functions:build`](/commands/functions#functionsbuild) | Build functions locally  |
-| [`functions:create`](/commands/functions#functionscreate) | Create a new function locally  |
-| [`functions:invoke`](/commands/functions#functionsinvoke) | Trigger a function while in netlify dev with simulated data, good for testing function calls including Netlify's Event Triggered Functions  |
+| [`functions:build`](/commands/functions.md#functionsbuild) | Build functions locally  |
+| [`functions:create`](/commands/functions.md#functionscreate) | Create a new function locally  |
+| [`functions:invoke`](/commands/functions.md#functionsinvoke) | Trigger a function while in netlify dev with simulated data, good for testing function calls including Netlify's Event Triggered Functions  |
 
 
 ### [init](/commands/init)


### PR DESCRIPTION
**- Summary**
I noticed some broken links when reading the function documentation and felt like it was my duty to fix them

**- Test plan**
**Case 1**
1. Navigate to https://github.com/netlify/cli/blob/master/docs/index.md
1. Click on any of the function subcommands

_**Expected Results**_
Taken to the appropriate page

_**Actual Results**_
404

**Case 2**
1. Navigate to https://github.com/netlify/cli/blob/master/docs/commands/functions.md
1. Click on any of the function subcommands

_**Expected Results**_
Taken to the appropriate page

_**Actual Results**_
404

**- Description for the changelog**

Fixes broken links to function subcommands that were missing the `.md` part of the URL

_Approved by Riley 😝_
<img src="https://user-images.githubusercontent.com/1108825/70668779-5dbb1500-1c29-11ea-94f7-4aeb02aa6524.jpg" width="300">

