### PR TITLE
Enforce strict validation of build command CLI flags

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -61,8 +61,6 @@ BuildCommand.description = `Beta - Netlify build`
 
 BuildCommand.examples = ['netlify build']
 
-BuildCommand.strict = false
-
 BuildCommand.hidden = true
 
 module.exports = BuildCommand


### PR DESCRIPTION
We currently allow unknown CLI flags to be passed to `netlify build`, instead of validating them. This was due in order to make the template variable `${opt:...}` work. Since templating has been removed from Netlify Build, we can now enforce strict CLI flags validation for this command.