### PR TITLE
fix: use named Octokit import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,7 @@ jobs:
       - run: npm ci --prefix tests/site-cra
       - run: npm test
         env:
+          # GitHub secrets are not available when running on PR from forks
+          # We set a flag so we can skip tests that access Netlify API
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}

--- a/src/utils/gh-auth.js
+++ b/src/utils/gh-auth.js
@@ -1,5 +1,5 @@
 // A simple ghauth inspired library for getting a personal access token
-const Octokit = require('@octokit/rest')
+const { Octokit }  = require('@octokit/rest')
 const inquirer = require('inquirer')
 const querystring = require('querystring')
 const get = require('lodash.get')

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -1,7 +1,7 @@
 const version = require('../../../package.json').version
 const os = require('os')
 const ghauth = require('../../utils/gh-auth')
-const Octokit = require('@octokit/rest')
+const { Octokit } = require('@octokit/rest')
 const parseGitRemote = require('parse-github-url')
 const inquirer = require('inquirer')
 const path = require('path')

--- a/tests/addons.test.js
+++ b/tests/addons.test.js
@@ -47,58 +47,60 @@ async function deleteAddon(name) {
   return await callCli(['addons:delete', name, '-f'])
 }
 
-test.before(async t => {
-  const accounts = await listAccounts()
-  t.is(Array.isArray(accounts), true)
-  t.truthy(accounts.length)
-
-  const account = accounts[0]
-
-  console.log('creating new site for tests: ' + siteName)
-  const siteId = await createSite(siteName, account.slug)
-  t.truthy(siteId != null)
-
-  execOptions.env.NETLIFY_SITE_ID = siteId
-})
-
-test.serial('netlify addons:list', async t => {
-  const regex = /No addons currently installed/
-  const cliResponse = await exec(cliPath, ['addons:list'], execOptions)
-  t.is(regex.test(cliResponse.stdout), true)
-})
-
-test.serial('netlify addons:list --json', async t => {
-  const cliResponse = await exec(cliPath, ['addons:list', '--json'], execOptions)
-  const json = JSON.parse(cliResponse.stdout)
-  t.is(Array.isArray(json), true)
-  t.is(json.length, 0)
-})
-
-test.serial('netlify addons:create demo', async t => {
-  const regex = /Add-on "demo" created/
-  const cliResponse = await exec(cliPath, ['addons:create', 'demo', '--TWILIO_ACCOUNT_SID', 'lol'], execOptions)
-  t.is(regex.test(cliResponse.stdout), true)
-})
-
-test.serial('After creation netlify addons:list --json', async t => {
-  const cliResponse = await exec(cliPath, ['addons:list', '--json'], execOptions)
-  const json = JSON.parse(cliResponse.stdout)
-  t.is(Array.isArray(json), true)
-  t.is(json.length, 1)
-  t.is(json[0].service_slug, 'demo')
-})
-
-test.serial('netlify addon:delete demo', async t => {
-  const regex = /Addon "demo" deleted/
-  const cliResponse = await deleteAddon('demo')
-  t.is(regex.test(cliResponse), true)
-})
-
-test.after('cleanup', async t => {
-  console.log('Performing cleanup')
-  // Run cleanup
-  await deleteAddon('demo')
-
-  console.log(`deleting test site "${siteName}". ${execOptions.env.NETLIFY_SITE_ID}`)
-  await exec(cliPath, ['sites:delete', execOptions.env.NETLIFY_SITE_ID, '--force'], execOptions)
-})
+if (process.env.IS_FORK !== 'true') {
+  test.before(async t => {
+    const accounts = await listAccounts()
+    t.is(Array.isArray(accounts), true)
+    t.truthy(accounts.length)
+  
+    const account = accounts[0]
+  
+    console.log('creating new site for tests: ' + siteName)
+    const siteId = await createSite(siteName, account.slug)
+    t.truthy(siteId != null)
+  
+    execOptions.env.NETLIFY_SITE_ID = siteId
+  })
+  
+  test.serial('netlify addons:list', async t => {
+    const regex = /No addons currently installed/
+    const cliResponse = await exec(cliPath, ['addons:list'], execOptions)
+    t.is(regex.test(cliResponse.stdout), true)
+  })
+  
+  test.serial('netlify addons:list --json', async t => {
+    const cliResponse = await exec(cliPath, ['addons:list', '--json'], execOptions)
+    const json = JSON.parse(cliResponse.stdout)
+    t.is(Array.isArray(json), true)
+    t.is(json.length, 0)
+  })
+  
+  test.serial('netlify addons:create demo', async t => {
+    const regex = /Add-on "demo" created/
+    const cliResponse = await exec(cliPath, ['addons:create', 'demo', '--TWILIO_ACCOUNT_SID', 'lol'], execOptions)
+    t.is(regex.test(cliResponse.stdout), true)
+  })
+  
+  test.serial('After creation netlify addons:list --json', async t => {
+    const cliResponse = await exec(cliPath, ['addons:list', '--json'], execOptions)
+    const json = JSON.parse(cliResponse.stdout)
+    t.is(Array.isArray(json), true)
+    t.is(json.length, 1)
+    t.is(json[0].service_slug, 'demo')
+  })
+  
+  test.serial('netlify addon:delete demo', async t => {
+    const regex = /Addon "demo" deleted/
+    const cliResponse = await deleteAddon('demo')
+    t.is(regex.test(cliResponse), true)
+  })
+  
+  test.after('cleanup', async t => {
+    console.log('Performing cleanup')
+    // Run cleanup
+    await deleteAddon('demo')
+  
+    console.log(`deleting test site "${siteName}". ${execOptions.env.NETLIFY_SITE_ID}`)
+    await exec(cliPath, ['sites:delete', execOptions.env.NETLIFY_SITE_ID, '--force'], execOptions)
+  })  
+}


### PR DESCRIPTION
**- Summary**

Octokit now uses named imports and prints a deprecation notice if you use the default import 

```
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```

this change swaps out to the named import to remove this deprecation notice