### PR TITLE
Upgrade to latest `@netlify/build` and `@netlify/config`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -691,16 +691,16 @@
       }
     },
     "@netlify/build": {
-      "version": "0.1.114",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.1.114.tgz",
-      "integrity": "sha512-l/L9JOtU+4iI7AqbTx00BRvfRlcbxurVI0oxeDR/k2DHt4En+eMFOu9ZwwCKEPIdMr5onG9GL2ymA1cxPE9MFw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.2.2.tgz",
+      "integrity": "sha512-ZwglLcvgmsFyjDEfkDBKDaMy1/G4HCr0THqft/CBhXa/FnB0lA1DO48iHTkwtdTEEE3f4B8l6wKwnzsEYJHwpQ==",
       "requires": {
-        "@netlify/cache-utils": "^0.2.6",
-        "@netlify/config": "^0.5.2",
-        "@netlify/functions-utils": "^0.2.3",
+        "@netlify/cache-utils": "^0.2.8",
+        "@netlify/config": "^0.6.0",
+        "@netlify/functions-utils": "^0.2.4",
         "@netlify/git-utils": "^0.2.2",
         "@netlify/run-utils": "^0.1.1",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-9",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-11",
         "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -933,9 +933,9 @@
           }
         },
         "uuid": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         },
         "yarn": {
           "version": "1.22.4",
@@ -945,9 +945,9 @@
       }
     },
     "@netlify/cache-utils": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.6.tgz",
-      "integrity": "sha512-fkJC/WSuFGMdTeUTqQ8yBA3+MZgEl5bmSNqs8DZ8fQtPrrD9t6Wy8iw+QN5lhqIFxLl2j2nDoPbjNeBxTwspWA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.8.tgz",
+      "integrity": "sha512-gH04KLAnAs3HR/AGojWjFfvHbSSmypRZ7K7ca1r19agobjcH+IWrYLxHDcd1HtnvIpitWAYlT4YYGOajr1ywKg==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "cpy": "^8.0.0",
@@ -987,9 +987,9 @@
       }
     },
     "@netlify/config": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.5.2.tgz",
-      "integrity": "sha512-Um7+VQSuYEAZbQcIwvLgCNm5de8JuTdsCjUzALMk37+xgayqalv+aSUKxK18qal3SsHJcD3NI6qEJ9FsGdE8SQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.6.0.tgz",
+      "integrity": "sha512-0qTQUQF65zLpwih3Bc7ucIrweHZk0Qi4d3i2GT/Idt76VGCLoLmr2J5qPD6WdffgemtnNUjS7LUmeymKYeiRmg==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -1001,6 +1001,7 @@
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
         "map-obj": "^4.1.0",
+        "netlify": "^4.0.1",
         "p-filter": "^2.1.0",
         "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
@@ -1060,6 +1061,37 @@
             "p-locate": "^4.1.0"
           }
         },
+        "netlify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.1.tgz",
+          "integrity": "sha512-9UGQmUNOdgIlNNubj+yz1oghTzHf1OcRqEL+Wt4TgdFqQKwdRZYH2nDqAcLfM3MlibuXJKHNDgXuaHIM0R8BaQ==",
+          "requires": {
+            "@netlify/open-api": "^0.13.2",
+            "@netlify/zip-it-and-ship-it": "^0.4.0-9",
+            "backoff": "^2.5.0",
+            "clean-deep": "^3.0.2",
+            "filter-obj": "^2.0.1",
+            "flush-write-stream": "^2.0.0",
+            "folder-walker": "^3.2.0",
+            "from2-array": "0.0.4",
+            "hasha": "^3.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "micro-api-client": "^3.3.0",
+            "node-fetch": "^2.2.0",
+            "p-map": "^2.1.0",
+            "p-wait-for": "^2.0.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "qs": "^6.7.0",
+            "rimraf": "^2.6.3",
+            "tempy": "^0.2.1",
+            "through2-filter": "^3.0.0",
+            "through2-map": "^3.0.0"
+          }
+        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -1073,6 +1105,28 @@
             "p-limit": "^2.2.0"
           }
         },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "tempy": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+          "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+          "requires": {
+            "temp-dir": "^1.0.0",
+            "unique-string": "^1.0.0"
+          }
+        },
         "toml": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
@@ -1081,9 +1135,9 @@
       }
     },
     "@netlify/functions-utils": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.3.tgz",
-      "integrity": "sha512-gm7T8VmjG/TT8vCGdBgnONF1CzzC/2QLEY63PWDYmKI4bZXX9XDBpUjdfFgsV8G5Aq3dv20qVv7HNkl2GfzrjA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-0.2.4.tgz",
+      "integrity": "sha512-1Y1x/ywbrSMaqCWJo4XS4lEQmW8pqLtcMlWPZVFVNPnv0WmyA9zdJwk+5KciM/QA+dYVmW/szfwulBOWl+CHMA==",
       "requires": {
         "cpy": "^8.0.0",
         "path-exists": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -691,16 +691,16 @@
       }
     },
     "@netlify/build": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.2.2.tgz",
-      "integrity": "sha512-ZwglLcvgmsFyjDEfkDBKDaMy1/G4HCr0THqft/CBhXa/FnB0lA1DO48iHTkwtdTEEE3f4B8l6wKwnzsEYJHwpQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.2.3.tgz",
+      "integrity": "sha512-Y0Jhb2dInHSLK+SXWSbuiR8IcNvPSBeMxuOiZ5DfSDBGeeUqNj3OKnbwa2I3y9mjfWLk0xKWXg/6qQPKXMF7LQ==",
       "requires": {
         "@netlify/cache-utils": "^0.2.8",
         "@netlify/config": "^0.6.0",
         "@netlify/functions-utils": "^0.2.4",
         "@netlify/git-utils": "^0.2.2",
         "@netlify/run-utils": "^0.1.1",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-11",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-12",
         "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -718,7 +718,7 @@
         "locate-path": "^5.0.0",
         "log-process-errors": "^5.0.3",
         "map-obj": "^4.1.0",
-        "netlify": "^4.0.0",
+        "netlify": "^4.0.3",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
         "p-filter": "^2.1.0",
@@ -1254,64 +1254,25 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.4.0-11",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-11.tgz",
-      "integrity": "sha512-UUsTCOaIgByyZjGuMqnOe4372aYFGUCfGhLLHTjeo+chYhBJvBNt1vWp5DLzzQdGj3UPUM0seH3MmmwX+OK/EA==",
+      "version": "0.4.0-12",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-12.tgz",
+      "integrity": "sha512-SqcHuYAH69ArHwKS31N8Wz9yj9OiZmyTYZGI+SVz3jwnf5HMBjRDgeRi4dMNxM3xnpM2gsp9aLkAwlLx+xwKVQ==",
       "requires": {
         "archiver": "^3.0.0",
         "common-path-prefix": "^2.0.0",
         "cp-file": "^7.0.0",
         "elf-tools": "^1.1.1",
-        "end-of-stream": "^1.4.1",
-        "glob": "^7.1.3",
-        "make-dir": "^3.0.0",
+        "end-of-stream": "^1.4.4",
+        "glob": "^7.1.6",
+        "make-dir": "^3.0.2",
         "p-map": "^3.0.0",
         "path-exists": "^4.0.0",
         "pkg-dir": "^4.2.0",
-        "precinct": "^6.1.1",
+        "precinct": "^6.2.0",
         "require-package-name": "^2.0.1",
-        "resolve": "^1.10.0",
-        "util.promisify": "^1.0.0",
-        "yargs": "^14.2.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
+        "resolve": "^1.15.1",
+        "util.promisify": "^1.0.1",
+        "yargs": "^15.3.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -4501,6 +4462,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -4511,6 +4473,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -4521,6 +4484,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -11763,12 +11727,12 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.2.tgz",
-      "integrity": "sha512-aPurXKECyYLMFvNlk40L5/nwSerTM7zDW8eYBc5jqYKUVqewxzSTkntj3gJsYq2NStdS3CAjvCvBdqZ6KwuWvQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.3.tgz",
+      "integrity": "sha512-GScxFnxoJoV4k4IQHecuGwJSg+jiTu1l6SFPlyRwcZR1hAmNySNFmxHvDfjuLSj4tEdO3eF2Dt+LKK1a+4PsmA==",
       "requires": {
         "@netlify/open-api": "^0.13.2",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-11",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-12",
         "backoff": "^2.5.0",
         "clean-deep": "^3.0.2",
         "filter-obj": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.2.2",
+    "@netlify/build": "^0.2.3",
     "@netlify/config": "^0.6.0",
-    "@netlify/zip-it-and-ship-it": "^0.4.0-11",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-12",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -119,7 +119,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
-    "netlify": "^4.0.2",
+    "netlify": "^4.0.3",
     "netlify-redirect-parser": "^2.3.0",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.1.114",
-    "@netlify/config": "^0.5.2",
+    "@netlify/build": "^0.2.2",
+    "@netlify/config": "^0.6.0",
     "@netlify/zip-it-and-ship-it": "^0.4.0-11",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -19,19 +19,15 @@ class BuildCommand extends Command {
 
   // Retrieve Netlify Build options
   getOptions() {
-    const {
-      site: { id: siteId },
-      cachedConfig
-    } = this.netlify
     // We have already resolved the configuration using `@netlify/config`
     // This is stored as `this.netlify.cachedConfig` and can be passed to
     // `@netlify/build --cachedConfig`.
-    const cachedConfigOption = JSON.stringify(cachedConfig)
+    const cachedConfig = JSON.stringify(this.netlify.cachedConfig)
     const {
       flags: { dry }
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
-    return { cachedConfig: cachedConfigOption, token, dry, siteId }
+    return { cachedConfig, token, dry }
   }
 }
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -31,11 +31,11 @@ class BaseCommand extends Command {
 
     const [token] = this.getConfigToken(authViaFlag)
 
-    const cachedConfig = await this.getConfig(cwd, projectRoot)
-    const { configPath, config } = cachedConfig
-
     // Get site id & build state
     const state = new StateConfig(projectRoot)
+
+    const cachedConfig = await this.getConfig(cwd, projectRoot, state, token)
+    const { configPath, config } = cachedConfig
 
     const apiOpts = {}
     if (NETLIFY_API_URL) {
@@ -71,13 +71,15 @@ class BaseCommand extends Command {
   }
 
   // Find and resolve the Netlify configuration
-  async getConfig(cwd, projectRoot) {
+  async getConfig(cwd, projectRoot, state, token) {
     try {
       return await resolveConfig({
         config: argv.config,
         cwd: cwd,
         repositoryRoot: projectRoot,
-        context: argv.context
+        context: argv.context,
+        siteId: state.get('siteId'),
+        token
       })
     } catch (error) {
       const message = error.type === 'userError' ? error.message : error.stack


### PR DESCRIPTION
This upgrades to the latest version of `@netlify/build` and `@netlify/config`. This includes the breaking changes:
  - the `siteId` option is now passed to `@netlify/config` instead of `@netlify/build`
  - the `token` option must now be passed to `@netlify/config`

Those changes are due to the ongoing work on supporting UI build settings in local builds (https://github.com/netlify/build/issues/962).