### PR TITLE
Update path to detectors folder

### DIFF
--- a/docs/netlify-dev.md
+++ b/docs/netlify-dev.md
@@ -124,7 +124,7 @@ Netlify Dev is meant to work with zero config for the majority of users, by usin
 
 Netlify Dev will attempt to detect the SSG or build command that you are using, and run these on your behalf, while adding other development utilities. If you have a JavaScript project, it looks for the best `package.json` script to run for you, using simple heuristics, so you can use the full flexibility of npm scripts. We may add more intelligence to this in future.
 
-**Overriding the detectors**: The number of [project types which Netlify Dev can detect](https://github.com/netlify/netlify-dev-plugin/tree/master/src/detectors) is growing, but if yours is not yet supported (contributions welcome!), you can instruct Netlify Dev to run the project on your behalf by declaring it in a `[dev]` block of your `netlify.toml` file.
+**Overriding the detectors**: The number of [project types which Netlify Dev can detect](https://github.com/netlify/cli/tree/master/src/detectors) is growing, but if yours is not yet supported (contributions welcome!), you can instruct Netlify Dev to run the project on your behalf by declaring it in a `[dev]` block of your `netlify.toml` file.
 
 ```toml
 # sample dev block in the toml


### PR DESCRIPTION
**- Summary**

I was reading the documentation for `netlify dev` and noticed that the detectors link goes to the archived netlify-dev-plugin.

**- Test plan**

Does not apply.

**- Description for the changelog**

Documentation now links to current folder of detectors.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="621" alt="image" src="https://user-images.githubusercontent.com/32344/72222544-cdd8f580-355d-11ea-898c-c41abdb57da5.png">

