### PR TITLE
Fix functions server port assignment

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -409,15 +409,13 @@ class DevCommand extends Command {
           functionWatcher.on('change', functionBuilder.build)
           functionWatcher.on('unlink', functionBuilder.build)
         }
-        const functionsPort = settings.functionsPort
+        const functionsPort = await getPort({ port: settings.functionsPort || 34567 })
+        settings.functionsPort = functionsPort
 
-        // returns a value but we dont use it
         await serveFunctions({
           ...settings,
-          port: functionsPort,
           functionsDir
         })
-        settings.functionsPort = functionsPort
       }
 
       let { url, port } = await startProxy(settings, addonUrls, site.configPath)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This PR assigns a port for the functions server in the `dev` command, sets it in the config and then uses it when starting the functions server. Previously, duplicate logic could result in the functions server starting on a specific port and then the CLI waiting for it on another port. This would prevent startup of the whole dev environment (_endless dots_).

The port is elected as follow:
- `functionsPort` option in `netlify.toml` if provided
- `34567` otherwise

If the elected port is currently in use, a random port is assigned.

This fixes the following issues: #659 #634 

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

The test must be run in a context where the functions server is started. This requires a `.functions` directory with appropriate contents.

The code was tested with the following configuration:
- no port specified in `netlify.toml`
- no port specified in `netlify.toml` but port `34567` is busy
- port `11111` specified in `netlify.toml`
- port `11111` specified in `netlify.toml` but port `11111` is busy

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix function servers port assignment issue preventing `netlify dev` startup

**- A picture of a cute animal (not mandatory but encouraged)**
![Puppy](https://user-images.githubusercontent.com/520053/71941441-ffe30400-31b9-11ea-868e-b08681cbdb1b.gif)
