### PR TITLE
Add `fail-fast: false` to CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,19 +2,19 @@ name: Testing for CLI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         node-version: [8.x, 10.x, 12.x, 13.x]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
@@ -25,5 +25,4 @@ jobs:
       - run: npm ci
       - run: npm test
         env:
-          CI: true
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
When one of the environments of the CI matrix fails, it is useful to let the others complete, so we know if the failure is related to a specific OS or Node.js version. This PR adds this.

It also applies Prettier, and removes `CI=true` from environment variables since GitHub actions just added [support for it](https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/).