### PR TITLE
Make `netlify build` visible

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -45,10 +45,8 @@ BuildCommand.flags = {
   })
 }
 
-BuildCommand.description = `Beta - Netlify build`
+BuildCommand.description = `(Beta) Build on your local machine`
 
 BuildCommand.examples = ['netlify build']
-
-BuildCommand.hidden = true
 
 module.exports = BuildCommand


### PR DESCRIPTION
Now that Netlify Build is officially in Beta, we should make the `netlify build` CLI command visible.

This also adjusts the command's description.