### PR TITLE
Add support for getting/tailing deploy logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,243 @@
         }
       }
     },
+    "@firebase/app": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.3.17.tgz",
+      "integrity": "sha512-/8lDeeIxgdCIMffrfBPQ3bcdSkF8bx4KCp8pKMPOG/HYKoeM8I9eP4zlzxL5ABzRjvcdhK9KOYOn0jRrNrGD9g==",
+      "requires": {
+        "@firebase/app-types": "0.3.10",
+        "@firebase/util": "0.2.14",
+        "dom-storage": "2.1.0",
+        "tslib": "1.9.3",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/app-types": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.3.10.tgz",
+      "integrity": "sha512-l+5BJtSQopalBXiY/YuSaB9KF9PnDj37FLV0Sx3qJjh5B3IthCuZbPc1Vpbbbee/QZgudl0G212BBsUMGHP+fQ=="
+    },
+    "@firebase/auth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.10.2.tgz",
+      "integrity": "sha512-+S8RZcHhhat2xrW/RGOcSZO8pv0qHveaw09Bq/gXhZyJfN86UeiMc3sv4YMo1Hu7fRRorNteijpmlH522eI0AA==",
+      "requires": {
+        "@firebase/auth-types": "0.6.1"
+      }
+    },
+    "@firebase/auth-types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.6.1.tgz",
+      "integrity": "sha512-uciPeIQJC1NZDhI5+BWbyqi70YXIjT3jm03sYtIgkPt2sr3n8sq1RpnoTMYfAJkQ0QlgLaBkeM/huMx06eBoXQ=="
+    },
+    "@firebase/database": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.3.20.tgz",
+      "integrity": "sha512-fZHRIlRQlND/UrzI1beUTRKfktjMvMEiUOar6ylFZqOj2KNVO4CrF95UGqRl0HBGhZzlBKzaDYAcJze2D6C4+Q==",
+      "requires": {
+        "@firebase/database-types": "0.3.11",
+        "@firebase/logger": "0.1.13",
+        "@firebase/util": "0.2.14",
+        "faye-websocket": "0.11.1",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/database-types": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.3.11.tgz",
+      "integrity": "sha512-iRAZzs7Zlmmvh7r0XlR1MAO6I6bm1HjW9m1ytfJ6E/8+zItHnbVH4iiVVkC39r1wMGrtPMz8FiIUWoaasPF5dA=="
+    },
+    "@firebase/firestore": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.2.2.tgz",
+      "integrity": "sha512-5o3SFTpMYaWrWRlm5qBX84fNDwdiPTbb0qo6KDI+OvIzTaMsEfOJ4vUz+Binxfq0dPen0fU6JLO+xix8Sa8TBA==",
+      "requires": {
+        "@firebase/firestore-types": "1.2.1",
+        "@firebase/logger": "0.1.13",
+        "@firebase/webchannel-wrapper": "0.2.19",
+        "grpc": "1.20.0",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.2.1.tgz",
+      "integrity": "sha512-/Klu3uVLoTjW3ckYqFTV3lr9HzEKM7pMpPHao1Sy+YwIUmTjFMI1LE2WcXMx6HN2jipFjjD/Xjg0hY0+0dnPCg=="
+    },
+    "@firebase/functions": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.6.tgz",
+      "integrity": "sha512-jpRLY8GyhmFufnN3eilvIuAqD9qsG2/AftGtFaTRL0ObSySmraYcVOpKAxsFZW//9EMNtI9c9/rw+QFq5SkuyA==",
+      "requires": {
+        "@firebase/functions-types": "0.3.5",
+        "@firebase/messaging-types": "0.2.11",
+        "isomorphic-fetch": "2.2.1",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.5.tgz",
+      "integrity": "sha512-3hTMqfSugCfxzT6vZPbzQ58G4941rsFr99fWKXGKFAl2QpdMBCnKmEKdg/p5M47xIPyzIQn6NMF5kCo/eICXhA=="
+    },
+    "@firebase/installations": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.1.0.tgz",
+      "integrity": "sha512-drt9kDT4w/OCXt5nboOIaUGI3lDwHAoSY2V6qJTbtbd3qVSxE0EBLA4c+allpWdmrhGBrASApuA0eAjphxuXIw==",
+      "requires": {
+        "@firebase/installations-types": "0.1.0",
+        "@firebase/util": "0.2.14",
+        "idb": "3.0.2"
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.1.0.tgz",
+      "integrity": "sha512-cw2UIvPa3+umy6w7dGj0LqQQ9v7WEOro5s+6B+v54Tw25WyLnR6cBIkyyahv3Uu9QPnGZCIsemlQwxIaIOMb9g=="
+    },
+    "@firebase/logger": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.13.tgz",
+      "integrity": "sha512-wIbLwQ2oJCkvHIE7J3FDxpScKY84fSctEEjOi0PB+Yn2dN8AwqtM7YF8rtcY8cxntv8dyR+i7GNg1Nd89cGxkA=="
+    },
+    "@firebase/messaging": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.3.19.tgz",
+      "integrity": "sha512-xY1Hlsj0MqyU/AmJQLyH9Uknhs8+1OsD2xXE8W34qk0g2RtpygUN7JMD21d5w5zZ5dMtLNhVSIxU8oI2rAUjcA==",
+      "requires": {
+        "@firebase/messaging-types": "0.2.11",
+        "@firebase/util": "0.2.14",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.2.11.tgz",
+      "integrity": "sha512-uWtzPMj1mAX8EbG68SnxE12Waz+hRuO7vtosUFePGBfxVNNmPx5vJyKZTz+hbM4P77XddshAiaEkyduro4gNgA=="
+    },
+    "@firebase/performance": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.1.tgz",
+      "integrity": "sha512-vo/24+W35foc2ShRgeIlx2Ej45+Sn6uYPpnYzTtJb3DwE3sb0BVGocVgINbXyguUq2PHS+6yLsCm88y12DS2EA==",
+      "requires": {
+        "@firebase/installations": "0.1.0",
+        "@firebase/logger": "0.1.13",
+        "@firebase/performance-types": "0.0.1",
+        "@firebase/util": "0.2.14",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.1.tgz",
+      "integrity": "sha512-U45GbVAnPyz7wPLd3FrWdTeaFSvgsnGfGK58VojfEMmFnMAixCM3qBv1XJ0xfhyKbK1xZN4+usWAR8F3CwRAXw=="
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.13.tgz",
+      "integrity": "sha512-nmz0KMrGZh4wvy8iPnOCtpSXw0LwXPdj9lqgeOVClXMgJBi5+FS1q0W1Ofn7BULmMc8tYsGGY+T2HvfmznMuPg==",
+      "requires": {
+        "core-js": "3.0.1",
+        "promise-polyfill": "8.1.0",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
+      }
+    },
+    "@firebase/storage": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.2.15.tgz",
+      "integrity": "sha512-WR80AXm1btlHERavhSwiTwFAyT/M/Jn6/2I3RAlcVOS6NnKVdRIcSVW1zY9jvO3fdeksqBU9NKTXeXFTmsrw6g==",
+      "requires": {
+        "@firebase/storage-types": "0.2.11",
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.2.11.tgz",
+      "integrity": "sha512-vGTFJmKbfScmCAVUamREIBTopr5Uusxd8xPAgNDxMZwICvdCjHO0UH0pZZj6iBQuwxLe/NEtFycPnu1kKT+TPw=="
+    },
+    "@firebase/util": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.14.tgz",
+      "integrity": "sha512-2ke1Lra0R5T+5ucCMWft/IB2rI/IzumHHYm9aqrM9lJ3XURiWmBHAYrvaPVP7///gDhJAo+NNDUCAJH/Y4PmvA==",
+      "requires": {
+        "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.19.tgz",
+      "integrity": "sha512-U9e2dCB38mD2AvV/zAjghauwa0UX15Wt98iBgm8IOw8spluDxysx8UZFUhj38fu0iFXORVRBqseyK2wCxZIl5w=="
+    },
     "@jest/types": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
@@ -2297,6 +2534,15 @@
       "resolved": "https://registry.npmjs.org/ascii-table/-/ascii-table-0.0.9.tgz",
       "integrity": "sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM="
     },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3719,6 +3965,14 @@
         "semver": "^6.0.0"
       }
     },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "requires": {
+        "long": "~3"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -4367,8 +4621,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "coffee-script": {
       "version": "1.12.7",
@@ -4449,6 +4702,11 @@
         "color": "3.0.x",
         "text-hex": "1.0.x"
       }
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5754,6 +6012,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+    },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -5919,6 +6182,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -7109,6 +7380,14 @@
         "reusify": "^1.0.0"
       }
     },
+    "faye-websocket": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -7265,6 +7544,22 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "firebase": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-5.11.1.tgz",
+      "integrity": "sha512-cop2UHytKas8WJZTovZqhpZIgwRfsvegijyOjgmMJoaOHCnyH4eymPneglgXsK5ExOdxJSTC4QD5qETrdL3dMw==",
+      "requires": {
+        "@firebase/app": "0.3.17",
+        "@firebase/auth": "0.10.2",
+        "@firebase/database": "0.3.20",
+        "@firebase/firestore": "1.2.2",
+        "@firebase/functions": "0.4.6",
+        "@firebase/messaging": "0.3.19",
+        "@firebase/performance": "0.2.1",
+        "@firebase/polyfill": "0.3.13",
+        "@firebase/storage": "0.2.15"
       }
     },
     "flat": {
@@ -8083,6 +8378,423 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "grpc": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.20.0.tgz",
+      "integrity": "sha512-HgYuJzRomkBlJAfC/78epuWzwMiByxgj4JsO6G6dHXXNfARTsUqpM/FmPSJJNFGvzCev0g6tn33CE7nWEmhDEg==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.0.0",
+        "node-pre-gyp": "^0.12.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.12",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        }
+      }
+    },
     "gulp-header": {
       "version": "1.8.12",
       "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
@@ -8316,6 +9028,11 @@
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
+    },
+    "http-parser-js": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
       "version": "1.18.0",
@@ -8610,6 +9327,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -8801,6 +9523,11 @@
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -9170,6 +9897,36 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -9532,6 +10289,14 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -9933,8 +10698,7 @@
     "lodash.clone": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
-      "dev": true
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -10198,6 +10962,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -11001,9 +11770,7 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11325,8 +12092,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "14.1.1",
@@ -11678,6 +12444,11 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
     "ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -11703,6 +12474,14 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-name": {
       "version": "3.1.0",
@@ -12375,6 +13154,11 @@
         "asap": "~2.0.3"
       }
     },
+    "promise-polyfill": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.0.tgz",
+      "integrity": "sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA=="
+    },
     "propagate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
@@ -12385,6 +13169,93 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
+    "protobufjs": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+      "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+      "requires": {
+        "ascli": "~1",
+        "bytebuffer": "~5",
+        "glob": "^7.0.5",
+        "yargs": "^3.10.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -15134,10 +16005,30 @@
         "defaults": "^1.0.3"
       }
     },
+    "websocket-driver": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+      "requires": {
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+    },
     "well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q=="
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "2.0.2",
@@ -15219,6 +16110,11 @@
           }
         }
       }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "windows-release": {
       "version": "3.2.0",
@@ -15456,6 +16352,11 @@
         }
       }
     },
+    "ws": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+    },
     "xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -15474,6 +16375,11 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "express": "^4.17.1",
     "express-logging": "^1.1.1",
     "find-up": "^3.0.0",
+    "firebase": "^5.11.1",
     "fs-extra": "^8.1.0",
     "fuzzy": "^0.1.3",
     "get-port": "^5.1.0",
@@ -105,6 +106,7 @@
     "inquirer": "^6.5.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "is-docker": "^1.1.0",
+    "isomorphic-ws": "^4.0.1",
     "jwt-decode": "^2.2.0",
     "lambda-local": "^1.7.1",
     "lodash.get": "^4.4.2",
@@ -140,7 +142,8 @@
     "wait-port": "^0.2.2",
     "winston": "^3.2.1",
     "wrap-ansi": "^6.0.0",
-    "write-file-atomic": "^3.0.0"
+    "write-file-atomic": "^3.0.0",
+    "ws": "^7.2.3"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -82,7 +82,7 @@ class DeployCommand extends Command {
         return
       } catch (err) {
         if (err.status === 404) {
-          this.error('Site not found. Please rerun "netlify link" and make sure that your site has a deployment source configured.')
+          this.error('Site not found. Please rerun "netlify link" and make sure that your site has CI configured.')
         } else {
           this.error(err.message)
         }

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -13,7 +13,7 @@ const randomItem = require('random-item')
 const inquirer = require('inquirer')
 const SitesCreateCommand = require('./sites/create')
 const LinkCommand = require('./link')
-const { NETLIFYDEV } = require('../utils/logo')
+const { NETLIFYDEVLOG } = require('../utils/logo')
 const { waitForBuildFinish } = require('../utils/logs.js')
 
 class DeployCommand extends Command {
@@ -81,7 +81,8 @@ class DeployCommand extends Command {
     if (flags.trigger) {
       try {
         const siteBuild = await api.createSiteBuild({ siteId: siteId })
-        this.log(`${NETLIFYDEV} A new deployment was triggered successfully. Waiting for the build to start`)
+        this.log(`${NETLIFYDEVLOG} A new deployment was triggered successfully.`)
+        this.log(`${NETLIFYDEVLOG} Waiting for the build to start ⏳`)
         const deployData = await api.getDeploy({ deployId: siteBuild.deploy_id })
         if (deployData && deployData.log_access_attributes && Object.keys(deployData.log_access_attributes).length) {
           await waitForBuildFinish(api, site.id, siteBuild.deploy_id, accessToken)

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,15 +1,19 @@
 const Command = require('../utils/command')
 const { CLIError } = require('@oclif/errors')
-const pWaitFor = require('p-wait-for')
 const cli = require('cli-ux').default
 const prettyjson = require('prettyjson')
 const chalk = require('chalk')
 
+const { waitForBuildFinish } = require('../utils/logs')
+
 class SitesWatchCommand extends Command {
   async run() {
+    const { args } = this.parse(SitesWatchCommand)
     await this.authenticate()
     const client = this.netlify.api
     const siteId = this.netlify.site.id
+
+    const [accessToken] = this.getConfigToken()
 
     // wait for 1 sec for everything to kickoff
     console.time('Deploy time')
@@ -47,7 +51,7 @@ class SitesWatchCommand extends Command {
       //   return !build.done
       // })
 
-      const noActiveBuilds = await waitForBuildFinish(client, siteId)
+      const noActiveBuilds = await waitForBuildFinish(client, siteId, args.deployId, accessToken)
 
       const siteData = await client.getSite({ siteId })
 
@@ -73,35 +77,8 @@ SitesWatchCommand.description = `Watch for site deploy to finish`
 
 SitesWatchCommand.examples = [`netlify watch`, `git push && netlify watch`]
 
-async function waitForBuildFinish(api, siteId) {
-  let firstPass = true
-
-  await pWaitFor(waitForBuildToFinish, {
-    interval: 1000,
-    timeout: 1.2e6, // 20 mins,
-    message: 'Timeout while waiting for deploy to finish'
-  })
-
-  // return only when build done or timeout happens
-  return firstPass
-
-  async function waitForBuildToFinish() {
-    const builds = await api.listSiteBuilds({ siteId })
-    const currentBuilds = builds.filter(build => {
-      // build.error
-      return !build.done
-    })
-
-    // if build.error
-    // @TODO implement build error messages into this
-
-    if (!currentBuilds || !currentBuilds.length) {
-      cli.action.stop()
-      return true
-    }
-    firstPass = false
-    return false
-  }
-}
+SitesWatchCommand.args = [
+  { name: 'deployId' },
+]
 
 module.exports = SitesWatchCommand

--- a/src/utils/log_streamers/firebase.js
+++ b/src/utils/log_streamers/firebase.js
@@ -39,7 +39,7 @@ class FirebaseStreamer {
     this.endpoint = attributes.endpoint;
     this.path = attributes.path.replace(/\./g, "-");
     this.startAt = attributes.startAt;
-    this.token = attributes.token;
+    this.token = attributes.accessToken;
   }
 
   listen(updater, errorHandler = logError) {

--- a/src/utils/log_streamers/firebase.js
+++ b/src/utils/log_streamers/firebase.js
@@ -1,0 +1,81 @@
+const TIMEOUT_IN_MILLIS = 20000;
+
+const baseConfig = {
+  authDomain: "netlify.firebaseapp.com",
+  projectId: "firebase-netlify",
+  storageBucket: "firebase-netlify.appspot.com",
+  messagingSenderId: "344466503271"
+};
+
+const firebaseApps = {};
+
+function loadFirebase(firebaseConfig) {
+  const { databaseURL } = firebaseConfig;
+  let app = firebaseApps[databaseURL];
+  return app
+    ? Promise.resolve(app)
+    : Promise.all([
+        require(/* webpackChunkName: "firebase" */ "firebase/app"),
+        require(/* webpackChunkName: "firebase" */ "firebase/database")
+      ]).then(([firebase, ...rest]) => {
+        app = firebase.initializeApp(
+          {
+            ...baseConfig,
+            ...firebaseConfig
+          },
+          databaseURL
+        );
+        firebaseApps[databaseURL] = app;
+        return app;
+      });
+}
+
+function logError(error) {
+  console.error(error);
+}
+
+class FirebaseStreamer {
+  constructor(attributes) {
+    this.endpoint = attributes.endpoint;
+    this.path = attributes.path.replace(/\./g, "-");
+    this.startAt = attributes.startAt;
+    this.token = attributes.token;
+  }
+
+  listen(updater, errorHandler = logError) {
+    let connected = false;
+
+    setTimeout(() => {
+      !connected && errorHandler(new Error("Connection timed out"));
+    }, TIMEOUT_IN_MILLIS);
+
+    let firebaseConfig = {
+      apiKey: this.token,
+      databaseURL: this.endpoint
+    };
+    loadFirebase(firebaseConfig).then(firebase => {
+      this.api = firebase.database().ref(this.path);
+      if (this.startAt) {
+        this.api.orderByChild("ts").startAt(this.startAt);
+      }
+      this.api.on("child_added", snapshot => {
+        // Called for every line in the log
+        connected = true;
+        updater(snapshot.val());
+      });
+      this.api.on("value", snapshot => {
+        // Fallback for empty logs
+        if (!connected) {
+          connected = true;
+          updater();
+        }
+      });
+    });
+  }
+
+  close() {
+    this.api && this.api.off && this.api.off();
+  }
+}
+
+module.exports = FirebaseStreamer;

--- a/src/utils/log_streamers/humiobase.js
+++ b/src/utils/log_streamers/humiobase.js
@@ -1,0 +1,73 @@
+const WebSocket = require('isomorphic-ws');
+
+class HumioStreamer {
+  constructor({ deployId, date, persisted }, accessToken, fetchLog) {
+    this.deployId = deployId;
+    this.date = new Date(date);
+    this.backoff = 1000;
+    this.reset = false;
+    this.persisted = persisted;
+    this.fetchLog = fetchLog;
+    this.accessToken = accessToken;
+  }
+
+  listen(updater, errorHandler) {
+    if (this.persisted) {
+      return this.fetchLog(this.deployId)
+        .then(data => {
+          let reset = true;
+          data.forEach(line => {
+            updater({
+              reset,
+              ts: line.ts,
+              log: line.msg // mimic Firebase format
+            });
+            reset = false;
+          });
+        })
+        .catch(errorHandler);
+    } else {
+      const yesterday = new Date() - ( 1000 * 60 * 60 * 24);
+      if (this.date < yesterday) {
+        updater({
+          reset: true,
+          ts: new Date().getTime(),
+          log: "Build log has expired..."
+        });
+        return;
+      }
+    }
+
+    this.ws = new WebSocket("wss://log-streaming.netlify.com/ws");
+    this.ws.onmessage = e => {
+      const data = JSON.parse(e.data);
+      data.reset = this.reset;
+      this.reset = false;
+      updater(data);
+    };
+    this.ws.onopen = e => {
+      this.ws.send(
+        JSON.stringify({
+          access_token: this.accessToken,
+          deploy_id: this.deployId
+        })
+      );
+    };
+    this.ws.onclose = e => {
+      this.reset = true;
+      setTimeout(() => this.listen(updater), this.backoff);
+      this.backoff = Math.max(this.backoff * 2, 30);
+    };
+  }
+
+  close() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.backoff = 0;
+    this.reset = false;
+  }
+}
+
+module.exports = HumioStreamer

--- a/src/utils/log_streamers/humiobase.js
+++ b/src/utils/log_streamers/humiobase.js
@@ -1,7 +1,7 @@
 const WebSocket = require('isomorphic-ws');
 
 class HumioStreamer {
-  constructor({ deployId, date, persisted }, accessToken, fetchLog) {
+  constructor({ deployId, date, persisted, accessToken }, fetchLog) {
     this.deployId = deployId;
     this.date = new Date(date);
     this.backoff = 1000;

--- a/src/utils/log_streamers/index.js
+++ b/src/utils/log_streamers/index.js
@@ -1,0 +1,18 @@
+const FirebaseStreamer = require("./firebase");
+const HumioStreamer = require("./humiobase");
+const NatsStreamer = require("./nats-streamer");
+const SocketeerStreamer = require("./socketeer");
+
+const providers = {
+  firebase: FirebaseStreamer,
+  humio: HumioStreamer,
+  nats_streaming: NatsStreamer,
+  socketeer: SocketeerStreamer
+};
+
+function getLogStreamer(attributes, deploy, fetchLog) {
+  const klass = providers[attributes.type];
+  return klass && new klass(attributes, deploy, fetchLog);
+}
+
+module.exports = getLogStreamer

--- a/src/utils/log_streamers/nats-streamer.js
+++ b/src/utils/log_streamers/nats-streamer.js
@@ -1,0 +1,73 @@
+const WebSocket = require('isomorphic-ws');
+
+class NatsStreamer {
+  constructor({ deployId, date, persisted }, accessToken, fetchLog) {
+    this.deployId = deployId;
+    this.date = new Date(date);
+    this.backoff = 1000;
+    this.reset = false;
+    this.persisted = persisted;
+    this.fetchLog = fetchLog;
+    this.accessToken = accessToken;
+  }
+
+  listen(updater, errorHandler) {
+    if (this.persisted) {
+      return this.fetchLog(this.deployId)
+        .then(data => {
+          let reset = true;
+          data.forEach(line => {
+            updater({
+              reset,
+              ts: line.ts,
+              log: line.msg
+            });
+            reset = false;
+          });
+        })
+        .catch(errorHandler);
+    } else {
+      const yesterday = new Date() - ( 1000 * 60 * 60 * 24);
+      if (this.date < yesterday) {
+        updater({
+          reset: true,
+          ts: new Date().getTime(),
+          log: "Build log has expired..."
+        });
+        return;
+      }
+    }
+
+    this.ws = new WebSocket("wss://buildlogs.services.netlify.com/deploylog");
+    this.ws.onmessage = e => {
+      const data = JSON.parse(e.data);
+      data.reset = this.reset;
+      this.reset = false;
+      updater(data);
+    };
+    this.ws.onopen = e => {
+      this.ws.send(
+        JSON.stringify({
+          access_token: this.accessToken,
+          deploy_id: this.deployId
+        })
+      );
+    };
+    this.ws.onclose = e => {
+      this.reset = true;
+      setTimeout(() => this.listen(updater), this.backoff);
+      this.backoff = Math.max(this.backoff * 2, 30);
+    };
+  }
+
+  close() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.backoff = 0;
+    this.reset = false;
+  }
+}
+
+module.exports = NatsStreamer;

--- a/src/utils/log_streamers/nats-streamer.js
+++ b/src/utils/log_streamers/nats-streamer.js
@@ -1,7 +1,7 @@
 const WebSocket = require('isomorphic-ws');
 
 class NatsStreamer {
-  constructor({ deployId, date, persisted }, accessToken, fetchLog) {
+  constructor({ deployId, date, persisted, accessToken }, fetchLog) {
     this.deployId = deployId;
     this.date = new Date(date);
     this.backoff = 1000;

--- a/src/utils/log_streamers/resources.js
+++ b/src/utils/log_streamers/resources.js
@@ -1,0 +1,6 @@
+const LogResources = {
+  BUILD: "build",
+  FUNCTION: "function"
+};
+
+module.exports = LogResources;

--- a/src/utils/log_streamers/socketeer.js
+++ b/src/utils/log_streamers/socketeer.js
@@ -1,0 +1,87 @@
+const url = require("url");
+
+const LogResources = require("./resources");
+const WebSocket = require('isomorphic-ws');
+
+const socketeerApiBase = "wss://socketeer.services.netlify.com"
+
+function logError(error) {
+  console.error(error);
+}
+
+const projectIdFromEndpoint = endpoint => {
+  const host = new url.URL(endpoint).hostname;
+  if (!host.endsWith(".firebaseio.com")) {
+    throw new Error("invalid firebase endpoint");
+  }
+  return host.replace(".firebaseio.com", "");
+};
+
+class SocketeerStreamer {
+  constructor(attributes) {
+    switch (attributes.resource) {
+      case LogResources.BUILD:
+        this._initBuildLog(attributes);
+        break;
+      case LogResources.FUNCTION:
+        this._initFunctionLog(attributes);
+        break;
+      default:
+        throw new Error("unknown log type");
+    }
+  }
+
+  _initBuildLog(attributes) {
+    this.path = "/build/logs";
+    this.subscribeMsg = {
+      access_token: attributes.apiToken,
+      project_id:
+        attributes.fbProjectId || projectIdFromEndpoint(attributes.endpoint),
+      build_id: attributes.buildId
+    };
+  }
+
+  _initFunctionLog(attributes) {
+    this.path = "/function/logs";
+    this.subscribeMsg = {
+      access_token: attributes.apiToken,
+      account_id: attributes.awsAccountId,
+      function_id: attributes.functionId,
+      site_id: attributes.siteId
+    };
+  }
+
+  listen(updater, errorHandler = logError) {
+    const url = `${socketeerApiBase}${this.path}`;
+    this.ws = new WebSocket(url);
+    this.ws.addEventListener("open", () => {
+      this.ws.send(JSON.stringify(this.subscribeMsg));
+    });
+    this.ws.addEventListener("message", ({ data }) => {
+      try {
+        const { ts, message, type } = JSON.parse(data);
+        if (type === "start") {
+          return;
+        }
+        updater({
+          ts,
+          type,
+          log: message
+        });
+      } catch (e) {
+        errorHandler(e);
+      }
+    });
+    this.ws.addEventListener("error", errorHandler);
+  }
+
+  close() {
+    if (!this.ws || this.ws.readyState === WebSocket.CLOSED) {
+      return;
+    }
+    this.ws.close();
+    this.ws = null;
+  }
+}
+
+module.exports = SocketeerStreamer;

--- a/src/utils/log_streamers/socketeer.js
+++ b/src/utils/log_streamers/socketeer.js
@@ -34,7 +34,7 @@ class SocketeerStreamer {
   _initBuildLog(attributes) {
     this.path = "/build/logs";
     this.subscribeMsg = {
-      access_token: attributes.apiToken,
+      access_token: attributes.accessToken,
       project_id:
         attributes.fbProjectId || projectIdFromEndpoint(attributes.endpoint),
       build_id: attributes.buildId
@@ -44,7 +44,7 @@ class SocketeerStreamer {
   _initFunctionLog(attributes) {
     this.path = "/function/logs";
     this.subscribeMsg = {
-      access_token: attributes.apiToken,
+      access_token: attributes.accessToken,
       account_id: attributes.awsAccountId,
       function_id: attributes.functionId,
       site_id: attributes.siteId

--- a/src/utils/logs.js
+++ b/src/utils/logs.js
@@ -5,7 +5,7 @@ const getLogStreamer = require('./log_streamers')
 
 async function waitForBuildFinish(api, siteId, deployId, accessToken) {
     let firstPass = true
-    let p = Promise.resolve()
+    let p = new Promise(() => {})
 
     if (deployId) {
         let rej

--- a/src/utils/logs.js
+++ b/src/utils/logs.js
@@ -8,21 +8,21 @@ async function waitForBuildFinish(api, siteId, deployId, accessToken) {
     let p = new Promise(() => {})
 
     if (deployId) {
-        let rej
-        p = new Promise((_, reject) => rej = reject)
-        const deployment = await api.getDeploy({ deploy_id: deployId })
-        const streamer = getLogStreamer(
-            {
-                ...deployment.log_access_attributes,
-                deployId: deployment.id,
-                buildId: deployment.build_id,
-                date: deployment.created_at,
-                resource: 'build',
-                accessToken: accessToken,
-            },
-            () => deployment.log_access_attributes,
-        )
-        streamer.listen(bit => console.log(bit && `${new Date(bit.ts || bit.time).toLocaleTimeString()}: ${bit.log}`), rej)
+        p = new Promise(async (_, reject) => {
+            const deployment = await api.getDeploy({ deploy_id: deployId })
+            const streamer = getLogStreamer(
+                {
+                    ...deployment.log_access_attributes,
+                    deployId: deployment.id,
+                    buildId: deployment.build_id,
+                    date: deployment.created_at,
+                    resource: 'build',
+                    accessToken: accessToken,
+                },
+                () => deployment.log_access_attributes,
+            )
+            streamer.listen(bit => console.log(bit && `${new Date(bit.ts || bit.time).toLocaleTimeString()}: ${bit.log}`), reject)
+        })
     }
 
     await Promise.race([p, pWaitFor(waitForBuildToFinish, {

--- a/src/utils/logs.js
+++ b/src/utils/logs.js
@@ -1,0 +1,58 @@
+const pWaitFor = require('p-wait-for')
+const cli = require('cli-ux').default
+
+const getLogStreamer = require('./log_streamers')
+
+async function waitForBuildFinish(api, siteId, deployId, accessToken) {
+    let firstPass = true
+    let p = Promise.resolve()
+
+    if (deployId) {
+        let rej
+        p = new Promise((_, reject) => rej = reject)
+        const deployment = await api.getDeploy({ deploy_id: deployId })
+        const streamer = getLogStreamer(
+            {
+                ...deployment.log_access_attributes,
+                deployId: deployment.id,
+                buildId: deployment.build_id,
+                date: deployment.created_at,
+                resource: 'build',
+                accessToken: accessToken,
+            },
+            () => deployment.log_access_attributes,
+        )
+        streamer.listen(bit => console.log(bit && `${new Date(bit.ts || bit.time).toLocaleTimeString()}: ${bit.log}`), rej)
+    }
+
+    await Promise.race([p, pWaitFor(waitForBuildToFinish, {
+        interval: 1000,
+        timeout: 1.2e6, // 20 mins,
+        message: 'Timeout while waiting for deploy to finish'
+    })])
+
+    // return only when build done or timeout happens
+    return firstPass
+
+    async function waitForBuildToFinish() {
+        const builds = await api.listSiteBuilds({ siteId })
+        const currentBuilds = builds.filter(build => {
+            // build.error
+            return !build.done && (deployId ? build.deploy_id === deployId : true)
+        })
+
+        // if build.error
+        // @TODO implement build error messages into this
+
+        if (!currentBuilds || !currentBuilds.length) {
+            cli.action.stop()
+            return true
+        }
+        firstPass = false
+        return false
+    }
+}
+
+module.exports = {
+    waitForBuildFinish,
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/69
Fixes: https://github.com/netlify/cli/issues/119
Fixes: https://github.com/netlify/cli/issues/70
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Run `netlify deploy --trigger` in a project dir that is linked and has CI configured.
Run `netlify watch <deployId>` to watch logs for that deploy
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Import log streamers from app.netlify.com codebase
* Move `waitForBuildFinish` function out of `watch` command
* Use log streamers in `waitForBuildFinish` if `deployId` is provided
* Run `waitForBuildFinish` in `netlify deploy --trigger`
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐕