### PR TITLE
Use base64 encoding for binary types

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -130,15 +130,13 @@ function createHandler(dir) {
     }
     const { functionPath } = functions[func]
 
-    const encoding = (request.headers["content-type"] || "").match(
+    const isBase64Encoded = !!(request.headers['content-type'] || '').match(
       /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/
-    )
-      ? "base64"
-      : "utf8";
+    );
 
-    const body = request.get('content-length') ? request.body.toString(encoding) : undefined
-    let isBase64Encoded = false
-    if (body) isBase64Encoded = Buffer.from(body, 'base64').toString('base64') === body
+    const body = request.get('content-length') ?
+      request.body.toString(isBase64Encoded ? 'base64' : 'utf8') :
+      undefined;
 
     let remoteAddress = request.get('x-forwarded-for') || request.connection.remoteAddress || ''
     remoteAddress = remoteAddress

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -132,11 +132,9 @@ function createHandler(dir) {
 
     const isBase64Encoded = !!(request.headers['content-type'] || '').match(
       /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/
-    );
+    )
 
-    const body = request.get('content-length') ?
-      request.body.toString(isBase64Encoded ? 'base64' : 'utf8') :
-      undefined;
+    const body = request.get('content-length') ? request.body.toString(isBase64Encoded ? 'base64' : 'utf8') : undefined
 
     let remoteAddress = request.get('x-forwarded-for') || request.connection.remoteAddress || ''
     remoteAddress = remoteAddress

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -130,7 +130,7 @@ function createHandler(dir) {
     }
     const { functionPath } = functions[func]
 
-    const isBase64Encoded = !!(request.headers['content-type'] || '').match(
+    const isBase64Encoded = !!(request.headers['content-type'] || '').toLowerCase().match(
       /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/
     )
 

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -130,7 +130,13 @@ function createHandler(dir) {
     }
     const { functionPath } = functions[func]
 
-    const body = request.get('content-length') ? request.body.toString() : undefined
+    const encoding = (request.headers["content-type"] || "").match(
+      /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/
+    )
+      ? "base64"
+      : "utf8";
+
+    const body = request.get('content-length') ? request.body.toString(encoding) : undefined
     let isBase64Encoded = false
     if (body) isBase64Encoded = Buffer.from(body, 'base64').toString('base64') === body
 

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -130,9 +130,9 @@ function createHandler(dir) {
     }
     const { functionPath } = functions[func]
 
-    const isBase64Encoded = !!(request.headers['content-type'] || '').toLowerCase().match(
-      /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/
-    )
+    const isBase64Encoded = !!(request.headers['content-type'] || '')
+      .toLowerCase()
+      .match(/image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/)
 
     const body = request.get('content-length') ? request.body.toString(isBase64Encoded ? 'base64' : 'utf8') : undefined
 


### PR DESCRIPTION
This might not be an exhaustive list of all the mimetypes we'll have to support, but it solves the problem I was running into (uploading images through a Netlify function locally using `netlify dev`)

**- Summary**

I've been trying to use a Netlify function as an image/file uploading proxy and running into problems, both locally using `netlify dev` and in production.

I managed to fix the problems in production after looking at [this thread](https://community.netlify.com/t/baffled-by-binary-event-body-in-lambda-function/17395). I believe this is something you're currently looking into.

Going over the `netlify-cli` code, I saw there was no way of changing the default 'utf8' decoding format for the request `body` Buffer, which won't work for binary data. As I say above, I'm unsure if there are any other mime-types we'll want to add to the list, I couldn't find a definitive list for this (if there is one). 

**- Test plan**

You can now upload images running `netlify dev` locally.

**- Description for the changelog**

Uses base64 encoding for `body` Buffers when the `content-type` suggests binary data.
