### PR TITLE
Add detector for Expo

### DIFF
--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -8,16 +8,17 @@ module.exports = function() {
   /** everything below now assumes that we are within expo */
 
   const possibleArgsArrs = scanScripts({
-    // prefer the `start:web` script instead of expo's default `web` since that runs
-    // `expo start --web`, which auto launches the (non-proxied) web browser.
-    preferredScriptsArr: ['start:web'],
-    // `expo start:web` does not auto launch the web browser
-    preferredCommand: 'expo start:web'
+    // This script will run `expo start --web` in a new Expo project.
+    // Note: Expo will automatically launch the browser with your app's
+    // Webpack server listening on port 19006, but the instance proxied
+    // by `netlify dev` will be running on port 8888.
+    preferredScriptsArr: ['web'],
+    preferredCommand: 'expo start --web'
   })
 
   if (possibleArgsArrs.length === 0) {
     // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['expo', 'start:web'])
+    possibleArgsArrs.push(['expo', 'start', '--web'])
   }
   return {
     type: 'expo',

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -1,0 +1,32 @@
+const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(['package.json', 'app.json'])) return false
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(['expo'])) return false
+
+  /** everything below now assumes that we are within expo */
+
+  const possibleArgsArrs = scanScripts({
+    // prefer the `start:web` script instead of expo's default `web` since that runs
+    // `expo start --web`, which auto launches the (non-proxied) web browser.
+    preferredScriptsArr: ['start:web'],
+    // `expo start:web` does not auto launch the web browser
+    preferredCommand: 'expo start:web'
+  })
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(['expo', 'start:web'])
+  }
+  return {
+    type: 'expo',
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 19006,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${19006}(/)?`, 'g'),
+    dist: 'web-build'
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
This PR adds a detector for `netlify-cli` to work automagically with Expo projects.

Prior to this, every project needed to be configured using `netlify.toml` before `netlify dev` could be used.

This also fixes #333 since `netlify publish` now uses the detector config to find the publish directory.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
I created a new blank Expo project, ran the `dev` command on that folder and it started up successfully. Then I ran the `publish` command and it didn't ask for the build directory.

*Note*: I also needed to use #669 or the port allocation of the functions server becomes random and `netlify dev` can't connect.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Add detector for Expo
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![7241gucrk6941](https://user-images.githubusercontent.com/318800/71884462-b69ea000-3138-11ea-8e73-9c87f28b9e42.png)
