### PR TITLE
Fix Netlify Go Functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,9 +1200,9 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.4.0-9",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-9.tgz",
-      "integrity": "sha512-93wYQiKEfBeLJS0iozCF9Uoe31tWMglnk+ozKV6ANPI8t4vUbFT5CEjUAV/gXGLFLPcQSJ25NXhi2vxgbJ4GKA==",
+      "version": "0.4.0-11",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-11.tgz",
+      "integrity": "sha512-UUsTCOaIgByyZjGuMqnOe4372aYFGUCfGhLLHTjeo+chYhBJvBNt1vWp5DLzzQdGj3UPUM0seH3MmmwX+OK/EA==",
       "requires": {
         "archiver": "^3.0.0",
         "common-path-prefix": "^2.0.0",
@@ -3532,15 +3532,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "backoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
@@ -4917,7 +4908,8 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -11717,14 +11709,15 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.0.tgz",
-      "integrity": "sha512-JZxkVN3XHhwrfrW8kOgmSmyXrIeXdl5BKEitVO3oI8WU2fVSHYdtZ+FiUaKkL6NnrnMEnGETa8E18mXD3RCiLA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.2.tgz",
+      "integrity": "sha512-aPurXKECyYLMFvNlk40L5/nwSerTM7zDW8eYBc5jqYKUVqewxzSTkntj3gJsYq2NStdS3CAjvCvBdqZ6KwuWvQ==",
       "requires": {
         "@netlify/open-api": "^0.13.2",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-9",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-11",
         "backoff": "^2.5.0",
         "clean-deep": "^3.0.2",
+        "filter-obj": "^2.0.1",
         "flush-write-stream": "^2.0.0",
         "folder-walker": "^3.2.0",
         "from2-array": "0.0.4",
@@ -11735,7 +11728,6 @@
         "lodash.set": "^4.3.2",
         "micro-api-client": "^3.3.0",
         "node-fetch": "^2.2.0",
-        "omit.js": "^1.0.2",
         "p-map": "^2.1.0",
         "p-wait-for": "^2.0.0",
         "parallel-transform": "^1.1.0",
@@ -12346,14 +12338,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
       "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
-    },
-    "omit.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
-      "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
-      "requires": {
-        "babel-runtime": "^6.23.0"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -13757,11 +13741,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@netlify/build": "^0.1.114",
     "@netlify/config": "^0.5.2",
-    "@netlify/zip-it-and-ship-it": "^0.4.0-9",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-11",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -119,7 +119,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
-    "netlify": "^4.0.0",
+    "netlify": "^4.0.2",
     "netlify-redirect-parser": "^2.3.0",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
Netlify Go Functions were broken. The new version of `zip-it-and-ship-it` is fixing it.

This PR upgrades to the latest version of `zip-it-and-ship-it`. The `js-client` uses it too and just made a patch release, included in this PR too.