### PR TITLE
Allow overriding functions env vars with .env file

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -431,9 +431,18 @@ class DevCommand extends Command {
       const functionsPort = await getPort({ port: settings.functionsPort || 34567 })
       settings.functionsPort = functionsPort
 
-      await serveFunctions({
+      const functionsServer = await serveFunctions({
         ...settings,
         functionsDir
+      })
+      functionsServer.listen(settings.functionsPort, function(err) {
+        if (err) {
+          console.error(`${NETLIFYDEVERR} Unable to start lambda server: `, err) // eslint-disable-line no-console
+          process.exit(1)
+        }
+
+        // add newline because this often appears alongside the client devserver's output
+        console.log(`\n${NETLIFYDEVLOG} Lambda server is listening on ${settings.functionsPort}`) // eslint-disable-line no-console
       })
     }
 

--- a/src/tests/dummy-site/functions/env-file/.env
+++ b/src/tests/dummy-site/functions/env-file/.env
@@ -1,0 +1,1 @@
+DUMMY_VAR=true

--- a/src/tests/dummy-site/functions/env-file/env-file.js
+++ b/src/tests/dummy-site/functions/env-file/env-file.js
@@ -1,0 +1,6 @@
+exports.handler = async (event, context) => {
+    return {
+        statusCode: 200,
+        body: `${process.env.DUMMY_VAR}`,
+    }
+}

--- a/src/tests/dummy-site/functions/no-env.js
+++ b/src/tests/dummy-site/functions/no-env.js
@@ -1,0 +1,6 @@
+exports.handler = async (event, context) => {
+    return {
+        statusCode: 200,
+        body: `${process.env.DUMMY_VAR}`,
+    }
+}

--- a/src/tests/dummy-site/functions/override-process-env/.env
+++ b/src/tests/dummy-site/functions/override-process-env/.env
@@ -1,0 +1,1 @@
+DUMMY_VAR=true

--- a/src/tests/dummy-site/functions/override-process-env/override-process-env.js
+++ b/src/tests/dummy-site/functions/override-process-env/override-process-env.js
@@ -1,0 +1,6 @@
+exports.handler = async (event, context) => {
+    return {
+        statusCode: 200,
+        body: `${process.env.DUMMY_VAR}`,
+    }
+}

--- a/src/tests/serve-functions.test.js
+++ b/src/tests/serve-functions.test.js
@@ -1,0 +1,89 @@
+const path = require('path')
+const http = require('http')
+
+const test = require('ava')
+const getPort = require('get-port')
+
+const sitePath = path.join(__dirname, 'dummy-site')
+const { serveFunctions } = require('../utils/serve-functions')
+
+test.before(async t => {
+    // Explicitly set env var on process to simulate remote env vars
+    process.env.DUMMY_VAR = false
+
+    const port = await getPort({ port: 34567 })
+    const server = await serveFunctions({
+        functionsDir: path.resolve(sitePath, 'functions'),
+        functionsPort: port,
+    })
+    t.context.port = port
+
+    return new Promise((resolve, reject) => t.context.server = server.listen(port, (err) => {
+        if (err) return reject(err)
+        setTimeout(resolve, 200)
+    }))
+})
+
+test('envfile variable', async t => {
+    const options = {
+        hostname: 'localhost',
+        port: t.context.port,
+        path: '/env-file',
+        method: 'GET'
+    }
+
+    let data = ''
+    const req = http.request(options, (res) => res.on('data', (d) => data += d.toString()))
+
+    req.on('error', error => t.log('error', error))
+    req.end()
+
+    return new Promise((resolve, reject) => req.on('close', () => {
+        t.is(data, 'true')
+        resolve()
+    }))
+})
+test('undefined variable', async t => {
+    const options = {
+        hostname: 'localhost',
+        port: t.context.port,
+        path: '/no-env',
+        method: 'GET'
+    }
+
+    let data = ''
+    const req = http.request(options, (res) => res.on('data', (d) => data += d.toString()))
+
+    req.on('error', error => t.log('error', error))
+    req.end()
+
+    return new Promise((resolve, reject) => req.on('close', () => {
+        t.is(data, 'undefined')
+        resolve()
+    }))
+})
+
+test('override process env', async t => {
+    let data = ''
+    const options = {
+        hostname: 'localhost',
+        port: t.context.port,
+        path: '/override-process-env',
+        method: 'GET'
+    }
+    const req = http.request(options, (res) => res.on('data', (d) => data += d.toString()))
+
+    req.on('error', error => t.log('error', error))
+    req.end()
+
+    req.on('close', () => {
+        t.is(data, 'true')
+    })
+
+    // Verify that explicitly set env var was restored after request
+    t.is(process.env.DUMMY_VAR, 'false')
+})
+
+test.after(t => {
+    t.context.server.close()
+})

--- a/src/tests/serve-functions.test.js
+++ b/src/tests/serve-functions.test.js
@@ -9,7 +9,7 @@ const { serveFunctions } = require('../utils/serve-functions')
 
 test.before(async t => {
     // Explicitly set env var on process to simulate remote env vars
-    process.env.DUMMY_VAR = false
+    process.env.DUMMY_VAR = 'false'
 
     const port = await getPort({ port: 34567 })
     const server = await serveFunctions({

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -157,8 +157,9 @@ function createHandler(dir) {
     const callback = createCallback(response)
     // we already checked that it exports a function named handler above
     let envConfig = {}
-    if (fs.existsSync(path.resolve(path.dirname(functionPath)))) {
-      envConfig = dotenv.parse(fs.readFileSync(path.resolve(path.dirname(functionPath), '.env')))
+    const envPath = path.resolve(path.dirname(functionPath), '.env')
+    if (fs.existsSync(envPath)) {
+      envConfig = dotenv.parse(fs.readFileSync(envPath))
     }
 
     return lambdaLocal.execute({

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -208,17 +208,7 @@ async function serveFunctions(settings) {
     return r
   })
 
-  app.listen(settings.functionsPort, function(err) {
-    if (err) {
-      console.error(`${NETLIFYDEVERR} Unable to start lambda server: `, err) // eslint-disable-line no-console
-      process.exit(1)
-    }
-
-    // add newline because this often appears alongside the client devserver's output
-    console.log(`\n${NETLIFYDEVLOG} Lambda server is listening on ${settings.functionsPort}`) // eslint-disable-line no-console
-  })
-
-  return Promise.resolve()
+  return app
 }
 
 module.exports = { serveFunctions }

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -125,7 +125,7 @@ function createHandler(dir) {
       response.end('Function not found...')
       return
     }
-    const { functionPath, moduleDir } = functions[func]
+    const { functionPath } = functions[func]
 
     const body = request.body.toString()
     var isBase64Encoded = Buffer.from(body, 'base64').toString('base64') === body
@@ -160,7 +160,7 @@ function createHandler(dir) {
       lambdaPath: functionPath,
       clientContext: JSON.stringify(buildClientContext(request.headers) || {}),
       callback: callback,
-      envfile: path.resolve(moduleDir, '.env'),
+      envfile: path.resolve(path.dirname(functionPath), '.env'),
       envdestroy: false,
       verboseLevel: 3,
       timeoutMs: 10 * 1000,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/734
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Env variables set in [app.netlify.com](https://app.netlify.com) override variables in `.env` files for functions when running with `netlify dev`.
**- If the current behavior is a bug, please provide the steps to reproduce.**
* Link your project to a Netlify site using `netlify link`
* Create an env variable in [app.netlify.com](https://app.netlify.com) for your site
* Create a `.env` file in your function directory with the same variable name (access that env variable in your function)
* Run `netilfy dev` and access your function, see the value for the env var
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Record `process.env` before creating functions handler
* Provide variables from `.env` file to `lambda-local` (will result in overriding `process.env`)
* Restore `process.env` from earlier recorded object after `lambda-local` has finished executing
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🦁