### PR TITLE
Internal only: Rename proxyPort to frameworkPort

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -158,7 +158,7 @@ function initializeProxy(port, distDir, projectDir) {
 
 async function startProxy(settings, addonUrls, configPath, projectDir, functionsDir) {
   try {
-    await waitPort({ port: settings.proxyPort })
+    await waitPort({ port: settings.frameworkPort })
   } catch (err) {
     console.error(NETLIFYDEVERR, `Netlify Dev doesn't know what port your site is running on.`)
     console.error(NETLIFYDEVERR, `Please set --targetPort.`)
@@ -170,7 +170,7 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
   }
   const functionsServer = settings.functionsPort ? `http://localhost:${settings.functionsPort}` : null
 
-  const proxy = initializeProxy(settings.proxyPort, settings.dist, projectDir)
+  const proxy = initializeProxy(settings.frameworkPort, settings.dist, projectDir)
 
   const rewriter = await createRewriter({
     distDir: settings.dist,
@@ -192,7 +192,7 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
       const options = {
         match,
         addonUrls,
-        target: `http://localhost:${settings.proxyPort}`,
+        target: `http://localhost:${settings.frameworkPort}`,
         publicFolder: settings.dist,
         functionsServer,
         functionsPort: settings.functionsPort,
@@ -340,14 +340,14 @@ async function startDevServer(settings, log) {
     const server = new StaticServer({
       rootPath: settings.dist,
       name: 'netlify-dev',
-      port: settings.proxyPort,
+      port: settings.frameworkPort,
       templates: {
         notFound: '404.html'
       }
     })
 
     server.start(function() {
-      log(`\n${NETLIFYDEVLOG} Server listening to`, settings.proxyPort)
+      log(`\n${NETLIFYDEVLOG} Server listening to`, settings.frameworkPort)
     })
     return
   }
@@ -463,7 +463,7 @@ class DevCommand extends Command {
     }
 
     if (flags.live) {
-      await waitPort({ port: settings.proxyPort })
+      await waitPort({ port: settings.frameworkPort })
       const liveSession = await createTunnel(site.id, accessToken, this.log)
       url = liveSession.session_url
       process.env.BASE_URL = url

--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -9,7 +9,7 @@
     framework: String, // e.g. gatsby, vue-cli
     command: String, // e.g. yarn, npm
     port: Number, // e.g. 8888
-    proxyPort: Number, // e.g. 3000
+    frameworkPort: Number, // e.g. 3000
     env: Object, // env variables, see examples
     possibleArgsArrs: [[String]], // e.g [['run develop]], so that the combined command is 'npm run develop', but we allow for multiple
     urlRegexp: RegExp, // see examples
@@ -53,7 +53,7 @@ module.exports = function() {
     framework: 'gitbook',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 4000,
+    frameworkPort: 4000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),

--- a/src/detectors/angular.js
+++ b/src/detectors/angular.js
@@ -23,7 +23,7 @@ module.exports = function() {
     framework: 'angular',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 4200,
+    frameworkPort: 4200,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4200}(/)?`, 'g'),

--- a/src/detectors/brunch.js
+++ b/src/detectors/brunch.js
@@ -16,7 +16,7 @@ module.exports = function() {
     framework: 'brunch',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3333,
+    frameworkPort: 3333,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3333}(/)?`, 'g'),

--- a/src/detectors/create-react-app.js
+++ b/src/detectors/create-react-app.js
@@ -25,7 +25,7 @@ module.exports = function() {
     framework: 'create-react-app',
     command: getYarnOrNPMCommand(),
     port: 8888, // the port that the Netlify Dev User will use
-    proxyPort: 3000, // the port that create-react-app normally outputs
+    frameworkPort: 3000, // the port that create-react-app normally outputs
     env: { ...process.env, BROWSER: 'none', PORT: 3000 },
     stdio: ['inherit', 'pipe', 'pipe'],
     possibleArgsArrs,

--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -16,7 +16,7 @@ module.exports = function() {
     framework: 'docusaurus',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3000,
+    frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/eleventy.js
+++ b/src/detectors/eleventy.js
@@ -11,7 +11,7 @@ module.exports = function() {
   return {
     framework: 'eleventy',
     port: 8888,
-    proxyPort: 8080,
+    frameworkPort: 8080,
     env: { ...process.env },
     command: 'npx',
     possibleArgsArrs: [['eleventy', '--serve', '--watch']],

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -23,7 +23,7 @@ module.exports = function() {
     framework: 'ember',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 4200,
+    frameworkPort: 4200,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4200}(/)?`, 'g'),

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -24,7 +24,7 @@ module.exports = function() {
     framework: 'expo',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 19006,
+    frameworkPort: 19006,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${19006}(/)?`, 'g'),

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -20,7 +20,7 @@ module.exports = function() {
     framework: 'gatsby',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8000,
+    frameworkPort: 8000,
     env: { ...process.env, GATSBY_LOGGER: 'yurnalist' },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8000}(/)?`, 'g'),

--- a/src/detectors/gridsome.js
+++ b/src/detectors/gridsome.js
@@ -16,7 +16,7 @@ module.exports = function() {
     framework: 'gridsome',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8080,
+    frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/hexo.js
+++ b/src/detectors/hexo.js
@@ -20,7 +20,7 @@ module.exports = function() {
     framework: 'hexo',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 4000,
+    frameworkPort: 4000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),

--- a/src/detectors/hugo.js
+++ b/src/detectors/hugo.js
@@ -8,7 +8,7 @@ module.exports = function() {
   return {
     framework: 'hugo',
     port: 8888,
-    proxyPort: 1313,
+    frameworkPort: 1313,
     env: { ...process.env },
     command: 'hugo',
     possibleArgsArrs: [['server', '-w']],

--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -8,7 +8,7 @@ module.exports = function() {
   return {
     framework: 'jekyll',
     port: 8888,
-    proxyPort: 4000,
+    frameworkPort: 4000,
     env: { ...process.env },
     command: 'bundle',
     possibleArgsArrs: [['exec', 'jekyll', 'serve', '-w']],

--- a/src/detectors/middleman.js
+++ b/src/detectors/middleman.js
@@ -8,7 +8,7 @@ module.exports = function() {
   return {
     framework: 'middleman',
     port: 8888,
-    proxyPort: 4567,
+    frameworkPort: 4567,
     env: { ...process.env },
     command: 'bundle',
     possibleArgsArrs: [['exec', 'middleman', 'server']],

--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -20,7 +20,7 @@ module.exports = function() {
     framework: 'next',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3000,
+    frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -22,7 +22,7 @@ module.exports = function() {
     framework: 'nuxt',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3000,
+    frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/parcel.js
+++ b/src/detectors/parcel.js
@@ -23,7 +23,7 @@ module.exports = function() {
     framework: 'parcel',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 1234,
+    frameworkPort: 1234,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${1234}(/)?`, 'g'),

--- a/src/detectors/phenomic.js
+++ b/src/detectors/phenomic.js
@@ -16,7 +16,7 @@ module.exports = function() {
     framework: 'phenomic',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3333,
+    frameworkPort: 3333,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3333}(/)?`, 'g'),

--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -23,7 +23,7 @@ module.exports = function() {
     framework: 'quasar-cli-v0.17',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8080,
+    frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -23,7 +23,7 @@ module.exports = function() {
     framework: 'quasar',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8081,
+    frameworkPort: 8081,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -20,7 +20,7 @@ module.exports = function() {
     framework: 'react-static',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3000,
+    frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -22,7 +22,7 @@ module.exports = function() {
     framework: 'sapper',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 3000,
+    frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/stencil.js
+++ b/src/detectors/stencil.js
@@ -20,7 +20,7 @@ module.exports = function() {
     framework: 'stencil',
     command: getYarnOrNPMCommand(),
     port: 8888, // the port that the Netlify Dev User will use
-    proxyPort: 3333, // the port that stencil normally outputs
+    frameworkPort: 3333, // the port that stencil normally outputs
     env: { ...process.env, BROWSER: 'none', PORT: 3000 },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -24,7 +24,7 @@ module.exports = function() {
     framework: 'svelte',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 5000,
+    frameworkPort: 5000,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${5000}(/)?`, 'g'),

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -22,7 +22,7 @@ module.exports = function() {
     framework: 'vue',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8080,
+    frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -22,7 +22,7 @@ module.exports = function() {
     framework: 'vuepress',
     command: getYarnOrNPMCommand(),
     port: 8888,
-    proxyPort: 8080,
+    frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -101,9 +101,9 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
     if (!settings.command) throw new Error('No "command" specified or detected. The "command" option is required to use "targetPort" option.')
     if (flags.dir) throw new Error('"targetPort" option cannot be used in conjunction with "dir" flag which is used to run a static server.')
 
-    settings.proxyPort = devConfig.targetPort
+    settings.frameworkPort = devConfig.targetPort
     settings.urlRegexp = devConfig.urlRegexp || new RegExp(`(http://)([^:]+:)${devConfig.targetPort}(/)?`, 'g')
-  } else if (devConfig.port && devConfig.port === settings.proxyPort) {
+  } else if (devConfig.port && devConfig.port === settings.frameworkPort) {
     throw new Error(
       'The "port" option you specified conflicts with the port of your application. Please use a different value for "port"'
     )
@@ -113,10 +113,10 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
     settings = await getStaticServerSettings(settings, flags, projectDir, log)
   }
 
-  if (!settings.proxyPort) throw new Error('No "targetPort" option specified or detected.')
+  if (!settings.frameworkPort) throw new Error('No "targetPort" option specified or detected.')
 
   settings.port = devConfig.port || settings.port
-  if (devConfig.port && devConfig.port === settings.proxyPort) {
+  if (devConfig.port && devConfig.port === settings.frameworkPort) {
     throw new Error('The "port" option you specified conflicts with the port of your application. Please use a different value for "port"')
   }
   const port = await getPort({ port: settings.port || 8888 })
@@ -152,7 +152,7 @@ async function getStaticServerSettings(settings, flags, projectDir, log) {
     env: { ...process.env },
     noCmd: true,
     port: 8888,
-    proxyPort: await getPort({ port: 3999 }),
+    frameworkPort: await getPort({ port: 3999 }),
     dist,
   }
 }

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -64,7 +64,7 @@ test('serverSettings: custom framework parameters', async t => {
   t.is(settings.command, devConfig.command.split(' ')[0])
   t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
   t.deepEqual(settings.env, env)
-  t.is(settings.targetPort, devConfig.proxyPort)
+  t.is(settings.targetPort, devConfig.frameworkPort)
   t.is(settings.dist, devConfig.publish)
 })
 
@@ -132,7 +132,7 @@ test('serverSettings: no config', async t => {
   t.is(settings.framework, undefined)
   t.is(settings.cmd, undefined)
   t.truthy(settings.port)
-  t.truthy(settings.proxyPort)
+  t.truthy(settings.frameworkPort)
   t.is(settings.noCmd, true)
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
This doesn't affect anything on the outside or any functionality. This is just to reduce confusion around different port names.

https://github.com/netlify/cli/issues/882
https://github.com/netlify/cli/issues/677
https://github.com/netlify/cli/issues/658
https://github.com/netlify/cli/pull/669
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
No changes to functionality
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
* Rename `proxyPort` to `frameworkPort` internally
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🦆