### PR TITLE
Upgrade `zip-it-and-ship-it`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -529,9 +529,9 @@
       }
     },
     "@netlify/build": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.4.4.tgz",
-      "integrity": "sha512-yqep78XiPDPKclWCv2voOG9OwYOwFRvtCSWKktnh0uhvlwxXUT21fUjJ2FyoNhQiLko6yf02ikvM1omXmbuO5w==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.4.5.tgz",
+      "integrity": "sha512-ojCZpwslFPDBsZRBRQ6JUVDiKKxS4baELG04l9uCE0yZgPpCPUzBapuIFYjltIiZP8kqX4Ip1iSi8XjvHi6yIg==",
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^0.4.1",
@@ -539,7 +539,7 @@
         "@netlify/functions-utils": "^0.2.4",
         "@netlify/git-utils": "^0.2.2",
         "@netlify/run-utils": "^0.1.1",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-14",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-15",
         "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -556,7 +556,7 @@
         "locate-path": "^5.0.0",
         "log-process-errors": "^5.1.2",
         "map-obj": "^4.1.0",
-        "netlify": "^4.0.5",
+        "netlify": "^4.1.1",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
         "p-filter": "^2.1.0",
@@ -856,9 +856,9 @@
       }
     },
     "@netlify/open-api": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.2.tgz",
-      "integrity": "sha512-OcA/IdyDv1JF4tsrb7sNu77otewa1G0mzBOcFOi9IL0CwAyGxQWolDptILFyrVQIbHban2b6l4LPFvdnVaF6bA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.3.tgz",
+      "integrity": "sha512-eke9J5vz+EJfdDonKpWxQpRBbvZC2Xolmo6shykHMCFyuYpvGbclefaPf+M8Pf+0oC9u50lr1EStSv2fwb44hA=="
     },
     "@netlify/run-utils": {
       "version": "0.1.1",
@@ -893,9 +893,9 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.4.0-14",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-14.tgz",
-      "integrity": "sha512-R27SCZr1UvPYyhKgvKnBOZLg+JVuzRf0zaqLRwCnRo8fcDcEaeB70flPs/BXK0m2QLGT9kk+sZhSBWJz8WqoNA==",
+      "version": "0.4.0-15",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-15.tgz",
+      "integrity": "sha512-B4EQu4ctjTFe8ZpXF/cEzNebwXpUBCcpTYPVqBk/Ki0IFdXa833o2T/ABHgRY4xZX5i/V+CCsZXj5K8Vrc7dhw==",
       "requires": {
         "archiver": "^3.0.0",
         "common-path-prefix": "^2.0.0",
@@ -10795,12 +10795,12 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.0.5.tgz",
-      "integrity": "sha512-UEo/yNCLh7VVpTIO2ZKxppjBlhIOnfVwWUDZ+BBTC6SCZD77U4WVjbgSvFYroqekjiBug/kjYGKTBPI+dp7gPQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.1.1.tgz",
+      "integrity": "sha512-0b0VSAWbvOFcDLIUwmPdRgwCsLe3j1iF+JRN8okbPnk5Hhg9MLHCgr/pURFKTxULnndUeycdUdIvBPR9tqUY6g==",
       "requires": {
         "@netlify/open-api": "^0.13.2",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-14",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-15",
         "backoff": "^2.5.0",
         "clean-deep": "^3.3.0",
         "filter-obj": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.4.4",
+    "@netlify/build": "^0.4.5",
     "@netlify/config": "^0.11.1",
-    "@netlify/zip-it-and-ship-it": "^0.4.0-14",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-15",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -117,7 +117,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.5",
-    "netlify": "^4.0.5",
+    "netlify": "^4.1.1",
     "netlify-redirect-parser": "^2.4.0",
     "netlify-redirector": "^0.2.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
This upgrades `zip-it-and-ship-it` to include some updates with Prisma: https://github.com/netlify/zip-it-and-ship-it/pull/100

The `js-client` and `@netlify/build` are updated too since they depend on `zip-it-and-ship-it` as well.