### PR TITLE
Upgrade `@netlify/build` and `@netlify/config`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -691,22 +691,21 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.98.tgz",
-      "integrity": "sha512-L1MKWEihvQO3rzTCChRRoZjyNyjZf3ucLPmlWgJTOju8Z24cEieY5Ixf2XNPJt8a6MOR9BLYeqIudAWKoHQefA==",
+      "version": "0.1.114",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.114.tgz",
+      "integrity": "sha512-l/L9JOtU+4iI7AqbTx00BRvfRlcbxurVI0oxeDR/k2DHt4En+eMFOu9ZwwCKEPIdMr5onG9GL2ymA1cxPE9MFw==",
       "requires": {
-        "@netlify/cache-utils": "^0.2.2",
-        "@netlify/config": "^0.4.7",
-        "@netlify/functions-utils": "^0.2.1",
-        "@netlify/git-utils": "^0.2.0",
-        "@netlify/run-utils": "^0.1.0",
+        "@netlify/cache-utils": "^0.2.6",
+        "@netlify/config": "^0.5.2",
+        "@netlify/functions-utils": "^0.2.3",
+        "@netlify/git-utils": "^0.2.2",
+        "@netlify/run-utils": "^0.1.1",
         "@netlify/zip-it-and-ship-it": "^0.4.0-9",
-        "analytics": "0.3.0",
+        "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "clean-stack": "^2.2.0",
         "execa": "^3.3.0",
-        "fast-glob": "^3.1.0",
         "figures": "^3.2.0",
         "filter-obj": "^2.0.1",
         "global-cache-dir": "^1.0.1",
@@ -719,94 +718,35 @@
         "locate-path": "^5.0.0",
         "log-process-errors": "^5.0.3",
         "map-obj": "^4.1.0",
-        "netlify": "^3.1.0",
-        "omit.js": "^1.0.2",
+        "netlify": "^4.0.0",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
+        "p-filter": "^2.1.0",
         "p-reduce": "^2.1.0",
         "path-exists": "^4.0.0",
         "pkg-dir": "^4.2.0",
         "read-pkg-up": "^7.0.1",
-        "readdirp": "^3.1.3",
+        "readdirp": "^3.4.0",
         "redact-env": "^0.2.0",
         "replacestream": "^4.0.3",
         "resolve": "^1.15.1",
+        "semver": "^7.1.3",
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "unixify": "^1.0.0",
-        "uuid": "^3.4.0",
-        "yargs": "^15.1.0"
+        "uuid": "^7.0.2",
+        "yargs": "^15.3.1",
+        "yarn": "^1.22.4"
       },
       "dependencies": {
-        "@netlify/open-api": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.2.tgz",
-          "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
-        },
-        "@netlify/zip-it-and-ship-it": {
-          "version": "0.4.0-9",
-          "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-9.tgz",
-          "integrity": "sha512-93wYQiKEfBeLJS0iozCF9Uoe31tWMglnk+ozKV6ANPI8t4vUbFT5CEjUAV/gXGLFLPcQSJ25NXhi2vxgbJ4GKA==",
-          "requires": {
-            "archiver": "^3.0.0",
-            "common-path-prefix": "^2.0.0",
-            "cp-file": "^7.0.0",
-            "elf-tools": "^1.1.1",
-            "end-of-stream": "^1.4.1",
-            "glob": "^7.1.3",
-            "make-dir": "^3.0.0",
-            "p-map": "^3.0.0",
-            "path-exists": "^4.0.0",
-            "pkg-dir": "^4.2.0",
-            "precinct": "^6.1.1",
-            "require-package-name": "^2.0.1",
-            "resolve": "^1.10.0",
-            "util.promisify": "^1.0.0",
-            "yargs": "^14.2.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "yargs": {
-              "version": "14.2.3",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-              "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-              "requires": {
-                "cliui": "^5.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^15.0.1"
-              }
-            }
-          }
-        },
         "@sindresorhus/is": {
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
           "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.2.1",
@@ -864,6 +804,15 @@
             "strip-final-newline": "^2.0.0"
           }
         },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
         "got": {
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -905,72 +854,6 @@
             "p-locate": "^4.1.0"
           }
         },
-        "netlify": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/netlify/-/netlify-3.1.0.tgz",
-          "integrity": "sha512-x+wDgjw2Kqthy/gBe5irb8Z8KpKcX8kZPtLJcWDYF7+kjRzYiFrcBXsyw9F92hBXt2WFoejYB1mBBhDFPF08hQ==",
-          "requires": {
-            "@netlify/open-api": "^0.13.0",
-            "@netlify/zip-it-and-ship-it": "^0.3.1",
-            "backoff": "^2.5.0",
-            "clean-deep": "^3.0.2",
-            "flush-write-stream": "^2.0.0",
-            "folder-walker": "^3.2.0",
-            "from2-array": "0.0.4",
-            "hasha": "^3.0.0",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.flatten": "^4.4.0",
-            "lodash.get": "^4.4.2",
-            "lodash.set": "^4.3.2",
-            "micro-api-client": "^3.3.0",
-            "node-fetch": "^2.2.0",
-            "omit.js": "^1.0.2",
-            "p-map": "^2.1.0",
-            "p-wait-for": "^2.0.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "qs": "^6.7.0",
-            "rimraf": "^2.6.3",
-            "tempy": "^0.2.1",
-            "through2-filter": "^3.0.0",
-            "through2-map": "^3.0.0"
-          },
-          "dependencies": {
-            "@netlify/zip-it-and-ship-it": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.3.1.tgz",
-              "integrity": "sha512-vLKxc1/Kvy7c0TL6AMr39/3SIweMkXZXkfU5nUtw1DSBVXaz9aYtiFLBX8YOblJXFFs3rpcyhzmzctoQsOnqVA==",
-              "requires": {
-                "archiver": "^3.0.0",
-                "cliclopts": "^1.1.1",
-                "debug": "^4.1.1",
-                "elf-tools": "^1.1.1",
-                "glob": "^7.1.3",
-                "minimist": "^1.2.0",
-                "npm-packlist": "^1.1.12",
-                "p-all": "^2.0.0",
-                "precinct": "^6.1.1",
-                "read-pkg-up": "^4.0.0",
-                "require-package-name": "^2.0.1",
-                "resolve": "^1.10.0"
-              }
-            },
-            "p-map": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-              "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-            },
-            "read-pkg-up": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-              "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^3.0.0"
-              }
-            }
-          }
-        },
         "p-cancelable": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -1000,6 +883,24 @@
             "lines-and-columns": "^1.1.6"
           }
         },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+            }
+          }
+        },
         "read-pkg-up": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
@@ -1008,44 +909,20 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            },
-            "read-pkg": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-              "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-              "requires": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^2.5.0",
-                "parse-json": "^5.0.0",
-                "type-fest": "^0.6.0"
-              },
-              "dependencies": {
-                "type-fest": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-                  "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
-                }
-              }
-            }
           }
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
           "requires": {
-            "glob": "^7.1.3"
+            "picomatch": "^2.2.1"
           }
+        },
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -1053,60 +930,70 @@
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
             "ansi-regex": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-            }
           }
         },
-        "tempy": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
-          "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
-          "requires": {
-            "temp-dir": "^1.0.0",
-            "unique-string": "^1.0.0"
-          }
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
         },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "yarn": {
+          "version": "1.22.4",
+          "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.4.tgz",
+          "integrity": "sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA=="
         }
       }
     },
     "@netlify/cache-utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.2.tgz",
-      "integrity": "sha512-wZMn77Xiao895lju6fLhH9z/ocnRV79rU8z1GqmnfFDPa1o7CKV3xGLQKkMDvUopHGJRMM3Op9sIP7aWSUmqdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.6.tgz",
+      "integrity": "sha512-fkJC/WSuFGMdTeUTqQ8yBA3+MZgEl5bmSNqs8DZ8fQtPrrD9t6Wy8iw+QN5lhqIFxLl2j2nDoPbjNeBxTwspWA==",
       "requires": {
+        "array-flat-polyfill": "^1.0.1",
         "cpy": "^8.0.0",
         "del": "^5.1.0",
         "get-stream": "^5.1.0",
         "global-cache-dir": "^1.0.1",
-        "junk": "^3.1.0",
+        "locate-path": "^5.0.0",
         "move-file": "^1.2.0",
-        "p-map": "^3.0.0",
         "path-exists": "^4.0.0",
-        "readdirp": "^3.3.0"
+        "readdirp": "^3.4.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        }
       }
     },
     "@netlify/config": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.7.tgz",
-      "integrity": "sha512-lIhI1HFUb4XSnEtoOZN2GDQ1l7UuzhD4ytaWM3AzlOUbkVNnkOpt1h5Yz5Q80Frf0ppj1iCVhfVvAjjNJLAugg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.5.2.tgz",
+      "integrity": "sha512-Um7+VQSuYEAZbQcIwvLgCNm5de8JuTdsCjUzALMk37+xgayqalv+aSUKxK18qal3SsHJcD3NI6qEJ9FsGdE8SQ==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",
-        "dot-prop": "^5.2.0",
         "execa": "^3.4.0",
         "filter-obj": "^2.0.1",
         "find-up": "^4.1.0",
@@ -1114,8 +1001,8 @@
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
         "map-obj": "^4.1.0",
-        "omit.js": "^1.0.2",
         "p-filter": "^2.1.0",
+        "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
         "toml": "^3.0.0",
         "yargs": "^15.3.0"
@@ -1194,18 +1081,18 @@
       }
     },
     "@netlify/functions-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.1.tgz",
-      "integrity": "sha512-uLNCkMZoOEMEqU24E9DKHE5JeFMqP7LJHjgcFPv9vyG57BIEuiePDeuvhUDl++79ViSmVs/dbQThlr7Jerebsw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.3.tgz",
+      "integrity": "sha512-gm7T8VmjG/TT8vCGdBgnONF1CzzC/2QLEY63PWDYmKI4bZXX9XDBpUjdfFgsV8G5Aq3dv20qVv7HNkl2GfzrjA==",
       "requires": {
         "cpy": "^8.0.0",
         "path-exists": "^4.0.0"
       }
     },
     "@netlify/git-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-0.2.0.tgz",
-      "integrity": "sha512-hdLPGAbSS1wtk/hUs0ed1Udr/l1itb9788yPV2MVwSwhMZ/M1DEKOJRVNSUORPrbkQtkltIzNITPaQV9PeTnQQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@netlify/git-utils/-/git-utils-0.2.2.tgz",
+      "integrity": "sha512-zN4CEkR77fVSWX0WsEIMyrxJs+nze/No25c9sHt3gIxQfCzOxv8gN9+0SYOhdwyFJe3J7mD4RfWl1yjv2yypXA==",
       "requires": {
         "execa": "^3.4.0",
         "map-obj": "^4.1.0",
@@ -1281,9 +1168,9 @@
       "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
     },
     "@netlify/run-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-0.1.0.tgz",
-      "integrity": "sha512-Rv37jYppU6rzdv1EpMvTJ0EhAT+2fYV9MaxbbQQlObslwlRlVr5+bjhXsoIzqflobRcoh6mxwKGWITXl8C7CfA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/run-utils/-/run-utils-0.1.1.tgz",
+      "integrity": "sha512-l22IcDO9nDPcPMjO4Up3+VpdKgXKoIASHg39nBlODC1jVGNopnSYrkpVqWwqM9VsatMxLvKdQ5k9yC2WJDs6+w==",
       "requires": {
         "execa": "^3.4.0"
       },
@@ -2226,9 +2113,9 @@
       }
     },
     "analytics": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/analytics/-/analytics-0.3.0.tgz",
-      "integrity": "sha512-z7zmmfLFnQZIdRFA6mFk8w+M3/kxrEAFHYYnJI4pO6S2n4JVuzMv6XyItACuIX12bGo2aJyvBZDFLEHjHYMvqw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/analytics/-/analytics-0.3.1.tgz",
+      "integrity": "sha512-3VYuQN8w12zQOlD3DaEswXcm1/trxwq6EGwkAuPIh4JOofxNgp5rv/CtM1CCKNlBf1UOP31dCXMLzTz+qOlaMA==",
       "requires": {
         "analytics-utils": "^0.1.2",
         "redux": "^3.6.0"
@@ -4564,11 +4451,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "cliclopts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-      "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
     },
     "cliui": {
       "version": "5.0.0",
@@ -10648,6 +10530,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
@@ -10658,7 +10541,8 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -11887,6 +11771,100 @@
       "integrity": "sha512-IIeEriUGmsS3VfiRQ3DwlRCozhzRDqNcoepAIIjj1II86smKq3Qkx18ly5acaruTozdtxA1/3ZwkR6rNbiNMuw==",
       "requires": {
         "@netlify/config": "^0.4.1"
+      },
+      "dependencies": {
+        "@netlify/config": {
+          "version": "0.4.12",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.4.12.tgz",
+          "integrity": "sha512-oqUUxO2uY3Kb6VS8JGB/sloKE9ZMmsabFPdxDcy8ed725URTF86AIRsGjFunktREwIMov9VL5BbTnAHMilqBig==",
+          "requires": {
+            "array-flat-polyfill": "^1.0.1",
+            "chalk": "^3.0.0",
+            "deepmerge": "^4.2.2",
+            "dot-prop": "^5.2.0",
+            "execa": "^3.4.0",
+            "filter-obj": "^2.0.1",
+            "find-up": "^4.1.0",
+            "indent-string": "^4.0.0",
+            "is-plain-obj": "^2.1.0",
+            "js-yaml": "^3.13.1",
+            "map-obj": "^4.1.0",
+            "p-filter": "^2.1.0",
+            "path-exists": "^4.0.0",
+            "toml": "^3.0.0",
+            "yargs": "^15.3.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "toml": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+          "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+        }
       }
     },
     "netlify-redirector": {
@@ -13572,9 +13550,9 @@
       }
     },
     "react-is": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read": {
       "version": "1.0.7",
@@ -13602,6 +13580,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
@@ -13891,7 +13870,8 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -15600,24 +15580,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
-    "unixify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
-      "requires": {
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -16476,9 +16438,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.98",
-    "@netlify/config": "^0.4.7",
+    "@netlify/build": "^0.1.114",
+    "@netlify/config": "^0.5.2",
     "@netlify/zip-it-and-ship-it": "^0.4.0-9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",


### PR DESCRIPTION
This upgrades `@netlify/build`. This should not be necessary since we use semver. However semver only works when users are updating their `package-lock.json`. Making a dummy new release of the CLI (which is essentially the goal of this PR) will update users lock files (if they upgrade Netlify CLI). 

This is important as part of the MVP, to make sure users get the same experience on Netlify CLI than in the UI.

Important: I could not update `package-lock.json` since Netlify CLI fails to install on my machine due to #769. Could someone not on Linux help me run `npm install` to update that file then push to this PR? Thanks!