### PR TITLE
Allow users to unlock deployments while deploying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9656,6 +9656,11 @@
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
       "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc="
     },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
+    "lodash.isobject": "^3.0.2",
     "lodash.merge": "^4.6.2",
     "lodash.pick": "^4.4.0",
     "lodash.sample": "^4.2.1",

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -34,7 +34,7 @@ class DeployCommand extends Command {
     })
 
     let siteId = flags.site || site.id
-    let siteData
+    let siteData = {}
     if (!siteId) {
       this.log("This folder isn't linked to a site yet")
       const NEW_SITE = '+  Create & configure a new site'

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -11,6 +11,7 @@ const logSymbols = require('log-symbols')
 const cliSpinnerNames = Object.keys(require('cli-spinners'))
 const randomItem = require('random-item')
 const inquirer = require('inquirer')
+const isObject = require('lodash.isobject')
 const SitesCreateCommand = require('./sites/create')
 const LinkCommand = require('./link')
 const { NETLIFYDEV } = require('../utils/logo')
@@ -168,6 +169,11 @@ class DeployCommand extends Command {
 
     let results
     try {
+      if (isObject(siteData.published_deploy) && siteData.published_deploy.locked) {
+        console.error(`Deployments are "locked" for fr=or this context. Please "Start auto publishing" from ${siteData.admin_url}/deploys`)
+        this.exit(1)
+      }
+
       if (deployToProduction) {
         this.log('Deploying to main site URL...')
       } else {

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -170,7 +170,7 @@ class DeployCommand extends Command {
     let results
     try {
       if (isObject(siteData.published_deploy) && siteData.published_deploy.locked) {
-        console.error(`Deployments are "locked" for fr=or this context. Please "Start auto publishing" from ${siteData.admin_url}/deploys`)
+        console.error(`Deployments are "locked" for this context. Please "Start auto publishing" from ${siteData.admin_url}/deploys`)
         this.exit(1)
       }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/182
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
* "Stop auto publishing" from https://app.netlify.com for your site
* Try `netlify deploy --prod`
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Add package `lodash.isobject`
* Show a prompt asking you if you want to unlock deployments for your site
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐼