### PR TITLE
Dev: Dont add dots when waiting for port

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -158,7 +158,7 @@ function initializeProxy(port, distDir, projectDir) {
 
 async function startProxy(settings, addonUrls, configPath, projectDir, functionsDir, exit) {
   try {
-    await waitPort({ port: settings.frameworkPort })
+    await waitPort({ port: settings.frameworkPort, output: 'silent' })
   } catch (err) {
     console.error(NETLIFYDEVERR, `Netlify Dev could not connect to localhost:${settings.port}.`)
     console.error(NETLIFYDEVERR, `Please make sure your framework server is running on port ${settings.port}`)
@@ -166,7 +166,7 @@ async function startProxy(settings, addonUrls, configPath, projectDir, functions
   }
 
   if (functionsDir && settings.functionsPort) {
-    await waitPort({ port: settings.functionsPort })
+    await waitPort({ port: settings.functionsPort, output: 'silent' })
   }
   const functionsServer = settings.functionsPort ? `http://localhost:${settings.functionsPort}` : null
 
@@ -474,7 +474,7 @@ class DevCommand extends Command {
     }
 
     if (flags.live) {
-      await waitPort({ port: settings.frameworkPort })
+      await waitPort({ port: settings.frameworkPort, output: 'silent' })
       const liveSession = await createTunnel(site.id, accessToken, this.log)
       url = liveSession.session_url
       process.env.BASE_URL = url


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/903
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
`netlify dev` in Gatsby project should not add any `....` to terminal
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
Add `output: 'silent'` option to `waitPort` calls
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
🐝