### PR TITLE
Upgrade to latest version of Netlify Build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,16 +797,16 @@
       }
     },
     "@netlify/build": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.2.3.tgz",
-      "integrity": "sha512-Y0Jhb2dInHSLK+SXWSbuiR8IcNvPSBeMxuOiZ5DfSDBGeeUqNj3OKnbwa2I3y9mjfWLk0xKWXg/6qQPKXMF7LQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.2.5.tgz",
+      "integrity": "sha512-fRDo/2yEiow1AdlHRXxzFLbiUnns1OGqopb4gZFpfbOXtjFlj/xv2SscR6gDtNt5r85DtcoeXEF8S9kvsV6/Gw==",
       "requires": {
-        "@netlify/cache-utils": "^0.2.8",
-        "@netlify/config": "^0.6.0",
+        "@netlify/cache-utils": "^0.4.1",
+        "@netlify/config": "^0.9.0",
         "@netlify/functions-utils": "^0.2.4",
         "@netlify/git-utils": "^0.2.2",
         "@netlify/run-utils": "^0.1.1",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-12",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-13",
         "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -822,9 +822,9 @@
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
         "locate-path": "^5.0.0",
-        "log-process-errors": "^5.0.3",
+        "log-process-errors": "^5.1.1",
         "map-obj": "^4.1.0",
-        "netlify": "^4.0.3",
+        "netlify": "^4.0.4",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
         "p-filter": "^2.1.0",
@@ -839,6 +839,7 @@
         "semver": "^7.1.3",
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
+        "update-notifier": "^4.1.0",
         "uuid": "^7.0.2",
         "yargs": "^15.3.1",
         "yarn": "^1.22.4"
@@ -919,6 +920,14 @@
             "path-exists": "^4.0.0"
           }
         },
+        "global-dirs": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+          "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+          "requires": {
+            "ini": "^1.3.5"
+          }
+        },
         "got": {
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -952,6 +961,28 @@
           "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
           "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
+        "is-installed-globally": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+          "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+          "requires": {
+            "global-dirs": "^2.0.1",
+            "is-path-inside": "^3.0.1"
+          }
+        },
+        "is-npm": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+          "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
+        },
+        "latest-version": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+          "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+          "requires": {
+            "package-json": "^6.3.0"
+          }
+        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -976,6 +1007,24 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "requires": {
             "p-limit": "^2.2.0"
+          }
+        },
+        "package-json": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+          "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+          "requires": {
+            "got": "^9.6.0",
+            "registry-auth-token": "^4.0.0",
+            "registry-url": "^5.0.0",
+            "semver": "^6.2.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
           }
         },
         "parse-json": {
@@ -1025,10 +1074,41 @@
             "picomatch": "^2.2.1"
           }
         },
+        "registry-auth-token": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+          "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
+        "registry-url": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+          "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.1.tgz",
+          "integrity": "sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw=="
+        },
+        "semver-diff": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+          "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+          "requires": {
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -1036,6 +1116,26 @@
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
             "ansi-regex": "^5.0.0"
+          }
+        },
+        "update-notifier": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
+          "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+          "requires": {
+            "boxen": "^4.2.0",
+            "chalk": "^3.0.0",
+            "configstore": "^5.0.1",
+            "has-yarn": "^2.1.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.3.1",
+            "is-npm": "^4.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "pupa": "^2.0.1",
+            "semver-diff": "^3.1.1",
+            "xdg-basedir": "^4.0.0"
           }
         },
         "uuid": {
@@ -1051,9 +1151,9 @@
       }
     },
     "@netlify/cache-utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.2.8.tgz",
-      "integrity": "sha512-gH04KLAnAs3HR/AGojWjFfvHbSSmypRZ7K7ca1r19agobjcH+IWrYLxHDcd1HtnvIpitWAYlT4YYGOajr1ywKg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-0.4.1.tgz",
+      "integrity": "sha512-+l+g+3V8p7nuLLvFovmXR3gtwLy6MwTOWpfPfWOiHqmmKVcZcIEvH+m1X41lQd2UJMy9VpMXunDONDnzWhqiEQ==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "cpy": "^8.0.0",
@@ -1093,21 +1193,22 @@
       }
     },
     "@netlify/config": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.6.0.tgz",
-      "integrity": "sha512-0qTQUQF65zLpwih3Bc7ucIrweHZk0Qi4d3i2GT/Idt76VGCLoLmr2J5qPD6WdffgemtnNUjS7LUmeymKYeiRmg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.9.0.tgz",
+      "integrity": "sha512-0yzTnzzthXTfr8doEG0GNOw35tguPHyA8plWMRolihP95AjIzPgFAqIZ4mzoOnCx8piLfVtC/Nys7JhPnG3G+w==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",
         "execa": "^3.4.0",
+        "fast-safe-stringify": "^2.0.7",
         "filter-obj": "^2.0.1",
         "find-up": "^4.1.0",
         "indent-string": "^4.0.0",
         "is-plain-obj": "^2.1.0",
         "js-yaml": "^3.13.1",
         "map-obj": "^4.1.0",
-        "netlify": "^4.0.1",
+        "netlify": "^4.0.4",
         "p-filter": "^2.1.0",
         "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
@@ -1167,37 +1268,6 @@
             "p-locate": "^4.1.0"
           }
         },
-        "netlify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.1.tgz",
-          "integrity": "sha512-9UGQmUNOdgIlNNubj+yz1oghTzHf1OcRqEL+Wt4TgdFqQKwdRZYH2nDqAcLfM3MlibuXJKHNDgXuaHIM0R8BaQ==",
-          "requires": {
-            "@netlify/open-api": "^0.13.2",
-            "@netlify/zip-it-and-ship-it": "^0.4.0-9",
-            "backoff": "^2.5.0",
-            "clean-deep": "^3.0.2",
-            "filter-obj": "^2.0.1",
-            "flush-write-stream": "^2.0.0",
-            "folder-walker": "^3.2.0",
-            "from2-array": "0.0.4",
-            "hasha": "^3.0.0",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.flatten": "^4.4.0",
-            "lodash.get": "^4.4.2",
-            "lodash.set": "^4.3.2",
-            "micro-api-client": "^3.3.0",
-            "node-fetch": "^2.2.0",
-            "p-map": "^2.1.0",
-            "p-wait-for": "^2.0.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "qs": "^6.7.0",
-            "rimraf": "^2.6.3",
-            "tempy": "^0.2.1",
-            "through2-filter": "^3.0.0",
-            "through2-map": "^3.0.0"
-          }
-        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -1209,28 +1279,6 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "requires": {
             "p-limit": "^2.2.0"
-          }
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "tempy": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
-          "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
-          "requires": {
-            "temp-dir": "^1.0.0",
-            "unique-string": "^1.0.0"
           }
         },
         "toml": {
@@ -1360,9 +1408,9 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.4.0-12",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-12.tgz",
-      "integrity": "sha512-SqcHuYAH69ArHwKS31N8Wz9yj9OiZmyTYZGI+SVz3jwnf5HMBjRDgeRi4dMNxM3xnpM2gsp9aLkAwlLx+xwKVQ==",
+      "version": "0.4.0-13",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-13.tgz",
+      "integrity": "sha512-lisoSmrz+p52uMWCoNAgjWjA8GoYnfdlwysi0ZtmqwwlvrCM2hvPp6WanxXOixJs2kJv6XJYuJiVoSI0svW3sw==",
       "requires": {
         "archiver": "^3.0.0",
         "common-path-prefix": "^2.0.0",
@@ -1377,6 +1425,7 @@
         "precinct": "^6.2.0",
         "require-package-name": "^2.0.1",
         "resolve": "^1.15.1",
+        "unixify": "^1.0.0",
         "util.promisify": "^1.0.1",
         "yargs": "^15.3.1"
       }
@@ -6388,6 +6437,11 @@
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -9089,6 +9143,11 @@
         }
       }
     },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
+    },
     "hasha": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
@@ -10029,6 +10088,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -11001,9 +11065,9 @@
       "dev": true
     },
     "log-process-errors": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/log-process-errors/-/log-process-errors-5.0.3.tgz",
-      "integrity": "sha512-Ufq+Zf3ea/VoX7PXRJ163CLaqb6Fb4lNwUdH+nphCi7cqNfLwkkxJJPEHIZ7uNrskUmWPzA9h2YXT3AvbUXHkQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/log-process-errors/-/log-process-errors-5.1.1.tgz",
+      "integrity": "sha512-Eb90xoU3AC0XtIiMBF4J8SUNHt8sPZNz6GEsP7kn0gcfCD/tqp21i6yFzpRvOxBaWu6ySgSQNRc8FmEq+OG6Tg==",
       "requires": {
         "chalk": "^3.0.0-beta.2",
         "core-js": "^3.3.6",
@@ -11969,14 +12033,14 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.3.tgz",
-      "integrity": "sha512-GScxFnxoJoV4k4IQHecuGwJSg+jiTu1l6SFPlyRwcZR1hAmNySNFmxHvDfjuLSj4tEdO3eF2Dt+LKK1a+4PsmA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.4.tgz",
+      "integrity": "sha512-OyQdyLsuayicZShZv0xvYbpN3a1MoLvgVptK/xFW/yG3WjAIu5wLzTgSouShypJ/qgZ+zTT+oyTi4WwaP4poYw==",
       "requires": {
         "@netlify/open-api": "^0.13.2",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-12",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-13",
         "backoff": "^2.5.0",
-        "clean-deep": "^3.0.2",
+        "clean-deep": "^3.3.0",
         "filter-obj": "^2.0.1",
         "flush-write-stream": "^2.0.0",
         "folder-walker": "^3.2.0",
@@ -11988,38 +12052,37 @@
         "lodash.set": "^4.3.2",
         "micro-api-client": "^3.3.0",
         "node-fetch": "^2.2.0",
-        "p-map": "^2.1.0",
-        "p-wait-for": "^2.0.0",
+        "p-map": "^3.0.0",
+        "p-wait-for": "^3.1.0",
         "parallel-transform": "^1.1.0",
         "pump": "^3.0.0",
-        "qs": "^6.7.0",
-        "rimraf": "^2.6.3",
-        "tempy": "^0.2.1",
+        "qs": "^6.9.3",
+        "rimraf": "^3.0.2",
+        "tempy": "^0.3.0",
         "through2-filter": "^3.0.0",
         "through2-map": "^3.0.0"
       },
       "dependencies": {
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
           "requires": {
-            "glob": "^7.1.3"
+            "p-finally": "^1.0.0"
           }
         },
-        "tempy": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
-          "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+        "p-wait-for": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
+          "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
           "requires": {
-            "temp-dir": "^1.0.0",
-            "unique-string": "^1.0.0"
+            "p-timeout": "^3.0.0"
           }
+        },
+        "qs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
         }
       }
     },
@@ -13476,6 +13539,14 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pupa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
     "qqjs": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/qqjs/-/qqjs-0.3.11.tgz",
@@ -13654,7 +13725,8 @@
     "qs": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+      "dev": true
     },
     "query-string": {
       "version": "5.1.1",
@@ -14056,8 +14128,7 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -15268,7 +15339,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz",
       "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
-      "dev": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "type-fest": "^0.3.1",
@@ -15278,8 +15348,7 @@
         "type-fest": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-          "dev": true
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
         }
       }
     },
@@ -15765,6 +15834,24 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.2.3",
-    "@netlify/config": "^0.6.0",
-    "@netlify/zip-it-and-ship-it": "^0.4.0-12",
+    "@netlify/build": "^0.2.5",
+    "@netlify/config": "^0.9.0",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-13",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -119,7 +119,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.0",
-    "netlify": "^4.0.3",
+    "netlify": "^4.0.4",
     "netlify-redirect-parser": "^2.3.0",
     "netlify-redirector": "^0.1.0",
     "node-fetch": "^2.6.0",

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -27,7 +27,7 @@ class BuildCommand extends Command {
       flags: { dry }
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
-    return { cachedConfig, token, dry }
+    return { cachedConfig, token, dry, mode: 'cli' }
   }
 }
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -79,7 +79,8 @@ class BaseCommand extends Command {
         repositoryRoot: projectRoot,
         context: argv.context,
         siteId: state.get('siteId'),
-        token
+        token,
+        mode: 'cli'
       })
     } catch (error) {
       const message = error.type === 'userError' ? error.message : error.stack


### PR DESCRIPTION
This upgrades to the latest version of `@netlify/build`, `@netlify/config`, `netlify` and `@netlify/zip-it-and-ship-it`.

The Netlify CLI now passes a `--mode=cli` option so that Netlify Build can adapt some of its behavior depending on whether the build is run from the CLI or not.