### PR TITLE
Update syntax for functions:invoke --payload

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -107,7 +107,7 @@ $ netlify functions:invoke myfunction
 $ netlify functions:invoke --name myfunction
 $ netlify functions:invoke --name myfunction --identity
 $ netlify functions:invoke --name myfunction --no-identity
-$ netlify functions:invoke myfunction --payload "{"foo": 1}"
+$ netlify functions:invoke myfunction --payload '{"foo": 1}'
 $ netlify functions:invoke myfunction --querystring "foo=1
 $ netlify functions:invoke myfunction --payload "./pathTo.json"
 ```


### PR DESCRIPTION
As written, gives an empty object as the body of the received event. With the fix, will produce the desired result.

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Was trying to test lambda function invocations locally, would not work with documentation as written.

**- Test plan**

create a simple `testFunction`, expect a certain <payload>, attempt to pass that payload with `netlify functions:invoke testFunction --payload <payload>`

**- Description for the changelog**

Update documentation for CLI function invocation with --payload flag

**- A picture of a cute animal (not mandatory but encouraged)**
🐼