### PR TITLE
Add `--debug` CLI flag

### DIFF
--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -94,6 +94,7 @@ Add-ons are a way to extend the functionality of your Netlify site
 AddonsDeleteCommand.strict = false
 AddonsDeleteCommand.aliases = ['addon:delete']
 AddonsDeleteCommand.flags = {
+  ...AddonsDeleteCommand.flags,
   force: flags.boolean({
     char: 'f',
     description: 'delete without prompting (useful for CI)',

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -64,6 +64,7 @@ class AddonsListCommand extends Command {
 AddonsListCommand.description = `List currently installed add-ons for site`
 AddonsListCommand.aliases = ['addon:list']
 AddonsListCommand.flags = {
+  ...AddonsListCommand.flags,
   json: flags.boolean({
     description: 'Output add-on data as JSON',
   }),

--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -71,6 +71,7 @@ APICommand.args = [
 APICommand.examples = ['netlify api --list', 'netlify api getSite --data \'{ "site_id": "123456"}\'']
 
 APICommand.flags = {
+  ...APICommand.flags,
   data: oclif.flags.string({
     char: 'd',
     description: 'Data to use',

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -25,10 +25,10 @@ class BuildCommand extends Command {
     // `@netlify/build --cachedConfig`.
     const cachedConfig = JSON.stringify(this.netlify.cachedConfig)
     const {
-      flags: { dry },
+      flags: { dry, debug },
     } = this.parse(BuildCommand)
     const [token] = this.getConfigToken()
-    return { cachedConfig, token, dry, mode: 'cli' }
+    return { cachedConfig, token, dry, debug, mode: 'cli' }
   }
 
   checkOptions({ cachedConfig, token }) {
@@ -47,6 +47,7 @@ class BuildCommand extends Command {
 
 // Netlify Build programmatic options
 BuildCommand.flags = {
+  ...BuildCommand.flags,
   dry: flags.boolean({
     description: 'Dry run: show instructions without running them',
   }),

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -372,6 +372,7 @@ DeployCommand.examples = [
 ]
 
 DeployCommand.flags = {
+  ...DeployCommand.flags,
   dir: flags.string({
     char: 'd',
     description: 'Specify a folder to deploy',

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -553,6 +553,7 @@ DevCommand.examples = ['$ netlify dev', '$ netlify dev -c "yarn start"', '$ netl
 DevCommand.strict = false
 
 DevCommand.flags = {
+  ...DevCommand.flags,
   command: flags.string({
     char: 'c',
     description: 'command to run',

--- a/src/commands/functions/build.js
+++ b/src/commands/functions/build.js
@@ -59,6 +59,7 @@ FunctionsBuildCommand.description = `Build functions locally
 `
 FunctionsBuildCommand.aliases = ['function:build']
 FunctionsBuildCommand.flags = {
+  ...FunctionsBuildCommand.flags,
   functions: flags.string({
     char: 'f',
     description: 'Specify a functions folder to build to',

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -60,6 +60,7 @@ FunctionsCreateCommand.examples = [
 ]
 FunctionsCreateCommand.aliases = ['function:create']
 FunctionsCreateCommand.flags = {
+  ...FunctionsCreateCommand.flags,
   name: flags.string({ char: 'n', description: 'function name' }),
   url: flags.string({ char: 'u', description: 'pull template from URL' }),
 }

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -221,6 +221,7 @@ FunctionsInvokeCommand.args = [
 ]
 
 FunctionsInvokeCommand.flags = {
+  ...FunctionsInvokeCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'function name to invoke',

--- a/src/commands/functions/list.js
+++ b/src/commands/functions/list.js
@@ -94,6 +94,7 @@ NOT the same as listing the functions that have been deployed. For that info you
 `
 FunctionsListCommand.aliases = ['function:list']
 FunctionsListCommand.flags = {
+  ...FunctionsListCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'name to print',

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -242,6 +242,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
 InitCommand.description = `Configure continuous deployment for a new or existing site`
 
 InitCommand.flags = {
+  ...InitCommand.flags,
   manual: flags.boolean({
     char: 'm',
     description: 'Manually configure a git remote for CI',

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -113,6 +113,7 @@ LinkCommand.description = `Link a local repo or project folder to an existing si
 LinkCommand.examples = ['netlify link', 'netlify link --id 123-123-123-123', 'netlify link --name my-site-name']
 
 LinkCommand.flags = {
+  ...LinkCommand.flags,
   id: flags.string({
     description: 'ID of site to link to',
   }),

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -44,6 +44,7 @@ function msg(location) {
 }
 
 LoginCommand.flags = {
+  ...LoginCommand.flags,
   new: flags.boolean({
     description: 'Login to new Netlify account',
   }),

--- a/src/commands/open/index.js
+++ b/src/commands/open/index.js
@@ -29,6 +29,7 @@ class OpenCommand extends Command {
 }
 
 OpenCommand.flags = {
+  ...OpenCommand.flags,
   site: flags.boolean({
     description: 'Open site',
   }),

--- a/src/commands/sites/config.js
+++ b/src/commands/sites/config.js
@@ -22,6 +22,7 @@ Extra documentation goes here
 `
 
 SitesConfigCommand.flags = {
+  ...SitesConfigCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'name to print',

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -200,6 +200,7 @@ Create a blank site that isn't associated with any git remote.  Does not link to
 `
 
 SitesCreateCommand.flags = {
+  ...SitesCreateCommand.flags,
   'name': flags.string({
     char: 'n',
     description: 'name of site',

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -109,6 +109,7 @@ SitesDeleteCommand.args = [
 ]
 
 SitesDeleteCommand.flags = {
+  ...SitesDeleteCommand.flags,
   force: flags.boolean({
     char: 'f',
     description: 'delete without prompting (useful for CI)',

--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -78,6 +78,7 @@ Count: ${logSites.length}
 SitesListCommand.description = `List all sites you have access to`
 
 SitesListCommand.flags = {
+  ...SitesListCommand.flags,
   json: flags.boolean({
     description: 'Output site data as JSON',
   }),

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -108,6 +108,7 @@ class StatusCommand extends Command {
 StatusCommand.description = `Print status information`
 
 StatusCommand.flags = {
+  ...StatusCommand.flags,
   verbose: flags.boolean({
     description: 'Output system info',
   }),

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -1,4 +1,4 @@
-const { Command } = require('@oclif/command')
+const { Command, flags } = require('@oclif/command')
 const API = require('netlify')
 const merge = require('lodash.merge')
 const { format, inspect } = require('util')
@@ -78,6 +78,7 @@ class BaseCommand extends Command {
         cwd: cwd,
         repositoryRoot: projectRoot,
         context: argv.context,
+        debug: argv.debug,
         siteId: state.get('siteId'),
         token,
         mode: 'cli',
@@ -269,6 +270,12 @@ function getAuthArg(cliArgs) {
     return cliArgs.auth || cliArgs.a
   }
   return cliArgs.auth
+}
+
+BaseCommand.flags = {
+  debug: flags.boolean({
+    description: 'Print debugging information',
+  }),
 }
 
 module.exports = BaseCommand

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -49,6 +49,10 @@ test('build command - can use the --context flag', async t => {
   await runBuildCommand(t, 'context-site', { flags: ['--context=staging'], output: 'testStaging' })
 })
 
+test('build command - can use the --debug flag', async t => {
+  await runBuildCommand(t, 'success-site', { flags: ['--debug'], output: 'Resolved config' })
+})
+
 test('build command - can run in subdirectories', async t => {
   await runBuildCommand(t, 'subdir-site/subdir', { output: 'testCommand' })
 })


### PR DESCRIPTION
This adds a `--debug` CLI flag to all commands.

When enabled, this prints additional information in `@netlify/config` showing the configuration before and after resolution.
It also prints additional information inside `@netlify/build` when using `netlify build`.

This could prove very useful when debugging bug reports that might be configuration-related.

Instead of adding the flag to each command, this PR adds it to the base command, since all commands use `@netlify/config`.

This PR includes a test for this new flag.