### PR TITLE
change to run netlify dev on the port that quasar normally uses

### DIFF
--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -15,15 +15,15 @@ module.exports = function() {
   })
 
   if (possibleArgsArrs.length === 0) {
-    // ofer to run this default when the user doesnt have any matching scripts setup!
-    possibleArgsArrs.push(['quasar', 'dev'])
+    // offer to run this default when the user doesnt have any matching scripts setup!
+    possibleArgsArrs.push(['quasar', 'dev', '-p 8081'])
   }
 
   return {
     type: 'quasar-cli',
     command: getYarnOrNPMCommand(),
-    port: 8888,
-    proxyPort: 8080,
+    port: 8080,
+    proxyPort: 8081,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -22,7 +22,7 @@ module.exports = function() {
   return {
     type: 'quasar-cli',
     command: getYarnOrNPMCommand(),
-    port: 8080,
+    port: 8888,
     proxyPort: 8081,
     env: { ...process.env },
     possibleArgsArrs,


### PR DESCRIPTION
This help prevent the need to remember to load a different url when using netlify dev instead of quasar dev.