### PR TITLE
fix: use path.sep in get-functions.test.js

### DIFF
--- a/src/utils/get-functions.test.js
+++ b/src/utils/get-functions.test.js
@@ -19,7 +19,7 @@ test('pass dummy repository with *.js files', t => {
   const f = getFunctions(sitePath)
   t.deepEqual(f, {
     index: {
-      functionPath: sitePath + '/index.js',
+      functionPath: sitePath + path.sep + 'index.js',
       moduleDir: findModuleDir(sitePath)
     }
   })


### PR DESCRIPTION
`src/utils/get-functions.js` uses `path.resolve`, meaning it returns `\\` on windows.
So it makes sense to use `path.*` methods or variables in tests, instead of hardcoded `/` separator (e.g. `/index.js` => path.sep + 'index.js')

fixes this test result

```
  utils » get-functions » pass dummy repository with *.js files

  C:\work\netlify-cli\src\utils\get-functions.test.js:20

   19:   const f = getFunctions(sitePath)
   20:   t.deepEqual(f, {
   21:     index: {

  Difference:

    {
      index: {
  -     functionPath: 'C:\\work\\netlify-cli\\src\\tests\\dummy-repo\\index.js',
  +     functionPath: 'C:\\work\\netlify-cli\\src\\tests\\dummy-repo/index.js',
        moduleDir: 'C:\\work\\netlify-cli',
      },
    }
```