### PR TITLE
Move --verbose flag to netlify version command

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -29,4 +29,4 @@ You do NOT have to include this information if this is a FEATURE REQUEST
 
 
 **- Local Environment Information**
-<!-- Paste the results of `netlify version` here -->
+<!-- Paste the results of `netlify version --verbose` here -->

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -3,27 +3,12 @@ const prettyjson = require('prettyjson')
 const get = require('lodash.get')
 const chalk = require('chalk')
 const clean = require('clean-deep')
-const envinfo = require('envinfo')
 const { flags } = require('@oclif/command')
 
 class StatusCommand extends Command {
   async run() {
     const { globalConfig, api, site } = this.netlify
     const { flags } = this.parse(StatusCommand)
-
-    if (flags.verbose) {
-      this.log()
-      this.log(`────────────────────┐
- Environment Info   │
-────────────────────┘`)
-      const data = await envinfo.run({
-        System: ['OS', 'CPU'],
-        Binaries: ['Node', 'Yarn', 'npm'],
-        Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-        npmGlobalPackages: ['netlify-cli']
-      })
-      this.log(data)
-    }
 
     const current = globalConfig.get('userId')
     const [accessToken] = this.getConfigToken()

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -1,3 +1,4 @@
+const envinfo = require('envinfo')
 const header = require('../utils/header')
 const globalConfig = require('../utils/global-config')
 const { track } = require('../utils/telemetry')
@@ -18,6 +19,20 @@ module.exports = async context => {
       force: true
     })
     process.exit() // eslint-disable-line
+  }
+
+  if (process.argv.length > 3 &&
+      ['-v', '--version', 'version'].includes(process.argv[2]) && process.argv[3] === '--verbose') {
+    console.log(`────────────────────┐
+ Environment Info   │
+────────────────────┘`)
+    const data = await envinfo.run({
+      System: ['OS', 'CPU'],
+      Binaries: ['Node', 'Yarn', 'npm'],
+      Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
+      npmGlobalPackages: ['netlify-cli']
+    })
+    console.log(data)
   }
 
   header(context)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
`netlify status` shows information about current signed-in user and their linked site which is private information. `--verbose` flag shows information about current system and installed `netlify-cli` package.
IMO it makes more sense to move it to `netlify version` command. This way users can paste results of `netlify version --verbose` and it will give us a complete picture of their environment without a possibility of accidentally logging private information.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
`netlify version --verbose`
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Move `--verbose` flag logs to `netlify version` command.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
