### PR TITLE
Dev: Pass .env vars as an object to child process

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -380,7 +380,15 @@ class DevCommand extends Command {
       const { addEnvVariables } = require('../../utils/dev')
       addonUrls = await addEnvVariables(api, site, accessToken)
     }
+
     process.env.NETLIFY_DEV = 'true'
+    // Override env variables with .env file
+    const envFile = path.resolve(site.root, '.env')
+    if (fs.existsSync(envFile)) {
+      const vars = dotenv.parse(fs.readFileSync(envFile)) || {}
+      console.log(`${NETLIFYDEVLOG} Overriding the following env variables with ${chalk.blue('.env')} file:`, chalk.yellow(Object.keys(vars)))
+      Object.entries(vars).forEach(([key, val]) => process.env[key] = val)
+    }
 
     let settings = await serverSettings(Object.assign({}, config.dev, flags))
 
@@ -419,14 +427,6 @@ class DevCommand extends Command {
       }
     }
     if (!settings.jwtRolePath) settings.jwtRolePath = 'app_metadata.authorization.roles'
-
-    // Override env variables with .env file
-    const envFile = path.resolve(site.root, '.env')
-    if (fs.existsSync(envFile)) {
-      const vars = dotenv.parse(fs.readFileSync(envFile)) || {}
-      console.log(`${NETLIFYDEVLOG} Overriding the following env variables with ${chalk.blue('.env')} file:`, chalk.yellow(Object.keys(vars)))
-      Object.entries(vars).forEach(([key, val]) => process.env[key] = val)
-    }
 
     startDevServer(settings, this.log)
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -338,7 +338,7 @@ function startDevServer(settings, log) {
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.type}`)
   const args = settings.command === 'npm' ? ['run', ...settings.args] : settings.args
   const ps = child_process.spawn(settings.command, args, {
-    env: { ...process.env, ...settings.env, FORCE_COLOR: 'true' },
+    env: { ...settings.env, FORCE_COLOR: 'true' },
     stdio: settings.stdio || 'inherit',
     detached: true,
     shell: true,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
This is to fix an inconsistency in NodeJS which results in `process.env` not realizing changes if they're accessed shortly after.
Fixes: https://github.com/netlify/cli/issues/747
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
* Have your `create-react-app` project connected to Netlify production with `netlify link`.
* Have some env variable in Netlify production
* Have a `.env` file in project root locally that overrides that env variable
* Run `netlify dev` and observe the value of that env variable

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Pass the variables from `.env` file as `setting.env` object to `startDevServer`, so that, they're set explicitly on the new process.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐳