### PR TITLE
Upgrade js-client to `3.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10598,26 +10598,25 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-2.4.8.tgz",
-      "integrity": "sha512-htYbhZ0+pd6nazyoc874N9i3MiVyxe2Pm2ooZShkaRmf/e9NmgS5cOs+a4hvHGbye7tCnF78RV1i4JYAs0t3mw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-3.0.0.tgz",
+      "integrity": "sha512-/D0Y8qSUggcpgW3XHkHIE0Pjd89Dl1PoxfptoqBnWpSSVKCsnfhhxmYkmIpBHILSzVT3wePJHO3yOnF5PpQSqg==",
       "requires": {
         "@netlify/open-api": "^0.9.0",
         "@netlify/zip-it-and-ship-it": "^0.3.1",
         "backoff": "^2.5.0",
         "clean-deep": "^3.0.2",
-        "debug": "^4.1.1",
         "flush-write-stream": "^2.0.0",
         "folder-walker": "^3.2.0",
         "from2-array": "0.0.4",
         "hasha": "^3.0.0",
-        "is-stream": "^1.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.flatten": "^4.4.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "micro-api-client": "^3.3.0",
         "node-fetch": "^2.2.0",
+        "omit.js": "^1.0.2",
         "p-map": "^2.1.0",
         "p-wait-for": "^2.0.0",
         "parallel-transform": "^1.1.0",
@@ -10626,15 +10625,9 @@
         "rimraf": "^2.6.3",
         "tempy": "^0.2.1",
         "through2-filter": "^3.0.0",
-        "through2-map": "^3.0.0",
-        "util.promisify": "^1.0.0"
+        "through2-map": "^3.0.0"
       },
       "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
         "p-map": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
@@ -10944,7 +10937,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
-    "netlify": "^2.4.8",
+    "netlify": "^3.0.0",
     "netlify-redirect-parser": "^2.2.0",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
**- Summary**

This upgrades the JavaScript to its [latest major release](https://github.com/netlify/js-client/releases/tag/v3.0.0).

**- Test plan**

I have checked the source code and tried to run few CLI commands locally and everything looks ok. 

However during the code review, if you could please make some additional manual tests, this might be a good idea :)

**- Description for the changelog**

Upgrade `js-client` to `3.0.0`