### PR TITLE
Upgrade `@netlify/config`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -459,12 +459,12 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.79",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.79.tgz",
-      "integrity": "sha512-/bZ/OhsWcCHu+nlFjMNiW3vL/LK8qZJEg21TvV/5lb704uVejMoQWW41mSznqFzTQyWzdIPTsu1Fhpjw5SuPFg==",
+      "version": "0.1.83",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.83.tgz",
+      "integrity": "sha512-UShvpOf7u5epYlZcENBFV2VIIzSFhvY2jknWB++Qg5ukAKHllQ4o1O1XTqssi9Vx4Lp+50ODblkDno0ceTCHeg==",
       "requires": {
         "@netlify/cache-utils": "^0.2.2",
-        "@netlify/config": "^0.3.0",
+        "@netlify/config": "^0.4.1",
         "@netlify/functions-utils": "^0.2.0",
         "@netlify/git-utils": "^0.2.0",
         "@netlify/run-utils": "^0.1.0",
@@ -486,6 +486,7 @@
         "indent-string": "^4.0.0",
         "is-ci": "^2.0.0",
         "is-plain-obj": "^2.1.0",
+        "js-yaml": "^3.13.1",
         "log-process-errors": "^5.0.3",
         "map-obj": "^4.1.0",
         "moize": "^5.4.5",
@@ -863,6 +864,15 @@
             "temp-dir": "^1.0.0",
             "unique-string": "^1.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -883,23 +893,26 @@
       }
     },
     "@netlify/config": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.3.0.tgz",
-      "integrity": "sha512-PRIVRT0D9WF1SLxCQc2k59cD9zC+LbLvmG3yEitfaNN9/Pug4/SQQhudlpliA0SpNTuCpd5IYg9vmSqBBRRRiw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.1.tgz",
+      "integrity": "sha512-4/NLVTYoaIlnTaObiMekVv2QSj6qaDlRCLfQLG2lXRsSl9brTUCfKgCuv7ilK3TDOYs3urywMnSF/lwEFEB31A==",
       "requires": {
+        "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",
         "dot-prop": "^5.2.0",
+        "execa": "^3.4.0",
         "filter-obj": "^2.0.1",
         "find-up": "^4.1.0",
         "indent-string": "^4.0.0",
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
-        "make-dir": "^3.0.2",
+        "locate-path": "^5.0.0",
         "map-obj": "^4.1.0",
         "omit.js": "^1.0.2",
         "path-exists": "^4.0.0",
-        "toml": "^3.0.0"
+        "toml": "^3.0.0",
+        "yargs": "^15.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -920,6 +933,23 @@
             "supports-color": "^7.1.0"
           }
         },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -936,6 +966,11 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
         },
         "p-locate": {
           "version": "4.1.0",
@@ -4815,9 +4850,9 @@
       }
     },
     "cpy": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.1.tgz",
-      "integrity": "sha512-XplonbFkGld3KST+wKFutU+Al3srtT9RaeLTJeRY47QzzLDlA5kpK4s+o0DdgRx7W0cdkifOehGnCBCGIFfdeg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.1.0.tgz",
+      "integrity": "sha512-XwlImkjPxMr01qXqC564VD4rfcDQ2eKtYmFlCy0ixsLRJ1cwYVUBh+v47jsQTO1IrmvdjqO813VpDQ0JiTuOdA==",
       "requires": {
         "arrify": "^2.0.1",
         "cp-file": "^7.0.0",
@@ -4825,7 +4860,9 @@
         "has-glob": "^1.0.0",
         "junk": "^3.1.0",
         "nested-error-stacks": "^2.1.0",
-        "p-all": "^2.1.0"
+        "p-all": "^2.1.0",
+        "p-filter": "^2.1.0",
+        "p-map": "^3.0.0"
       },
       "dependencies": {
         "fast-glob": {
@@ -11827,6 +11864,21 @@
         "p-timeout": "^2.0.1"
       }
     },
+    "p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "requires": {
+        "p-map": "^2.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        }
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -15617,9 +15669,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
+      "integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -15631,7 +15683,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^16.1.0"
+        "yargs-parser": "^18.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15681,22 +15733,13 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
-        },
-        "yargs-parser": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },
     "yargs-parser": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
+      "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,12 +459,12 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.77",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.77.tgz",
-      "integrity": "sha512-jnuS9zsS17ishMlsSplfQO0hYJ6q5ho84m++jcZ4LLOYTpD7YWgATKaaBq7GoQ8bS7IRzLUyUEeKWu/gaI3lqQ==",
+      "version": "0.1.79",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.79.tgz",
+      "integrity": "sha512-/bZ/OhsWcCHu+nlFjMNiW3vL/LK8qZJEg21TvV/5lb704uVejMoQWW41mSznqFzTQyWzdIPTsu1Fhpjw5SuPFg==",
       "requires": {
         "@netlify/cache-utils": "^0.2.2",
-        "@netlify/config": "^0.2.0",
+        "@netlify/config": "^0.3.0",
         "@netlify/functions-utils": "^0.2.0",
         "@netlify/git-utils": "^0.2.0",
         "@netlify/run-utils": "^0.1.0",
@@ -883,9 +883,9 @@
       }
     },
     "@netlify/config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.2.0.tgz",
-      "integrity": "sha512-pWY4KH+KY+aVri4xbPPRsUPkKNyvhFeZD2papiumnHv7TtTrPvi/JjDAIDIzSKsH7N94mM5SPpMojdDlNca7MA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.3.0.tgz",
+      "integrity": "sha512-PRIVRT0D9WF1SLxCQc2k59cD9zC+LbLvmG3yEitfaNN9/Pug4/SQQhudlpliA0SpNTuCpd5IYg9vmSqBBRRRiw==",
       "requires": {
         "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,17 +459,17 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.66.tgz",
-      "integrity": "sha512-tEJmqRx9CANGA7e7iGVMyH+KbBm9CBQ1uVzbsxPkpm0XONvdAsby/1VF6ZsqAz3sqNZE9263pJ04gkG8SkFCBQ==",
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.77.tgz",
+      "integrity": "sha512-jnuS9zsS17ishMlsSplfQO0hYJ6q5ho84m++jcZ4LLOYTpD7YWgATKaaBq7GoQ8bS7IRzLUyUEeKWu/gaI3lqQ==",
       "requires": {
         "@netlify/cache-utils": "^0.2.2",
-        "@netlify/config": "^0.1.18",
-        "@netlify/functions-utils": "^0.1.0",
+        "@netlify/config": "^0.2.0",
+        "@netlify/functions-utils": "^0.2.0",
         "@netlify/git-utils": "^0.2.0",
         "@netlify/run-utils": "^0.1.0",
         "@netlify/zip-it-and-ship-it": "^0.4.0-8",
-        "ajv": "^6.10.2",
+        "ajv": "^6.11.0",
         "analytics": "0.3.0",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -477,18 +477,19 @@
         "deepmerge": "^4.2.2",
         "execa": "^3.3.0",
         "fast-glob": "^3.1.0",
-        "figures": "^3.1.0",
+        "figures": "^3.2.0",
         "filter-obj": "^2.0.1",
         "find-up": "^4.1.0",
         "global-cache-dir": "^1.0.1",
+        "got": "^9.6.0",
         "group-by": "^0.0.1",
         "indent-string": "^4.0.0",
         "is-ci": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
+        "is-plain-obj": "^2.1.0",
         "log-process-errors": "^5.0.3",
         "map-obj": "^4.1.0",
         "moize": "^5.4.5",
-        "netlify": "^3.0.0",
+        "netlify": "^3.1.0",
         "omit.js": "^1.0.2",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
@@ -499,14 +500,19 @@
         "readdirp": "^3.1.3",
         "redact-env": "^0.2.0",
         "replacestream": "^4.0.3",
-        "resolve": "^1.14.2",
+        "resolve": "^1.15.1",
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "unixify": "^1.0.0",
-        "uuid": "^3.3.3",
+        "uuid": "^3.4.0",
         "yargs": "^15.1.0"
       },
       "dependencies": {
+        "@netlify/open-api": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.1.tgz",
+          "integrity": "sha512-lq3xrVNv6Jl2yu3PuXYFTuiEVvXBU41e9zCVK8k5vuE/gYJxpeNXXY2OWO0sLy3AbjkpPWiSHjtUYuHMTcru3A=="
+        },
         "@netlify/zip-it-and-ship-it": {
           "version": "0.4.0-8",
           "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-8.tgz",
@@ -575,6 +581,11 @@
             }
           }
         },
+        "@sindresorhus/is": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -582,6 +593,27 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
+          }
+        },
+        "cacheable-request": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^3.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+            }
           }
         },
         "chalk": {
@@ -629,6 +661,123 @@
             }
           }
         },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            }
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+        },
+        "netlify": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/netlify/-/netlify-3.1.0.tgz",
+          "integrity": "sha512-x+wDgjw2Kqthy/gBe5irb8Z8KpKcX8kZPtLJcWDYF7+kjRzYiFrcBXsyw9F92hBXt2WFoejYB1mBBhDFPF08hQ==",
+          "requires": {
+            "@netlify/open-api": "^0.13.0",
+            "@netlify/zip-it-and-ship-it": "^0.3.1",
+            "backoff": "^2.5.0",
+            "clean-deep": "^3.0.2",
+            "flush-write-stream": "^2.0.0",
+            "folder-walker": "^3.2.0",
+            "from2-array": "0.0.4",
+            "hasha": "^3.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "micro-api-client": "^3.3.0",
+            "node-fetch": "^2.2.0",
+            "omit.js": "^1.0.2",
+            "p-map": "^2.1.0",
+            "p-wait-for": "^2.0.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "qs": "^6.7.0",
+            "rimraf": "^2.6.3",
+            "tempy": "^0.2.1",
+            "through2-filter": "^3.0.0",
+            "through2-map": "^3.0.0"
+          },
+          "dependencies": {
+            "@netlify/zip-it-and-ship-it": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.3.1.tgz",
+              "integrity": "sha512-vLKxc1/Kvy7c0TL6AMr39/3SIweMkXZXkfU5nUtw1DSBVXaz9aYtiFLBX8YOblJXFFs3rpcyhzmzctoQsOnqVA==",
+              "requires": {
+                "archiver": "^3.0.0",
+                "cliclopts": "^1.1.1",
+                "debug": "^4.1.1",
+                "elf-tools": "^1.1.1",
+                "glob": "^7.1.3",
+                "minimist": "^1.2.0",
+                "npm-packlist": "^1.1.12",
+                "p-all": "^2.0.0",
+                "precinct": "^6.1.1",
+                "read-pkg-up": "^4.0.0",
+                "require-package-name": "^2.0.1",
+                "resolve": "^1.10.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "p-map": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+              "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            }
+          }
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -653,24 +802,6 @@
             "lines-and-columns": "^1.1.6"
           }
         },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
-            }
-          }
-        },
         "read-pkg-up": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
@@ -679,6 +810,34 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "read-pkg": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+              "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+              "requires": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+              },
+              "dependencies": {
+                "type-fest": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                  "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+                }
+              }
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "strip-ansi": {
@@ -694,6 +853,15 @@
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
             }
+          }
+        },
+        "tempy": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+          "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+          "requires": {
+            "temp-dir": "^1.0.0",
+            "unique-string": "^1.0.0"
           }
         }
       }
@@ -715,12 +883,11 @@
       }
     },
     "@netlify/config": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.1.21.tgz",
-      "integrity": "sha512-7q9OQe56AyQXEeR8Fpm/cCzuG/tGDHcx8suXwFXBhVA7/1t84XDldHBlgzw5O9cIlvdwy26gJi3lU+KpHmihAg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.2.0.tgz",
+      "integrity": "sha512-pWY4KH+KY+aVri4xbPPRsUPkKNyvhFeZD2papiumnHv7TtTrPvi/JjDAIDIzSKsH7N94mM5SPpMojdDlNca7MA==",
       "requires": {
         "chalk": "^3.0.0",
-        "configorama": "^0.3.6",
         "deepmerge": "^4.2.2",
         "dot-prop": "^5.2.0",
         "filter-obj": "^2.0.1",
@@ -732,7 +899,7 @@
         "map-obj": "^4.1.0",
         "omit.js": "^1.0.2",
         "path-exists": "^4.0.0",
-        "resolve": "^1.15.1"
+        "toml": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -777,13 +944,18 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "toml": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+          "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
         }
       }
     },
     "@netlify/functions-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.1.0.tgz",
-      "integrity": "sha512-advkyvZ7uC/4oh5c2Fxg46OPNMAHqG7O+jfjh1/I4V0w9Z45zbeloFMr3UtKqd2VTfP5UA0dulLoRf2W8QuHzw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.0.tgz",
+      "integrity": "sha512-/wzOwrWU1VAqblZ7xf0gueCu0w049lEQjHpYNzIW0dbH7hqnlhw7Bcw7Ljn2TA+Lh5lecqPXoIQo9yvJn/ALJQ==",
       "requires": {
         "cpy": "^8.0.0",
         "path-exists": "^4.0.0"
@@ -1491,6 +1663,14 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
     },
     "@types/chai": {
       "version": "4.2.9",
@@ -4635,14 +4815,14 @@
       }
     },
     "cpy": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.0.tgz",
-      "integrity": "sha512-iTjLUqtVr45e17GFAyxA0lqFinbGMblMCTtAqrPzT/IETNtDuyyhDDk8weEZ08MiCc6EcuyNq2KtGH5J2BIAoQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.1.tgz",
+      "integrity": "sha512-XplonbFkGld3KST+wKFutU+Al3srtT9RaeLTJeRY47QzzLDlA5kpK4s+o0DdgRx7W0cdkifOehGnCBCGIFfdeg==",
       "requires": {
         "arrify": "^2.0.1",
         "cp-file": "^7.0.0",
         "globby": "^9.2.0",
-        "is-glob": "^4.0.1",
+        "has-glob": "^1.0.0",
         "junk": "^3.1.0",
         "nested-error-stacks": "^2.1.0",
         "p-all": "^2.1.0"
@@ -5047,6 +5227,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -7975,6 +8160,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+      "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+      "requires": {
+        "is-glob": "^3.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -10918,6 +11121,72 @@
       "integrity": "sha512-FILkBKm7WWyXtWkS5o9PWSBOQG03wKns0w9MnitiaVOaVSJk++61yIHFzd+j3rArlll2CwdsKTklJ3Wo08xLqA==",
       "requires": {
         "@netlify/config": "^0.1.12"
+      },
+      "dependencies": {
+        "@netlify/config": {
+          "version": "0.1.23",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.1.23.tgz",
+          "integrity": "sha512-gq6FYlxYMpgur79VoHEXj/07b7fAmMmw6A2svVM8nc1H1YF3VSau1PXFus2G1nHuk3g4pdcenfvT/KxaZWR6Rg==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "configorama": "^0.3.6",
+            "deepmerge": "^4.2.2",
+            "dot-prop": "^5.2.0",
+            "filter-obj": "^2.0.1",
+            "find-up": "^4.1.0",
+            "indent-string": "^4.0.0",
+            "is-plain-obj": "^2.1.0",
+            "js-yaml": "^3.13.1",
+            "make-dir": "^3.0.2",
+            "map-obj": "^4.1.0",
+            "omit.js": "^1.0.2",
+            "path-exists": "^4.0.0",
+            "resolve": "^1.15.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
       }
     },
     "netlify-redirector": {
@@ -11198,7 +11467,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -12523,9 +12792,9 @@
       }
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
     "read": {
       "version": "1.0.7",
@@ -14257,6 +14526,11 @@
           }
         }
       }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,9 +459,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.83",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.83.tgz",
-      "integrity": "sha512-UShvpOf7u5epYlZcENBFV2VIIzSFhvY2jknWB++Qg5ukAKHllQ4o1O1XTqssi9Vx4Lp+50ODblkDno0ceTCHeg==",
+      "version": "0.1.84",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.84.tgz",
+      "integrity": "sha512-lZ2Px7Q/922bPH07DNnJVVPc71UE5nqZzLAdblKLguGq2bLLWZoMy/3YtyRqJkNaY4kmf1jTXwde/nt8T2Exbg==",
       "requires": {
         "@netlify/cache-utils": "^0.2.2",
         "@netlify/config": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.79",
-    "@netlify/config": "^0.3.0",
+    "@netlify/build": "^0.1.83",
+    "@netlify/config": "^0.4.1",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.83",
+    "@netlify/build": "^0.1.84",
     "@netlify/config": "^0.4.1",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.7",
-    "@netlify/config": "^0.1.21",
+    "@netlify/build": "^0.1.77",
+    "@netlify/config": "^0.2.0",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.77",
-    "@netlify/config": "^0.2.0",
+    "@netlify/build": "^0.1.79",
+    "@netlify/config": "^0.3.0",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -1,5 +1,4 @@
 const build = require('@netlify/build')
-const { getConfigPath } = require('@netlify/config')
 const { flags } = require('@oclif/command')
 const Command = require('../../utils/command')
 
@@ -11,7 +10,7 @@ class BuildCommand extends Command {
       this.netlify.config contains resolved config via @netlify/config
       @netlify/build currently takes a path to config and resolves config values again
     */
-    const options = await this.getOptions()
+    const options = this.getOptions()
 
     await this.config.runHook('analytics', {
       eventName: 'command',
@@ -24,26 +23,15 @@ class BuildCommand extends Command {
   }
 
   // Retrieve Netlify Build options
-  async getOptions() {
-    const { site } = this.netlify
+  getOptions() {
+    const {
+      site: { id: siteId }
+    } = this.netlify
     const {
       flags: { dry = false, context }
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
-
-    // Try current directory first, then site root
-    const config = (await getConfigPath()) || (await getConfigPath(undefined, this.netlify.site.root))
-
-    let options = {
-      config,
-      token,
-      dry,
-      context
-    }
-    if (site.id) {
-      options.siteId = site.id
-    }
-    return options
+    return { token, dry, context, siteId }
   }
 }
 

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -5,11 +5,6 @@ const Command = require('../../utils/command')
 class BuildCommand extends Command {
   // Run Netlify Build
   async run() {
-    /*
-      @TODO remove this.getOptions() & use the parsed config from Command.
-      this.netlify.config contains resolved config via @netlify/config
-      @netlify/build currently takes a path to config and resolves config values again
-    */
     const options = this.getOptions()
 
     await this.config.runHook('analytics', {
@@ -25,13 +20,18 @@ class BuildCommand extends Command {
   // Retrieve Netlify Build options
   getOptions() {
     const {
-      site: { id: siteId }
+      site: { id: siteId },
+      cachedConfig
     } = this.netlify
+    // We have already resolved the configuration using `@netlify/config`
+    // This is stored as `this.netlify.cachedConfig` and can be passed to
+    // `@netlify/build --cachedConfig`.
+    const cachedConfigOption = JSON.stringify(cachedConfig)
     const {
-      flags: { dry = false, context }
+      flags: { dry = false }
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
-    return { token, dry, context, siteId }
+    return { cachedConfig: cachedConfigOption, token, dry, siteId }
   }
 }
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -10,7 +10,6 @@ const globalConfig = require('./global-config')
 const findRoot = require('./find-root')
 const chalkInstance = require('./chalk')
 const resolveConfig = require('@netlify/config')
-const getConfigPath = require('@netlify/config').getConfigPath
 
 const argv = require('minimist')(process.argv.slice(2))
 const { NETLIFY_AUTH_TOKEN, NETLIFY_API_URL } = process.env
@@ -33,8 +32,7 @@ class BaseCommand extends Command {
     const [token] = this.getConfigToken(authViaFlag)
 
     // Read new netlify.toml/yml/json
-    const configPath = await getConfigPath(argv.config, cwd)
-    const config = await resolveConfig(configPath, {
+    const { configPath, config } = await resolveConfig(argv.config, {
       cwd: cwd,
       context: argv.context
     })


### PR DESCRIPTION
Due to https://github.com/netlify/build/pull/868, the latest major release of `@netlify/config` had to merge the method for resolving the configuration and the method for retrieving the configuration file path.

This breaking change requires the CLI to be updated accordingly.