### PR TITLE
Remove duplicate port allocation - fixes #658

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -408,7 +408,7 @@ class DevCommand extends Command {
           functionWatcher.on('change', functionBuilder.build)
           functionWatcher.on('unlink', functionBuilder.build)
         }
-        const functionsPort = await getPort({ port: settings.functionsPort || 34567 })
+        const functionsPort = settings.functionsPort || 34567
 
         // returns a value but we dont use it
         await serveFunctions({

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -408,7 +408,7 @@ class DevCommand extends Command {
           functionWatcher.on('change', functionBuilder.build)
           functionWatcher.on('unlink', functionBuilder.build)
         }
-        const functionsPort = settings.functionsPort || 34567
+        const functionsPort = settings.functionsPort
 
         // returns a value but we dont use it
         await serveFunctions({


### PR DESCRIPTION
**- Summary**

Based on #658
When running `netlify dev` neither default functionsPort nor port passed in configuration is used.

**- Test plan**

Add to netlify.toml
```
[dev]
  functionsPort = 30303
```
and verify the port is used

**- Description for the changelog**

Remove duplicate call to getPort for the same port (default: 34567)
