### PR TITLE
fix: wait for chokidar ready event before listening to function builder src directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10048,8 +10048,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "is-docker": "^1.1.0",
     "jwt-decode": "^2.2.0",
     "lambda-local": "^1.7.1",
+    "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Fixes https://github.com/netlify/cli/issues/904

**- Test plan**

You can follow my comment [here](https://github.com/netlify/cli/issues/904#issuecomment-652421285) to reproduce

**- Description for the changelog**

[chokidar](https://github.com/paulmillr/chokidar) sends an initial `add` event for each existing file in the watched directory.
In the case of the bug, that event was fired for each file under `functions/node_modules` spawning multiple build commands.

You can ignore those initial events by waiting for the `ready` event or passing `ignoreInitial`:
https://github.com/paulmillr/chokidar#path-filtering

Also debounced the build command to make sure only one instance of it executes at a single point in time.

**- A picture of a cute animal (not mandatory but encouraged)**

🐈 
