### PR TITLE
Fix checks for "command" and "dir" combination

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -15,7 +15,7 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
   if (flags.dir) {
     settings = await getStaticServerSettings(settings, flags, projectDir, log)
     ;['command', 'targetPort'].forEach(p => {
-      if (devConfig.hasOwnProperty(p)) {
+      if (flags[p]) {
         throw new Error(
           `"${p}" option cannot be used in conjunction with "dir" flag which is used to run a static server`
         )
@@ -96,7 +96,7 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
   if (settings.command === 'npm' && !['start', 'run'].includes(settings.args[0])) {
     settings.args.unshift('run')
   }
-  if (devConfig.command) {
+  if (!settings.noCmd && devConfig.command) {
     settings.command = assignLoudly(devConfig.command.split(/\s/)[0], settings.command || null, tellUser('command')) // if settings.command is empty, its bc no settings matched
     settings.args = assignLoudly(devConfig.command.split(/\s/).slice(1), [], tellUser('command')) // if settings.command is empty, its bc no settings matched
   }

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -113,7 +113,7 @@ test('serverSettings: "dir" flag', async t => {
 test('serverSettings: "dir" flag and "command" as config param', async t => {
   const devConfig = {
     framework: '#auto',
-    command: "npm start",
+    command: 'npm start',
     publish: path.join(sitePath, 'build'),
     functions: path.join(sitePath, 'functions'),
   }

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -110,17 +110,31 @@ test('serverSettings: "dir" flag', async t => {
   t.is(settings.noCmd, true)
 })
 
-test('serverSettings: "dir" flag with "targetPort"', async t => {
-  const devConfig = { framework: '#auto', targetPort: 1234, functions: path.join(sitePath, 'functions') }
+test('serverSettings: "dir" flag and "command" as config param', async t => {
+  const devConfig = {
+    framework: '#auto',
+    command: "npm start",
+    publish: path.join(sitePath, 'build'),
+    functions: path.join(sitePath, 'functions'),
+  }
   const flags = { dir: sitePath }
+  const settings = await serverSettings(devConfig, flags, sitePath, () => {})
+  t.is(settings.command, undefined)
+  t.is(settings.noCmd, true)
+  t.is(settings.dist, flags.dir)
+})
+
+test('serverSettings: "dir" and "targetPort" flags', async t => {
+  const devConfig = { framework: '#auto', functions: path.join(sitePath, 'functions') }
+  const flags = { dir: sitePath, targetPort: 1234 }
   await t.throwsAsync(async () => {
     await serverSettings(devConfig, flags, sitePath, () => {})
   }, /"targetPort" option cannot be used in conjunction with "dir" flag/)
 })
 
-test('serverSettings: "dir" flag with "command"', async t => {
-  const devConfig = { framework: '#auto', command: 'ding', functions: path.join(sitePath, 'functions') }
-  const flags = { dir: sitePath }
+test('serverSettings: "dir" and "command" flags', async t => {
+  const devConfig = { framework: '#auto', functions: path.join(sitePath, 'functions') }
+  const flags = { dir: sitePath, command: 'ding' }
   await t.throwsAsync(async () => {
     await serverSettings(devConfig, flags, sitePath, () => {})
   }, /"command" option cannot be used in conjunction with "dir" flag/)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Fixes: https://github.com/netlify/cli/issues/932
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
Tests added
* Have `command` in `netlify.toml` `[dev]` section
* Run `netlify dev --dir something`

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Check for `command` and `targetPort` options in `flags` rather than `[dev]` config when `dir` flag is set
* Make sure `command` is not set from config when `dir` flag is set


**- A picture of a cute animal (not mandatory but encouraged)**
🦥