### PR TITLE
Parse headers and redirect rules on startup

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -118,7 +118,7 @@ function initializeProxy(port, distDir, projectDir) {
 
   let headerRules = headersFiles.reduce((prev, curr) => Object.assign(prev, parseHeadersFile(curr)), {})
   onChanges(headersFiles, () => {
-    console.log(`${NETLIFYDEVLOG} Reloading headers files`, headersFiles.map(p => path.relative(projectDir, p)))
+    console.log(`${NETLIFYDEVLOG} Reloading headers files`, headersFiles.filter(fs.existsSync).map(p => path.relative(projectDir, p)))
     headerRules = headersFiles.reduce((prev, curr) => Object.assign(prev, parseHeadersFile(curr)), {})
   })
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -116,7 +116,7 @@ function initializeProxy(port, distDir, projectDir) {
     path.resolve(distDir, '_headers'),
   ]))
 
-  let headerRules = {}
+  let headerRules = headersFiles.reduce((prev, curr) => Object.assign(prev, parseHeadersFile(curr)), {})
   onChanges(headersFiles, () => {
     console.log(`${NETLIFYDEVLOG} Reloading headers files`, headersFiles.map(p => path.relative(projectDir, p)))
     headerRules = headersFiles.reduce((prev, curr) => Object.assign(prev, parseHeadersFile(curr)), {})

--- a/src/tests/dev.test.js
+++ b/src/tests/dev.test.js
@@ -27,7 +27,7 @@ test.before(async t => {
 
         port = matches.pop()
         host = matches.pop()
-        setTimeout(resolve, process.platform === 'win32' ? 6000 : 2000)
+        resolve()
       }
     })
   })

--- a/src/tests/rules-proxy.test.js
+++ b/src/tests/rules-proxy.test.js
@@ -9,7 +9,7 @@ const sitePath = path.join(__dirname, 'dummy-site')
 const createRewriter = require('../utils/rules-proxy')
 
 test.before(async t => {
-  const rewriter = createRewriter({
+  const rewriter = await createRewriter({
     distDir: sitePath,
     projectDir: sitePath,
     configPath: path.join(sitePath, 'netlify.toml')

--- a/src/tests/rules-proxy.test.js
+++ b/src/tests/rules-proxy.test.js
@@ -22,7 +22,7 @@ test.before(async t => {
   t.context.port = port
   t.context.server = server
 
-  return new Promise(resolve => server.listen(port, () => setTimeout(resolve, process.platform === 'win32' ? 6000 : 2000)))
+  return server.listen(port)
 })
 
 test('homepage rule', async t => {

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -64,7 +64,7 @@ module.exports = async function createRewriter({ distDir, projectDir, jwtSecret,
       ]
         .concat(configPath ? path.resolve(configPath) : [])
     )
-  ).filter(f => f !== projectDir && fs.existsSync(f))
+  ).filter(f => f !== projectDir)
   let rules = await parseRules(configFiles)
 
   onChanges(configFiles, async () => {

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -68,7 +68,7 @@ module.exports = async function createRewriter({ distDir, projectDir, jwtSecret,
   let rules = await parseRules(configFiles)
 
   onChanges(configFiles, async () => {
-    console.log(`${NETLIFYDEVLOG} Reloading redirect rules from`, configFiles.map(p => path.relative(projectDir, p)))
+    console.log(`${NETLIFYDEVLOG} Reloading redirect rules from`, configFiles.filter(fs.existsSync).map(p => path.relative(projectDir, p)))
     rules = await parseRules(configFiles)
     matcher = null
   })

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -39,7 +39,6 @@ function onChanges(files, cb) {
   files.forEach(file => {
     const watcher = chokidar.watch(file)
     watcher.on('change', cb)
-    watcher.on('add', cb)
     watcher.on('unlink', cb)
   })
 }

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -55,7 +55,7 @@ function getCountry(req) {
   return 'us'
 }
 
-module.exports = function createRewriter({ distDir, projectDir, jwtSecret, jwtRole, configPath }) {
+module.exports = async function createRewriter({ distDir, projectDir, jwtSecret, jwtRole, configPath }) {
   let matcher = null
   const configFiles = Array.from(
     new Set(
@@ -66,7 +66,7 @@ module.exports = function createRewriter({ distDir, projectDir, jwtSecret, jwtRo
         .concat(configPath ? path.resolve(configPath) : [])
     )
   ).filter(f => f !== projectDir && fs.existsSync(f))
-  let rules = []
+  let rules = await parseRules(configFiles)
 
   onChanges(configFiles, async () => {
     console.log(`${NETLIFYDEVLOG} Reloading redirect rules from`, configFiles.map(p => path.relative(projectDir, p)))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Rules proxy needs some time before it can detect changes  t
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Sometimes `chokidar` can take some time before it triggers the `add`, `change` event (which is when we parse the config files) and that results in server running without the rules applied. This is especially prominent in Windows and causes the tests to fail.
Now, we're parsing the those files on startup and then adding `onChange` event callbacks.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
