### PR TITLE
Add ember detector

### DIFF
--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -1,0 +1,32 @@
+const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(['package.json'])) return false
+  if (!hasRequiredFiles(['ember-cli-build.js'])) return false
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(['ember-cli'])) return false
+
+  /** everything below now assumes that we are within vue */
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ['serve', 'start', 'run'],
+    preferredCommand: 'ember serve'
+  })
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(['ember', 'serve'])
+  }
+
+  return {
+    type: 'ember-cli',
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 4200,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${4200}(/)?`, 'g'),
+    dist: 'dist'
+  }
+}

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -7,7 +7,7 @@ module.exports = function() {
   // REQUIRED DEPS
   if (!hasRequiredDeps(['ember-cli'])) return false
 
-  /** everything below now assumes that we are within vue */
+  /** everything below now assumes that we are within ember */
 
   const possibleArgsArrs = scanScripts({
     preferredScriptsArr: ['serve', 'start', 'run'],


### PR DESCRIPTION
**- Summary**

This detects that a project is using ember-cli and runs the appropriate command.

**- Test plan**

Running `netlify dev` inside an ember-cli project correctly identifies and starts the project.

**- Description for the changelog**

`netlify dev` now detects ember-cli projects.