### PR TITLE
Improve error when cant connect to targetPort

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -156,13 +156,13 @@ function initializeProxy(port, distDir, projectDir) {
   return handlers
 }
 
-async function startProxy(settings, addonUrls, configPath, projectDir, functionsDir) {
+async function startProxy(settings, addonUrls, configPath, projectDir, functionsDir, exit) {
   try {
     await waitPort({ port: settings.proxyPort })
   } catch (err) {
-    console.error(NETLIFYDEVERR, `Netlify Dev doesn't know what port your site is running on.`)
-    console.error(NETLIFYDEVERR, `Please set --targetPort.`)
-    this.exit(1)
+    console.error(NETLIFYDEVERR, `Netlify Dev could not connect to localhost:${settings.port}.`)
+    console.error(NETLIFYDEVERR, `Please make sure your application server is running on port ${settings.port}`)
+    exit(1)
   }
 
   if (functionsDir && settings.functionsPort) {
@@ -457,7 +457,7 @@ class DevCommand extends Command {
       })
     }
 
-    let { url } = await startProxy(settings, addonUrls, site.configPath, site.root, settings.functions)
+    let { url } = await startProxy(settings, addonUrls, site.configPath, site.root, settings.functions, this.exit)
     if (!url) {
       throw new Error('Unable to start proxy server')
     }

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -161,7 +161,7 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
     await waitPort({ port: settings.proxyPort })
   } catch (err) {
     console.error(NETLIFYDEVERR, `Netlify Dev could not connect to localhost:${settings.port}.`)
-    console.error(NETLIFYDEVERR, `Please make sure your application server is running on port ${settings.port}`)
+    console.error(NETLIFYDEVERR, `Please make sure your framework server is running on port ${settings.port}`)
     exit(1)
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Related to https://github.com/netlify/cli/issues/898
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Update the log when can't connect to `targetPort`
* Make sure to exit correctly
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🦖