### PR TITLE
Fix for wrong function dir

### DIFF
--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -184,7 +184,7 @@ async function pickTemplate() {
 
 /* get functions dir (and make it if necessary) */
 function ensureFunctionDirExists(flags, config) {
-  const functionsDir = config.build && config.build.functions
+  const functionsDir = config.build && config.build.functionsSource
   if (!functionsDir) {
     this.log(`${NETLIFYDEVLOG} No functions folder specified in netlify.toml`)
     process.exit(1)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Currently,`netlify functions:create` is picking up the directory where built files need to be placed. `functionsSource` is the directory where source files are supposed to be.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
