### PR TITLE
Don't rely on files on disk for redirects when working with SPA servers

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -189,7 +189,8 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
         publicFolder: settings.dist,
         functionsServer,
         functionsPort: settings.functionsPort,
-        jwtRolePath: settings.jwtRolePath
+        jwtRolePath: settings.jwtRolePath,
+        serverType: settings.type,
       }
 
       if (match) return serveRedirect(req, res, proxy, match, options)
@@ -275,7 +276,7 @@ function serveRedirect(req, res, proxy, match, options) {
     return render404(options.publicFolder)
   }
 
-  if (match.force || (notStatic(reqUrl.pathname, options.publicFolder) && match.status !== 404)) {
+  if (match.force || (!options.serverType && notStatic(reqUrl.pathname, options.publicFolder) && match.status !== 404)) {
     const dest = new url.URL(match.to, `${reqUrl.protocol}//${reqUrl.host}`)
     if (isRedirect(match)) {
       res.writeHead(match.status, {

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -169,7 +169,6 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
     publicFolder: settings.dist,
     jwtRole: settings.jwtRolePath,
     configPath,
-    noCmd: settings.noCmd,
   })
 
   const server = http.createServer(function(req, res) {

--- a/src/tests/dummy-site/netlify.toml
+++ b/src/tests/dummy-site/netlify.toml
@@ -5,12 +5,12 @@
   publish = "build"
   functions = "functions"
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
+  from = "/something"
+  to = "/ping"
   status = 200
   force = false
 [[redirects]]
-  from = "/something"
-  to = "/ping"
+  from = "/*"
+  to = "/index.html"
   status = 200
   force = false

--- a/src/tests/rules-proxy.test.js
+++ b/src/tests/rules-proxy.test.js
@@ -38,7 +38,14 @@ test('homepage rule', async t => {
   req.end()
 
   return new Promise((resolve, reject) => req.on('close', () => {
-    t.is(data.length, 0)
+    data = JSON.parse(data)
+    t.is(data.from, '/*')
+    t.is(data.to, '/index.html')
+    t.is(data.force, false)
+    t.is(data.host, '')
+    t.is(data.negative, false)
+    t.is(data.scheme, '')
+    t.is(data.status, 200)
     resolve()
   }))
 })

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -55,7 +55,7 @@ function getCountry(req) {
   return 'us'
 }
 
-module.exports = function({ publicFolder, baseFolder, jwtSecret, jwtRole, configPath, noCmd }) {
+module.exports = function({ publicFolder, baseFolder, jwtSecret, jwtRole, configPath }) {
   let matcher = null
   const projectDir = path.resolve(baseFolder || process.cwd())
   const configFiles = [
@@ -67,7 +67,6 @@ module.exports = function({ publicFolder, baseFolder, jwtSecret, jwtRole, config
 
   onChanges(configFiles, async () => {
     rules = await parseRules(configFiles)
-    if (!noCmd) rules = rules.filter(r => !(r.path === '/*' && r.to === '/index.html' && r.status === 200))
     matcher = null
   })
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/794
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
`netlify dev` in `create-react-app` project
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Don't filter out homepage rule for SPA servers
* Pass server type to redirector
* Don't check for static files for redirect rules if server type is present (meaning that it's not a static server)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
