### PR TITLE
[dev] child process now close properly.

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -314,9 +314,9 @@ function startDevServer(settings, log) {
   })
   if (ps.stdout) ps.stdout.on('data', buff => process.stdout.write(buff.toString('utf8')))
   if (ps.stderr) ps.stderr.on('data', buff => process.stderr.write(buff.toString('utf8')))
-  ps.on('close', code => process.exit(code))
-  ps.on('SIGINT', process.exit)
-  ps.on('SIGTERM', process.exit)
+  process.on('close', ps.exit)
+  process.on('SIGINT', ps.exit)
+  process.on('SIGTERM', ps.exit)
 
   return ps
 }

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -314,9 +314,12 @@ function startDevServer(settings, log) {
   })
   if (ps.stdout) ps.stdout.on('data', buff => process.stdout.write(buff.toString('utf8')))
   if (ps.stderr) ps.stderr.on('data', buff => process.stderr.write(buff.toString('utf8')))
-  process.on('close', ps.exit)
-  process.on('SIGINT', ps.exit)
-  process.on('SIGTERM', ps.exit)
+  
+  ps.on('close', code => process.exit(code))
+  ps.on('exit', code => process.exit(code))
+  process.on('SIGINT', signal => ps.kill(signal))
+  process.on('SIGTERM', signal => ps.kill(signal))
+  process.on('SIGKILL', signal => ps.kill(signal))
 
   return ps
 }

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -315,12 +315,11 @@ function startDevServer(settings, log) {
   if (ps.stdout) ps.stdout.on('data', buff => process.stdout.write(buff.toString('utf8')))
   if (ps.stderr) ps.stderr.on('data', buff => process.stderr.write(buff.toString('utf8')))
   
-  ps.on('close', code => process.exit(code))
-  ps.on('exit', code => process.exit(code))
-  process.on('SIGINT', signal => ps.kill(signal))
-  process.on('SIGTERM', signal => ps.kill(signal))
-  process.on('SIGKILL', signal => ps.kill(signal))
+  ps.on('close', code => process.exit(code || 0))
+  ps.on('exit', code => process.exit(code || 0))
 
+  process.on('SIGINT', ps.kill)
+  process.on('SIGTERM', ps.kill)
   return ps
 }
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -316,7 +316,6 @@ function startDevServer(settings, log) {
   if (ps.stderr) ps.stderr.on('data', buff => process.stderr.write(buff.toString('utf8')))
   
   ps.on('close', code => process.exit(code || 0))
-  ps.on('exit', code => process.exit(code || 0))
 
   process.on('SIGINT', ps.kill)
   process.on('SIGTERM', ps.kill)


### PR DESCRIPTION
closes #653 

**- Summary**

Basically when I'd run `parcel src/index.html` via `netlify dev -c`, pressing `CTRL + C` (SIGTERM) would not shut down the process.

**- Test plan**

Run netlify dev and cancel it over and over again, even if it doesn't start completely. If it doesnt break, it works.

**- Description for the changelog**
Child processes now exit when SIGTERM command (`CTRL + C`) is issued.


**- A picture of a cute animal (not mandatory but encouraged)**

Have some hot diggity dogs.

<img src="https://3.bp.blogspot.com/-_f0j7Mp-WM8/WNSSbRTKL2I/AAAAAAAAMBg/E66R3hrzy-oJr_R_Y3NuZI5jK-2ExXtUwCEw/s1600/Group-of-Golden-Retrievers-showing-different-shades-resized.jpg"/>
