### PR TITLE
Fix CI tests failing

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -5,6 +5,7 @@ title: Netlify CLI build command
 # `build`
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
+
 (Beta) Build on your local machine
 
 **Usage**
@@ -15,14 +16,13 @@ netlify build
 
 **Flags**
 
-- `dry` (*boolean*) - Dry run: show instructions without running them
-- `context` (*option*) - Build context
+- `dry` (_boolean_) - Dry run: show instructions without running them
+- `context` (_option_) - Build context
 
 **Examples**
 
 ```bash
 netlify build
 ```
-
 
 <!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
CI tests are currently failing due to Prettier not having been run in a separate PR. This fixes this.