### PR TITLE
addition of two new flags --userId and email to identify the account …

### DIFF
--- a/src/commands/switch.js
+++ b/src/commands/switch.js
@@ -1,15 +1,20 @@
 const Command = require('../utils/command')
+const { flags } = require('@oclif/command')
 const chalk = require('chalk')
 const inquirer = require('inquirer')
 const LoginCommand = require('./login')
 
 class SwitchCommand extends Command {
   async run() {
+
+    let selectedAccount;
+    const { flags } = this.parse(SwitchCommand)
+
     const LOGIN_NEW = 'I would like to login to a new account'
     const availableUsersChoices = Object.values(this.netlify.globalConfig.get('users')).reduce(
-      (prev, current) =>
-        Object.assign(prev, { [current.id]: current.name ? `${current.name} (${current.email})` : current.email }),
-      {}
+        (prev, current) =>
+            Object.assign(prev, { [current.id]: current.name ? `${current.name} (${current.email})` : current.email }),
+        {}
     )
 
     await this.config.runHook('analytics', {
@@ -18,6 +23,21 @@ class SwitchCommand extends Command {
         command: 'switch'
       }
     })
+
+    if(Object.keys(flags).length) {
+
+      selectedAccount = Object.entries(availableUsersChoices).find(([k, v]) => Object.keys(flags)[0] === 'userId' ?
+          k === flags[Object.keys(flags)[0]] : v.includes(flags[Object.keys(flags)[0]]))
+
+      if(selectedAccount) {
+        this.netlify.globalConfig.set('userId', selectedAccount[0])
+        this.log('')
+        this.log(`You're now using account: ${chalk.bold(selectedAccount[1])}.`)
+      } else {
+        this.log(`Your account could not be determinded. ${chalk.bold(Object.keys(flags)[0])} was not found.`)
+      }
+      return this.exit()
+    }
 
     const { accountSwitchChoice } = await inquirer.prompt([
       {
@@ -31,7 +51,7 @@ class SwitchCommand extends Command {
     if (accountSwitchChoice === LOGIN_NEW) {
       await LoginCommand.run(['--new'])
     } else {
-      const selectedAccount = Object.entries(availableUsersChoices).find(([k, v]) => v === accountSwitchChoice)
+      selectedAccount = Object.entries(availableUsersChoices).find(([k, v]) => v === accountSwitchChoice)
       this.netlify.globalConfig.set('userId', selectedAccount[0])
       this.log('')
       this.log(`You're now using ${chalk.bold(selectedAccount[1])}.`)
@@ -42,5 +62,14 @@ class SwitchCommand extends Command {
 }
 
 SwitchCommand.description = `Switch your active Netlify account`
+
+SwitchCommand.flags = {
+  userId: flags.string({
+    description: 'Provide userId of the account you are switching to'
+  }),
+  email: flags.string({
+    description: 'Provide email of the account you are switching to'
+  })
+}
 
 module.exports = SwitchCommand


### PR DESCRIPTION
**- Summary**

The addition of these two flags will allow the user to switch between netlify accounts based on either an email address or userId. The reason for these flags to exists is to allow users who do not or cannot interact with terminal directly to be able to switch users programatically. 

UserId flag is direct comparison with userId contained in the availableUsersChoices object. 
However the email address is not a direct comparison, but rather an "includes" check as the email property in availableUsersChoices is not always just email address but can contain additional data (e.g. name).

**- Test plan**
Functionality tested manually on my netlify accounts, including testing of existing "switch" functionality.

**- Description for the changelog**

Two new available flags on switch command - switch by userId or email. 