### PR TITLE
Upgrade Netlify Build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -467,30 +467,56 @@
       }
     },
     "@bugsnag/browser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.0.1.tgz",
-      "integrity": "sha512-UbgX17kMWOz43h4Cm9ZZDotxPWTQYd7LToSVBYVxsaI7RZCk3ci8r/ws1uoGwAsmuUfObcvQR2dYzAYRVer4EA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.1.0.tgz",
+      "integrity": "sha512-0CPzzX8Ctqbeq/GZudGQ+4blKUA5h4WqJBo1pqU8IHMQX+GRWiQKMgDxtv+t+OB8vhJxKLrH/x7DuU2o9ULjgQ==",
+      "requires": {
+        "@bugsnag/core": "^7.1.0"
+      }
+    },
+    "@bugsnag/core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.1.0.tgz",
+      "integrity": "sha512-NtExhEGBRZZRXk/J7JvfoqwcnD52ZJyeqAePNpnsYkxvlmqTaVC8YTWVoLdyXjFsqUoLRRWdYYM/+w5aNJnDFA==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^5.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
     },
     "@bugsnag/js": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.0.1.tgz",
-      "integrity": "sha512-tReGOFCDUG1kWCNQ9AvCkVHnL015wYYAsg4XGK1hkdUIUoJk7qL8kuDRjpIe7x3vtOYi12IxZbI9mnzGiK8AsA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.1.0.tgz",
+      "integrity": "sha512-dDIAplxMN0YgdD6dGNXoM0OJYwHT9U4SKTou1PzOkiwIbHj321N9nkkYjTwECDOHFX7QXV30xG7kojaE9yy/Cw==",
       "requires": {
-        "@bugsnag/browser": "^7.0.1",
-        "@bugsnag/node": "^7.0.1"
+        "@bugsnag/browser": "^7.1.0",
+        "@bugsnag/node": "^7.1.0"
       }
     },
     "@bugsnag/node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.0.1.tgz",
-      "integrity": "sha512-/TB0W2hCm1l0XAnUn58MJsRMTA+ti0/4fNU9sPpCMEJkfatnRzGCscpYOvbzSARTW1xG445HZkYeAeRome/v8w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.1.0.tgz",
+      "integrity": "sha512-ie0qJaxjdilLRJBR/qlFDVUlb54KWPl/VTr1eWhz09Ytr9RnzDTbnpOGvrkLYUD6cy6ecTzvZuuB4uvFTEv4jg==",
       "requires": {
+        "@bugsnag/core": "^7.1.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
         "pump": "^3.0.0",
         "stack-generator": "^2.0.3"
       }
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-5.0.0.tgz",
+      "integrity": "sha512-EdGnA7n2UmX9Z0e2tIU0biKz8tCgtjbY69KoyH3yiMzm7Q9sriIlN9bZjqhTOKzM0GdLSGrkyKWif08xWKyucA=="
     },
     "@concordance/react": {
       "version": "2.0.0",
@@ -529,17 +555,17 @@
       }
     },
     "@netlify/build": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-0.4.15.tgz",
-      "integrity": "sha512-qweaSCFrzw+Dcd5DL6DIY/4m+FqBElJEdd47MyfVDm0VTzaNuhCPseHTb+Nbxl9VMC2H49+7eFXoyiHeR+3NlQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-1.0.1.tgz",
+      "integrity": "sha512-sTUKKshq9lX/alq/nw0DsBwhA99fnyMU/0LwytnTEu/5rLk9UlqzZfNoiDfTlzuzL08YinsWRV8ioPdYAc3gCw==",
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^0.4.1",
-        "@netlify/config": "^0.11.2",
+        "@netlify/config": "^1.0.0",
         "@netlify/functions-utils": "^0.2.4",
         "@netlify/git-utils": "^0.2.2",
         "@netlify/run-utils": "^0.1.1",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-16",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-19",
         "analytics": "0.3.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
@@ -555,18 +581,18 @@
         "js-yaml": "^3.13.1",
         "locate-path": "^5.0.0",
         "log-process-errors": "^5.1.2",
+        "make-dir": "^3.0.2",
         "map-obj": "^4.1.0",
-        "netlify": "^4.1.2",
+        "netlify": "^4.1.7",
         "os-name": "^3.1.0",
         "p-event": "^4.1.0",
-        "p-filter": "^2.1.0",
         "p-reduce": "^2.1.0",
         "path-exists": "^4.0.0",
         "pkg-dir": "^4.2.0",
         "pretty-ms": "^6.0.1",
         "read-pkg-up": "^7.0.1",
         "readdirp": "^3.4.0",
-        "resolve": "^1.15.1",
+        "resolve": "^2.0.0-next.1",
         "semver": "^7.1.3",
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -642,6 +668,14 @@
             "type-fest": "^0.8.1"
           }
         },
+        "resolve": {
+          "version": "2.0.0-next.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.1.tgz",
+          "integrity": "sha512-ZGTmuLZAW++TDjgslfUMRZcv7kXHv8z0zwxvuRWOPjnqc56HVsn1lVaqsWOZeQ8MwiilPVJLrcPVKG909QsAfA==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -699,12 +733,11 @@
       }
     },
     "@netlify/config": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.11.5.tgz",
-      "integrity": "sha512-6OxKIeg9LqXvAm48YbWWZi8R6vGEPrBbNmRNqznP9Cxgdo0MR0Hzn5jalUkMXJtiJpzqsABDGuOU0ysEeFW9/Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-1.0.0.tgz",
+      "integrity": "sha512-s9MMtFor7QznwXIr4ibWnCC66SlXIdAy9Goz5HGNK8vxH807jS4M5AyqbVFpSjYaBpaZaoKiRqW+XlWtx1wQ1w==",
       "requires": {
         "array-flat-polyfill": "^1.0.1",
-        "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",
         "execa": "^3.4.0",
         "fast-safe-stringify": "^2.0.7",
@@ -712,9 +745,7 @@
         "find-up": "^4.1.0",
         "indent-string": "^4.0.0",
         "is-plain-obj": "^2.1.0",
-        "js-yaml": "^3.13.1",
-        "netlify": "^4.1.3",
-        "p-filter": "^2.1.0",
+        "netlify": "^4.1.7",
         "p-locate": "^4.1.0",
         "path-exists": "^4.0.0",
         "toml": "^3.0.0",
@@ -722,47 +753,6 @@
         "yargs": "^15.3.0"
       },
       "dependencies": {
-        "@netlify/zip-it-and-ship-it": {
-          "version": "0.4.0-17",
-          "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-17.tgz",
-          "integrity": "sha512-T7u9N7p1RUG4qj/68R8b91rbJsuVg0ebcbiz0PA9o/kFv2GmlrPYZthUg4vG25Z5TD1UtHzkwyV+arf8llsguw==",
-          "requires": {
-            "archiver": "^3.0.0",
-            "common-path-prefix": "^2.0.0",
-            "cp-file": "^7.0.0",
-            "elf-tools": "^1.1.1",
-            "end-of-stream": "^1.4.4",
-            "glob": "^7.1.6",
-            "make-dir": "^3.0.2",
-            "p-map": "^3.0.0",
-            "path-exists": "^4.0.0",
-            "pkg-dir": "^4.2.0",
-            "precinct": "^6.2.0",
-            "require-package-name": "^2.0.1",
-            "resolve": "^2.0.0-next.1",
-            "unixify": "^1.0.0",
-            "util.promisify": "^1.0.1",
-            "yargs": "^15.3.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "execa": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
@@ -789,72 +779,10 @@
             "path-exists": "^4.0.0"
           }
         },
-        "netlify": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.1.3.tgz",
-          "integrity": "sha512-aqPU5Jc07UPZdXOO/81aY200m8r1a30yFtK+iOWNybZWdoE5MXm8QRRX8zbJoncWcZ74J/IZxfm7Vn/C92yGHw==",
-          "requires": {
-            "@netlify/open-api": "^0.13.2",
-            "@netlify/zip-it-and-ship-it": "^0.4.0-17",
-            "backoff": "^2.5.0",
-            "clean-deep": "^3.3.0",
-            "filter-obj": "^2.0.1",
-            "flush-write-stream": "^2.0.0",
-            "folder-walker": "^3.2.0",
-            "from2-array": "0.0.4",
-            "hasha": "^3.0.0",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.flatten": "^4.4.0",
-            "lodash.get": "^4.4.2",
-            "lodash.set": "^4.3.2",
-            "micro-api-client": "^3.3.0",
-            "node-fetch": "^2.2.0",
-            "p-map": "^3.0.0",
-            "p-wait-for": "^3.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "qs": "^6.9.3",
-            "rimraf": "^3.0.2",
-            "tempy": "^0.3.0",
-            "through2-filter": "^3.0.0",
-            "through2-map": "^3.0.0"
-          }
-        },
         "p-finally": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
-        },
-        "p-timeout": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-          "requires": {
-            "p-finally": "^1.0.0"
-          },
-          "dependencies": {
-            "p-finally": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-            }
-          }
-        },
-        "p-wait-for": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
-          "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
-          "requires": {
-            "p-timeout": "^3.0.0"
-          }
-        },
-        "resolve": {
-          "version": "2.0.0-next.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.1.tgz",
-          "integrity": "sha512-ZGTmuLZAW++TDjgslfUMRZcv7kXHv8z0zwxvuRWOPjnqc56HVsn1lVaqsWOZeQ8MwiilPVJLrcPVKG909QsAfA==",
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
@@ -941,9 +869,9 @@
       }
     },
     "@netlify/open-api": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.13.4.tgz",
-      "integrity": "sha512-HMBKoBfAtW9NB1MoVxfNAQwrDg2hfQx9pYxwq1OdoPCc0tp7/vn5vzKs4uaa0ZFC0HxH04uThd5HGA9DGa1iew=="
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.15.0.tgz",
+      "integrity": "sha512-Nk1NswVrUtI7SDbyn/uvITYeIG5iukKlhsu/6fg4k1G5RMHqMDtVHy+2qcOhKmkf7Qc3ZkIKKd2mQfM6zg2cxw=="
     },
     "@netlify/run-utils": {
       "version": "0.1.1",
@@ -978,15 +906,16 @@
       }
     },
     "@netlify/zip-it-and-ship-it": {
-      "version": "0.4.0-16",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-16.tgz",
-      "integrity": "sha512-lZKzDhwfMpcjpDtZxbWv4IWowdAo7T9I1qa3UFKiQxD0MoZhvvqEmfVX7jX2dgZQtUsnlLwC1wYufiPLYSkDtg==",
+      "version": "0.4.0-19",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.4.0-19.tgz",
+      "integrity": "sha512-QjGw5d8iTa9JLqFzMJw2DPYAmG0q7mfZsahf5rPPCmdNty/HkmNTkSswgxuTX+BCXsfjCnfCGbVZbM+8crIT0w==",
       "requires": {
         "archiver": "^3.0.0",
         "common-path-prefix": "^2.0.0",
         "cp-file": "^7.0.0",
         "elf-tools": "^1.1.1",
         "end-of-stream": "^1.4.4",
+        "find-up": "^4.1.0",
         "glob": "^7.1.6",
         "make-dir": "^3.0.2",
         "p-map": "^3.0.0",
@@ -994,10 +923,30 @@
         "pkg-dir": "^4.2.0",
         "precinct": "^6.2.0",
         "require-package-name": "^2.0.1",
-        "resolve": "^1.15.1",
+        "resolve": "^2.0.0-next.1",
+        "semver": "^7.3.2",
         "unixify": "^1.0.0",
         "util.promisify": "^1.0.1",
         "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.1.tgz",
+          "integrity": "sha512-ZGTmuLZAW++TDjgslfUMRZcv7kXHv8z0zwxvuRWOPjnqc56HVsn1lVaqsWOZeQ8MwiilPVJLrcPVKG909QsAfA==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -1675,9 +1624,9 @@
       }
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
+      "integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
@@ -1688,9 +1637,9 @@
       }
     },
     "@types/istanbul-reports": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -1767,9 +1716,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.8",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
-      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+      "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -11019,9 +10968,9 @@
       }
     },
     "moize": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/moize/-/moize-5.4.5.tgz",
-      "integrity": "sha512-egVrEnY3/gI5KytczjGiXamFxZwy5xJcRFxON4TOsPQzux6JrpxE/KPkOVol1M2CyW+NXUFhTNI7T/R7TgzVpQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-5.4.6.tgz",
+      "integrity": "sha512-gvMOccupuKKD9Yzgda474o/RIl0EIUnCPuNLn9GPo71HJZPhWdzu/RYZQjYRheDMcuJfXifB9ttzAYCrkGKM0A==",
       "requires": {
         "fast-equals": "^1.6.0",
         "fast-stringify": "^1.1.0",
@@ -11156,12 +11105,12 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netlify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.1.2.tgz",
-      "integrity": "sha512-AVffs4QmFtDJFL47pbN7/f+gSC2PzozdXnQ3SjfnjRvwhAtxVuOSzcFik+pNuDSuHx7ud/92WYReETzKc/+FPQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/netlify/-/netlify-4.1.7.tgz",
+      "integrity": "sha512-MMI84bLb1QrkAadnNRvglcUbje+hJNQo3ZEUAYJSUiQ4QPpIp9cuayFtfJ/N/dYRPehNiH7B6ZbSZ9FfmpUyVA==",
       "requires": {
-        "@netlify/open-api": "^0.13.2",
-        "@netlify/zip-it-and-ship-it": "^0.4.0-16",
+        "@netlify/open-api": "^0.15.0",
+        "@netlify/zip-it-and-ship-it": "^0.4.0-19",
         "backoff": "^2.5.0",
         "clean-deep": "^3.3.0",
         "filter-obj": "^2.0.1",
@@ -11211,6 +11160,81 @@
       "requires": {
         "@netlify/config": "^0.11.5",
         "lodash.isplainobject": "^4.0.6"
+      },
+      "dependencies": {
+        "@netlify/config": {
+          "version": "0.11.11",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-0.11.11.tgz",
+          "integrity": "sha512-Z7yzbx5qCX2I5RLlNyo0MMQ6GKJc8o5Nej9yspCavjqgYlUS7VJfbeE67WNxC26FXwDUqq00zJ0MrCS0Un1YOw==",
+          "requires": {
+            "array-flat-polyfill": "^1.0.1",
+            "chalk": "^3.0.0",
+            "deepmerge": "^4.2.2",
+            "execa": "^3.4.0",
+            "fast-safe-stringify": "^2.0.7",
+            "filter-obj": "^2.0.1",
+            "find-up": "^4.1.0",
+            "indent-string": "^4.0.0",
+            "is-plain-obj": "^2.1.0",
+            "js-yaml": "^3.13.1",
+            "netlify": "^4.1.7",
+            "p-filter": "^2.1.0",
+            "p-locate": "^4.1.0",
+            "path-exists": "^4.0.0",
+            "toml": "^3.0.0",
+            "tomlify-j0.4": "^3.0.0",
+            "yargs": "^15.3.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+        }
       }
     },
     "netlify-redirector": {
@@ -15725,9 +15749,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "dependencies": {
-    "@netlify/build": "^0.4.15",
-    "@netlify/config": "^0.11.5",
-    "@netlify/zip-it-and-ship-it": "^0.4.0-16",
+    "@netlify/build": "^1.0.1",
+    "@netlify/config": "^1.0.0",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-19",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
     "@oclif/errors": "^1.1.2",
@@ -118,7 +118,7 @@
     "log-symbols": "^2.2.0",
     "make-dir": "^3.0.0",
     "minimist": "^1.2.5",
-    "netlify": "^4.1.2",
+    "netlify": "^4.1.7",
     "netlify-redirect-parser": "^2.5.0",
     "netlify-redirector": "^0.2.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
This upgrades `@netlify/build`, `@netlify/cli`, `@netlify/zip-it-and-ship-it` and the `js-client` to their latest versions.

This includes the breaking changes outlined in https://github.com/netlify/build/issues/1068, but those are good with `@netlify/cli`.