### PR TITLE
Get functionsPort from devConfig

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -154,7 +154,7 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
   settings.port = port
 
   settings.jwtRolePath = devConfig.jwtRolePath || 'app_metadata.authorization.roles'
-  settings.functionsPort = await getPort({ port: settings.functionsPort || 0 })
+  settings.functionsPort = await getPort({ port: devConfig.functionsPort || 0 })
   settings.functions = devConfig.functions || settings.functions
 
   return settings


### PR DESCRIPTION
**- Summary**

In an app using react with webpack-dev-server I noticed the functionsPort option in dev config was being ignored, and apparently it was trying to set it from an undefined value and not from the dev config itself.

**- Test plan**

 * Have `functionsPort` in `netlify.toml [dev]` block.

Before:
![Screenshot from 2020-06-18 22-53-55](https://user-images.githubusercontent.com/5774777/85092034-d4c3fe00-b1b6-11ea-8256-7674207f1dbb.png)

After:

![Screenshot from 2020-06-18 22-54-59](https://user-images.githubusercontent.com/5774777/85092091-f0c79f80-b1b6-11ea-95f8-9a7b41749687.png)


**- Description for the changelog**

 * Get functionsPort config from the dev config block in `netlify.toml` 

**- A picture of a cute animal (not mandatory but encouraged)**

![doggos](https://i.redd.it/rschwdzq5q551.jpg)
