### PR TITLE
fix(telemetry): do not track disabling of telemetry

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -8,9 +8,6 @@ module.exports = async context => {
     globalConfig.set('telemetryDisabled', true)
     console.log('Netlify telemetry has been disabled')
     console.log('You can renable it anytime with the --telemetry-enable flag')
-    track('user_telemetryDisabled', {
-      force: true
-    })
     process.exit() // eslint-disable-line
   }
   if (context.id === '--telemetry-enable') {


### PR DESCRIPTION
Fixes #739. The line removed in this PR was added long ago without an issue or PR, so it isn't clear why we need it. Since disabling telemetry via config bypasses this call altogether, we should bypass it for users that disable via flag as well. `track()` shouldn't be called at all for users who disable telemetry.


