### PR TITLE
fix the dev server issue when proxy server returns 304 while redirect status is force set to 200

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -132,7 +132,12 @@ function initializeProxy(port, distDir, projectDir) {
     if (!isEmpty(pathHeaderRules)) {
       Object.entries(pathHeaderRules).forEach(([key, val]) => res.setHeader(key, val))
     }
-    res.writeHead(req.proxyOptions.status || proxyRes.statusCode, proxyRes.headers)
+    // leave 3xx redirects handling to browser
+    if (proxyRes.statusCode >= 300 && proxyRes.statusCode < 400) {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    } else {
+      res.writeHead(req.proxyOptions.status || proxyRes.statusCode, proxyRes.headers)
+    }
     proxyRes.on('data', function(data) {
       res.write(data)
     })


### PR DESCRIPTION
**- Summary**

currently if we have a redirect rule in netlify.toml with
force = true and status = 200
the response from proxy server will always be 200
this behavior is problematic when the proxy returns 304 with empty body
the browser will always render a blank page
the change proposed in this PR is to leave 3xx code back to the browser and never override

**- Test plan**

Before: Page Request return Status 200 with empty Body

<img width="1064" alt="Screen Shot 2020-04-27 at 1 43 26 PM" src="https://user-images.githubusercontent.com/666516/80403162-2756fd00-888d-11ea-92f0-1318e20c0bd7.png">
<img width="1064" alt="Screen Shot 2020-04-27 at 1 43 34 PM" src="https://user-images.githubusercontent.com/666516/80403171-2c1bb100-888d-11ea-8466-3fe217c96a60.png">

After: Page Request return Status 304

<img width="1062" alt="Screen Shot 2020-04-27 at 1 42 10 PM" src="https://user-images.githubusercontent.com/666516/80403223-48b7e900-888d-11ea-86c4-e3f9e9292663.png">


**- Description for the changelog**

when proxy server returns status code between 300 and 399, the return status will honor proxy server status instead of using the one designated in redirection rule.
