### PR TITLE
Revamp redirects parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10597,11 +10597,11 @@
       }
     },
     "netlify-redirect-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-1.0.3.tgz",
-      "integrity": "sha512-NDQKgrN5DgWIYvEyVRG8OgiM1KV140D+4f8rJkqbTCKj32uXokMuJ38woTyGnqBb565ygiFuU6uA0czHbvGxaw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netlify-redirect-parser/-/netlify-redirect-parser-2.0.2.tgz",
+      "integrity": "sha512-R9Fmb1a0zUGBGync1UBZgHsXOEET5Ny7zAOowG9ns5buQQuCEvSGM3Layw7SKByskbgraZXhBNL/TstL/XidCQ==",
       "requires": {
-        "@iarna/toml": "^2.2.3"
+        "@netlify/config": "^0.1.12"
       }
     },
     "netlify-redirector": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
     "netlify": "^2.4.8",
-    "netlify-redirect-parser": "^1.0.3",
+    "netlify-redirect-parser": "^2.0.2",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",
     "npm-packlist": "^1.4.4",

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -124,7 +124,7 @@ function initializeProxy(port) {
   return handlers
 }
 
-async function startProxy(settings, addonUrls) {
+async function startProxy(settings, addonUrls, configPath) {
   try {
     await waitPort({ port: settings.proxyPort })
   } catch(err) {
@@ -143,7 +143,8 @@ async function startProxy(settings, addonUrls) {
 
   const rewriter = createRewriter({
     publicFolder: settings.dist,
-    jwtRole: settings.jwtRolePath
+    jwtRole: settings.jwtRolePath,
+    configPath,
   })
 
   const server = http.createServer(function(req, res) {
@@ -415,7 +416,7 @@ class DevCommand extends Command {
         settings.functionsPort = functionsPort
       }
 
-      let { url, port } = await startProxy(settings, addonUrls)
+      let { url, port } = await startProxy(settings, addonUrls, site.configPath)
       if (!url) {
         throw new Error('Unable to start proxy server')
       }

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -7,8 +7,8 @@ const cookie = require('cookie')
 const redirectParser = require('netlify-redirect-parser')
 const { NETLIFYDEVWARN } = require('../utils/logo')
 
-async function parseFile(parser, name, dataOrFilePath) {
-  const result = await parser(dataOrFilePath)
+async function parseFile(parser, name, filePath) {
+  const result = await parser(filePath)
   if (result.errors.length) {
     console.error(`${NETLIFYDEVWARN} Warnings while parsing ${name} file:`)
     result.errors.forEach(err => {
@@ -26,7 +26,7 @@ async function parseRules(configFiles) {
 
     const fileName = file.split(path.sep).pop()
     if (fileName.endsWith('_redirects')) {
-      rules.push(...(await parseFile(redirectParser.parseRedirectsFormat, fileName, fs.readFileSync(file, 'utf-8'))))
+      rules.push(...(await parseFile(redirectParser.parseRedirectsFormat, fileName, file)))
     } else {
       rules.push(...(await parseFile(redirectParser.parseNetlifyConfig, fileName, file)))
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Standardizes parsing of redirect rules by offloading it to the new API's of `netlify-redirect-parser`. Depends on https://github.com/netlify/netlify-redirect-parser/pull/8

**- Test plan**

* Run `netlify dev` in any existing project with redirect rules defined

**- Description for the changelog**

* Pass down `configPath` to the redirect parsing logic
* Don't try to read all config files manually
* Only watch `_redirects` and adopted Netlify config file for redirect rules
* Use `netlify-redirect-parser`'s new `parseNetlifyConfig` function to parse different kinds of config files (`netlify.toml`, `netlify.yml` and `netlify.json`)

**- A picture of a cute animal (not mandatory but encouraged)**
# 🐼