### PR TITLE
Upgrade `zip-it-and-ship-it` and `js-client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,9 +1039,9 @@
       }
     },
     "@netlify/open-api": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.9.0.tgz",
-      "integrity": "sha512-9HpbxZX0LnU2IkaIYIjw6GCQZ6JMQ0Ai3F+9RrHr2jMAgXiiHRT19h2CiKEbjv44lYD5a0sRyV6kr+YRJVUQjg=="
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.2.tgz",
+      "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
     },
     "@netlify/run-utils": {
       "version": "0.1.0",
@@ -1076,31 +1076,62 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.3.1.tgz",
-      "integrity": "sha512-vLKxc1/Kvy7c0TL6AMr39/3SIweMkXZXkfU5nUtw1DSBVXaz9aYtiFLBX8YOblJXFFs3rpcyhzmzctoQsOnqVA==",
+      "version": "0.4.0-9",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-9.tgz",
+      "integrity": "sha512-93wYQiKEfBeLJS0iozCF9Uoe31tWMglnk+ozKV6ANPI8t4vUbFT5CEjUAV/gXGLFLPcQSJ25NXhi2vxgbJ4GKA==",
       "requires": {
         "archiver": "^3.0.0",
-        "cliclopts": "^1.1.1",
-        "debug": "^4.1.1",
+        "common-path-prefix": "^2.0.0",
+        "cp-file": "^7.0.0",
         "elf-tools": "^1.1.1",
+        "end-of-stream": "^1.4.1",
         "glob": "^7.1.3",
-        "minimist": "^1.2.0",
-        "npm-packlist": "^1.1.12",
-        "p-all": "^2.0.0",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "path-exists": "^4.0.0",
+        "pkg-dir": "^4.2.0",
         "precinct": "^6.1.1",
-        "read-pkg-up": "^4.0.0",
         "require-package-name": "^2.0.1",
-        "resolve": "^1.10.0"
+        "resolve": "^1.10.0",
+        "util.promisify": "^1.0.0",
+        "yargs": "^14.2.0"
       },
       "dependencies": {
-        "read-pkg-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -11029,12 +11060,12 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-3.0.0.tgz",
-      "integrity": "sha512-/D0Y8qSUggcpgW3XHkHIE0Pjd89Dl1PoxfptoqBnWpSSVKCsnfhhxmYkmIpBHILSzVT3wePJHO3yOnF5PpQSqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.0.tgz",
+      "integrity": "sha512-JZxkVN3XHhwrfrW8kOgmSmyXrIeXdl5BKEitVO3oI8WU2fVSHYdtZ+FiUaKkL6NnrnMEnGETa8E18mXD3RCiLA==",
       "requires": {
-        "@netlify/open-api": "^0.9.0",
-        "@netlify/zip-it-and-ship-it": "^0.3.1",
+        "@netlify/open-api": "^0.13.2",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-9",
         "backoff": "^2.5.0",
         "clean-deep": "^3.0.2",
         "flush-write-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@netlify/build": "^0.1.98",
     "@netlify/config": "^0.4.7",
-    "@netlify/zip-it-and-ship-it": "^0.3.1",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -117,7 +117,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
-    "netlify": "^3.0.0",
+    "netlify": "^4.0.0",
     "netlify-redirect-parser": "^2.3.0",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
This upgrades `zip-it-and-ship-it` to the latest version used inside Netlify Build.
This new version should be backward compatible, although it has not been tested with many real users yet.

This will ensure Netlify Build users are using consistent versions for `zip-it-and-ship-it` since that library is used separately by several projects: Netlify Build, Netlify CLI and the JavaScript client, which are requiring each other.

If there are issues in the beta version of `zip-it-and-ship-it`, it is better for us to catch those with local builds than with production builds.

This PR also upgrades to the latest major of the `js-client`. That major version only adds one thing: upgrading to the latest `zip-it-and-ship-it` as well (see https://github.com/netlify/js-client/pull/90). This PR put both upgrades together to ensure the same version of `zip-it-and-ship-it` is used whether used directly or through the `js-client`.

Before merging this, @RaeesBhatti are there any chances you could manually test it locally (anything related to Functions, such as deploying then, etc.)? Thanks a lot!