### PR TITLE
Output site_name when deployed with --json arg

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -215,6 +215,7 @@ class DeployCommand extends Command {
       const jsonData = {
         name: results.deploy.deployId,
         site_id: results.deploy.site_id,
+        site_name: results.deploy.name,
         deploy_id: results.deployId,
         deploy_url: deployUrl,
         logs: logsUrl


### PR DESCRIPTION
**- Summary**

"netlify deploy --json" was only showing "site_id" and "deploy_id" ...etc but was not enough information for us, so I add a new field "site_name" into that output.

**- Test plan**

Run `netlify deploy --json` and check an output that should have a fileld like `{ ... "site_name": [SITE_NAME] }`

**- Description for the changelog**

- `deploy --json` output has a new field "site_name".

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://pbs.twimg.com/media/DNjl9uzVwAEBRVO?format=jpg&name=large" />