### PR TITLE
Dev: Don't wait on functions port if no server

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -149,7 +149,7 @@ function initializeProxy(port, distDir, projectDir) {
   return handlers
 }
 
-async function startProxy(settings, addonUrls, configPath, projectDir) {
+async function startProxy(settings, addonUrls, configPath, projectDir, functionsDir) {
   try {
     await waitPort({ port: settings.proxyPort })
   } catch(err) {
@@ -158,7 +158,7 @@ async function startProxy(settings, addonUrls, configPath, projectDir) {
     this.exit(1)
   }
 
-  if (settings.functionsPort) {
+  if (functionsDir && settings.functionsPort) {
     await waitPort({ port: settings.functionsPort })
   }
   const functionsServer = settings.functionsPort ? `http://localhost:${settings.functionsPort}` : null
@@ -480,7 +480,7 @@ class DevCommand extends Command {
       })
     }
 
-    let { url, proxyPortUsed } = await startProxy(settings, addonUrls, site.configPath, site.root)
+    let { url, proxyPortUsed } = await startProxy(settings, addonUrls, site.configPath, site.root, functionsDir)
     if (!url) {
       throw new Error('Unable to start proxy server')
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/802
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Run `netlify dev` in a static project without functions directory specified or present.
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Check if a `functionsDir` is present before awaiting for functions server port.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🦄