### PR TITLE
Revert default autoLaunch behavior to true

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -438,7 +438,11 @@ class DevCommand extends Command {
         }
       })
 
-      if (!isEmpty(config.dev) && (!config.dev.hasOwnProperty('autoLaunch') || config.dev.autoLaunch !== false)) {
+      if (
+        isEmpty(config.dev) ||
+        !config.dev.hasOwnProperty('autoLaunch') ||
+        (config.dev.hasOwnProperty('autoLaunch') && config.dev.autoLaunch !== false)
+      ) {
         try {
           await open(url)
         } catch (err) {


### PR DESCRIPTION
**- Summary**
This PR reverts the default `autoLaunch` to `true`, the way it works in the current release of `netlify-cli`. Motivation is explained in https://github.com/netlify/cli/pull/631#issuecomment-571555799.

**- Test plan**
The change is really basic so not much testing is needed, but I tested it with a new basic project with and without a `netlify.toml`.

**- Description for the changelog**
Probably shouldn't be included in the changelog since it reverts a change present in master but not yet released.

**- A picture of a cute animal (not mandatory but encouraged)**
![ezgif com-webp-to-png (1)](https://user-images.githubusercontent.com/318800/71895005-29674580-3150-11ea-8b53-018645e75dd8.png)
