### PR TITLE
Upgrade `@netlify/build`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -454,27 +454,24 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.84",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.84.tgz",
-      "integrity": "sha512-lZ2Px7Q/922bPH07DNnJVVPc71UE5nqZzLAdblKLguGq2bLLWZoMy/3YtyRqJkNaY4kmf1jTXwde/nt8T2Exbg==",
+      "version": "0.1.98",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.98.tgz",
+      "integrity": "sha512-L1MKWEihvQO3rzTCChRRoZjyNyjZf3ucLPmlWgJTOju8Z24cEieY5Ixf2XNPJt8a6MOR9BLYeqIudAWKoHQefA==",
       "requires": {
         "@netlify/cache-utils": "^0.2.2",
-        "@netlify/config": "^0.4.1",
-        "@netlify/functions-utils": "^0.2.0",
+        "@netlify/config": "^0.4.7",
+        "@netlify/functions-utils": "^0.2.1",
         "@netlify/git-utils": "^0.2.0",
         "@netlify/run-utils": "^0.1.0",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-8",
-        "ajv": "^6.11.0",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-9",
         "analytics": "0.3.0",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "clean-stack": "^2.2.0",
-        "deepmerge": "^4.2.2",
         "execa": "^3.3.0",
         "fast-glob": "^3.1.0",
         "figures": "^3.2.0",
         "filter-obj": "^2.0.1",
-        "find-up": "^4.1.0",
         "global-cache-dir": "^1.0.1",
         "got": "^9.6.0",
         "group-by": "^0.0.1",
@@ -482,16 +479,16 @@
         "is-ci": "^2.0.0",
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
+        "locate-path": "^5.0.0",
         "log-process-errors": "^5.0.3",
         "map-obj": "^4.1.0",
-        "moize": "^5.4.5",
         "netlify": "^3.1.0",
         "omit.js": "^1.0.2",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
-        "p-map-series": "^2.1.0",
         "p-reduce": "^2.1.0",
         "path-exists": "^4.0.0",
+        "pkg-dir": "^4.2.0",
         "read-pkg-up": "^7.0.1",
         "readdirp": "^3.1.3",
         "redact-env": "^0.2.0",
@@ -505,14 +502,14 @@
       },
       "dependencies": {
         "@netlify/open-api": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.1.tgz",
-          "integrity": "sha512-lq3xrVNv6Jl2yu3PuXYFTuiEVvXBU41e9zCVK8k5vuE/gYJxpeNXXY2OWO0sLy3AbjkpPWiSHjtUYuHMTcru3A=="
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.2.tgz",
+          "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
         },
         "@netlify/zip-it-and-ship-it": {
-          "version": "0.4.0-8",
-          "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-8.tgz",
-          "integrity": "sha512-lr2kafpVKqHu2lS630B9CFfpoB6suIZixZfXKerS+r1Z81sBIJpIPGYArmNa3fOZyvXt8+kyFdiXVkibQYLsWw==",
+          "version": "0.4.0-9",
+          "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-9.tgz",
+          "integrity": "sha512-93wYQiKEfBeLJS0iozCF9Uoe31tWMglnk+ozKV6ANPI8t4vUbFT5CEjUAV/gXGLFLPcQSJ25NXhi2vxgbJ4GKA==",
           "requires": {
             "archiver": "^3.0.0",
             "common-path-prefix": "^2.0.0",
@@ -531,14 +528,6 @@
             "yargs": "^14.2.0"
           },
           "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
             "string-width": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -558,9 +547,9 @@
               }
             },
             "yargs": {
-              "version": "14.2.2",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
-              "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+              "version": "14.2.3",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+              "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
               "requires": {
                 "cliui": "^5.0.0",
                 "decamelize": "^1.2.0",
@@ -572,7 +561,7 @@
                 "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^15.0.0"
+                "yargs-parser": "^15.0.1"
               }
             }
           }
@@ -638,25 +627,6 @@
             "strip-final-newline": "^2.0.0"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          },
-          "dependencies": {
-            "locate-path": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-              "requires": {
-                "p-locate": "^4.1.0"
-              }
-            }
-          }
-        },
         "got": {
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -689,6 +659,14 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
           "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
         },
         "netlify": {
           "version": "3.1.0",
@@ -740,14 +718,6 @@
                 "resolve": "^1.10.0"
               }
             },
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
             "p-map": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
@@ -763,11 +733,6 @@
               }
             }
           }
-        },
-        "normalize-url": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         },
         "p-cancelable": {
           "version": "1.1.0",
@@ -808,6 +773,15 @@
             "type-fest": "^0.8.1"
           },
           "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
             "read-pkg": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -861,9 +835,9 @@
           }
         },
         "yargs-parser": {
-          "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -888,9 +862,9 @@
       }
     },
     "@netlify/config": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.1.tgz",
-      "integrity": "sha512-4/NLVTYoaIlnTaObiMekVv2QSj6qaDlRCLfQLG2lXRsSl9brTUCfKgCuv7ilK3TDOYs3urywMnSF/lwEFEB31A==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.7.tgz",
+      "integrity": "sha512-lIhI1HFUb4XSnEtoOZN2GDQ1l7UuzhD4ytaWM3AzlOUbkVNnkOpt1h5Yz5Q80Frf0ppj1iCVhfVvAjjNJLAugg==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -902,9 +876,9 @@
         "indent-string": "^4.0.0",
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
-        "locate-path": "^5.0.0",
         "map-obj": "^4.1.0",
         "omit.js": "^1.0.2",
+        "p-filter": "^2.1.0",
         "path-exists": "^4.0.0",
         "toml": "^3.0.0",
         "yargs": "^15.3.0"
@@ -983,9 +957,9 @@
       }
     },
     "@netlify/functions-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.0.tgz",
-      "integrity": "sha512-/wzOwrWU1VAqblZ7xf0gueCu0w049lEQjHpYNzIW0dbH7hqnlhw7Bcw7Ljn2TA+Lh5lecqPXoIQo9yvJn/ALJQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.1.tgz",
+      "integrity": "sha512-uLNCkMZoOEMEqU24E9DKHE5JeFMqP7LJHjgcFPv9vyG57BIEuiePDeuvhUDl++79ViSmVs/dbQThlr7Jerebsw==",
       "requires": {
         "cpy": "^8.0.0",
         "path-exists": "^4.0.0"
@@ -1929,6 +1903,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
       "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7004,7 +6979,8 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -7084,7 +7060,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -9387,7 +9364,8 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11207,6 +11185,11 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
     "npm-bundled": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
@@ -11386,7 +11369,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -11794,11 +11777,6 @@
       "requires": {
         "aggregate-error": "^3.0.0"
       }
-    },
-    "p-map-series": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz",
-      "integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q=="
     },
     "p-reduce": {
       "version": "2.1.0",
@@ -12424,7 +12402,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qqjs": {
       "version": "0.3.11",
@@ -15009,6 +14988,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -15491,9 +15471,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
-      "integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -15505,7 +15485,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.0"
+        "yargs-parser": "^18.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15559,9 +15539,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-      "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.84",
-    "@netlify/config": "^0.4.1",
+    "@netlify/build": "^0.1.98",
+    "@netlify/config": "^0.4.7",
     "@netlify/zip-it-and-ship-it": "^0.3.1",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",


### PR DESCRIPTION
This upgrades `@netlify/build`. This should not be necessary since we use semver. However semver only works when users are updating their `package-lock.json`. Making a dummy new release of the CLI (which is essentially the goal of this PR) will update users lock files (if they upgrade Netlify CLI). 

This is important as part of the MVP, to make sure users get the same experience on Netlify CLI than in the UI.