### PR TITLE
Dev: Resolve command before spawning

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "update-notifier": "^2.5.0",
     "uuid": "^3.3.3",
     "wait-port": "^0.2.2",
+    "which": "^2.0.2",
     "winston": "^3.2.1",
     "wrap-ansi": "^6.0.0",
     "write-file-atomic": "^3.0.0"

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -8,6 +8,7 @@ const http = require('http')
 const httpProxy = require('http-proxy')
 const waitPort = require('wait-port')
 const getPort = require('get-port')
+const which = require('which')
 const chokidar = require('chokidar')
 const proxyMiddleware = require('http-proxy-middleware')
 const cookie = require('cookie')
@@ -320,7 +321,7 @@ function serveRedirect(req, res, proxy, match, options) {
   return proxy.web(req, res, options)
 }
 
-function startDevServer(settings, log) {
+async function startDevServer(settings, log) {
   if (settings.noCmd) {
     const StaticServer = require('static-server')
 
@@ -341,7 +342,7 @@ function startDevServer(settings, log) {
 
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.type}`)
   const args = settings.command === 'npm' ? ['run', ...settings.args] : settings.args
-  const ps = child_process.spawn(settings.command, args, {
+  const ps = child_process.spawn(await which(settings.command), args, {
     env: { ...settings.env, FORCE_COLOR: 'true' },
     stdio: settings.stdio || 'inherit',
     detached: true,
@@ -436,7 +437,7 @@ class DevCommand extends Command {
     }
     settings.port = port
 
-    startDevServer(settings, this.log)
+    await startDevServer(settings, this.log)
 
     // serve functions from zip-it-and-ship-it
     // env variables relies on `url`, careful moving this code


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Fix `netlify dev` on Windows. Use `which` package to resolve path for command before spawning it. Apparently, Windows doesn't allow spawning binaries without using full path.
Fixes: https://github.com/netlify/cli/issues/689

**- Test plan**
Run `netlify dev --offline` in this project: https://github.com/sw-yx/gatsby-netlify-form-example-v2
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Use `which` package to resolve path for command before spawning it.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐼 