### PR TITLE
Do not pass `dry: false` option to `netlify build`

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -9,7 +9,7 @@ class BuildCommand extends Command {
 
     await this.config.runHook('analytics', {
       eventName: 'command',
-      payload: { command: 'build', dry: options.dry }
+      payload: { command: 'build', dry: Boolean(options.dry) }
     })
 
     const success = await build(options)
@@ -28,7 +28,7 @@ class BuildCommand extends Command {
     // `@netlify/build --cachedConfig`.
     const cachedConfigOption = JSON.stringify(cachedConfig)
     const {
-      flags: { dry = false }
+      flags: { dry }
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
     return { cachedConfig: cachedConfigOption, token, dry, siteId }


### PR DESCRIPTION
Currently `netlify build` passes the `dry: false` option unless it is set to `true` with the `--dry` CLI flag. We should instead pass `dry: undefined` to prevent the CLI flags from being unnecessarily logged.