### PR TITLE
Add tests for `netlify build`

### DIFF
--- a/src/tests/build.test.js
+++ b/src/tests/build.test.js
@@ -1,0 +1,48 @@
+const test = require('ava')
+const execa = require('execa')
+
+const BIN_PATH = `${__dirname}/../../bin/run`
+const FIXTURE_DIR = __dirname
+
+// Runs `netlify build ...flags` then verify:
+//  - its exit code is `exitCode`
+//  - that its output contains `output`
+// The command is run in the fixture directory `fixtureSubDir`.
+const runBuildCommand = async function(t, fixtureSubDir, { exitCode: expectedExitCode = 0, output, flags = [] } = {}) {
+  const { all, exitCode } = await execa(BIN_PATH, ['build', ...flags], {
+    reject: false,
+    cwd: `${FIXTURE_DIR}/${fixtureSubDir}`,
+    env: { FORCE_COLOR: '1' },
+    all: true
+  })
+  t.is(exitCode, expectedExitCode)
+  t.true(all.includes(output))
+}
+
+test('build command - succeeds', async t => {
+  await runBuildCommand(t, 'success-site', { output: 'testCommand' })
+})
+
+test('build command - fails', async t => {
+  await runBuildCommand(t, 'failure-site', { exitCode: 1, output: 'doesNotExist' })
+})
+
+test('build command - uses the CLI mode', async t => {
+  await runBuildCommand(t, 'success-site', { output: 'mode: cli' })
+})
+
+test('build command - can use the --dry flag', async t => {
+  await runBuildCommand(t, 'success-site', { flags: ['--dry'], output: 'If this looks good to you' })
+})
+
+test('build command - can use the --context flag', async t => {
+  await runBuildCommand(t, 'context-site', { flags: ['--context=staging'], output: 'testStaging' })
+})
+
+test('build command - can run in subdirectories', async t => {
+  await runBuildCommand(t, 'subdir-site/subdir', { output: 'testCommand' })
+})
+
+test('build command - wrong config', async t => {
+  await runBuildCommand(t, 'wrong-config-site', { exitCode: 1, output: 'Invalid syntax' })
+})

--- a/src/tests/context-site/netlify.toml
+++ b/src/tests/context-site/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+command = "echo testCommand"
+
+[context.staging]
+command = "echo testStaging"

--- a/src/tests/failure-site/netlify.toml
+++ b/src/tests/failure-site/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+command = "doesNotExist"

--- a/src/tests/subdir-site/netlify.toml
+++ b/src/tests/subdir-site/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+command = "echo testCommand"

--- a/src/tests/success-site/netlify.toml
+++ b/src/tests/success-site/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+command = "echo testCommand"

--- a/src/tests/wrong-config-site/netlify.toml
+++ b/src/tests/wrong-config-site/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+command = false


### PR DESCRIPTION
Fixes #835.

This adds tests for the `netlify build` command.

This only tests the integration between the Netlify CLI and `@netlify/build` and `@netlify/config`, since those already have their own tests in their respective repositories. 

The binary command is run (as opposed to importing the command programmatically) so that the tests are as close as possible to how users experience running this command.

Note: CI tests are failing due to other tests unrelated to this PR.