### PR TITLE
Make sure `siteId` and `token` are defined with `netlify build`

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -6,6 +6,7 @@ class BuildCommand extends Command {
   // Run Netlify Build
   async run() {
     const options = this.getOptions()
+    this.checkOptions(options)
 
     await this.config.runHook('analytics', {
       eventName: 'command',
@@ -28,6 +29,19 @@ class BuildCommand extends Command {
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
     return { cachedConfig, token, dry, mode: 'cli' }
+  }
+
+  checkOptions({ cachedConfig, token }) {
+    const { siteInfo = {} } = JSON.parse(cachedConfig)
+    if (!siteInfo.id && process.env.NODE_ENV !== 'test') {
+      console.error('Could not find the site ID. Please run netlify link.')
+      this.exit(1)
+    }
+
+    if (!token) {
+      console.error('Could not find the access token. Please run netlify login.')
+      this.exit(1)
+    }
   }
 }
 

--- a/src/tests/build.test.js
+++ b/src/tests/build.test.js
@@ -8,11 +8,15 @@ const FIXTURE_DIR = __dirname
 //  - its exit code is `exitCode`
 //  - that its output contains `output`
 // The command is run in the fixture directory `fixtureSubDir`.
-const runBuildCommand = async function(t, fixtureSubDir, { exitCode: expectedExitCode = 0, output, flags = [] } = {}) {
+const runBuildCommand = async function(
+  t,
+  fixtureSubDir,
+  { exitCode: expectedExitCode = 0, output, flags = [], env } = {}
+) {
   const { all, exitCode } = await execa(BIN_PATH, ['build', ...flags], {
     reject: false,
     cwd: `${FIXTURE_DIR}/${fixtureSubDir}`,
-    env: { FORCE_COLOR: '1' },
+    env: { FORCE_COLOR: '1', NETLIFY_AUTH_TOKEN: 'test', ...env },
     all: true
   })
   t.is(exitCode, expectedExitCode)
@@ -45,4 +49,12 @@ test('build command - can run in subdirectories', async t => {
 
 test('build command - wrong config', async t => {
   await runBuildCommand(t, 'wrong-config-site', { exitCode: 1, output: 'Invalid syntax' })
+})
+
+test('build command - missing siteId', async t => {
+  await runBuildCommand(t, 'success-site', {
+    exitCode: 1,
+    output: 'Could not find the site ID',
+    env: { NODE_ENV: '' }
+  })
 })


### PR DESCRIPTION
`netlify build` calls the API to retrieve UI build settings, so the build behaves correctly. To do that, it requires `siteId` and `token` to be available. This PR adds validation that informs users what to do if those values are missing.