### PR TITLE
Detect Server: Make sure "port" and 'targetPort" are not same

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -82,6 +82,9 @@ module.exports.serverSettings = async devConfig => {
     }
     if (devConfig.port) settings.port = devConfig.port
     if (devConfig.targetPort) {
+      if (devConfig.targetPort === devConfig.port) {
+        throw new Error('"port" and "targetPort" options cannot have same values. Please consult the documentation for more details: https://cli.netlify.com/netlify-dev#netlifytoml-dev-block')
+      }
       settings.proxyPort = devConfig.targetPort
       settings.urlRegexp = devConfig.urlRegexp || new RegExp(`(http://)([^:]+:)${devConfig.targetPort}(/)?`, 'g')
     }

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -87,6 +87,8 @@ module.exports.serverSettings = async devConfig => {
       }
       settings.proxyPort = devConfig.targetPort
       settings.urlRegexp = devConfig.urlRegexp || new RegExp(`(http://)([^:]+:)${devConfig.targetPort}(/)?`, 'g')
+    } else if (devConfig.port && devConfig.port === settings.proxyPort) {
+      throw new Error('The "port" option you specified conflicts with the port of your application. Please use a different value for "port"')
     }
     settings.dist = devConfig.publish || settings.dist // dont loudassign if they dont need it
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
We should throw an error if `port` and `targetPort` options are same.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Run `netlify dev -p 3000 --targetPort 3000`

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Throw an error if specified `port` conflicts with specified `targetPort`
* Throw an error if specified `port` conflicts with `proxyPort` provided by detector
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐑