### PR TITLE
fixes #977 change request body validation

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -52,9 +52,11 @@ function createCallback(response) {
       )
       return handleErr('Incorrect function response statusCode', response)
     }
-    if (typeof lambdaResponse.body !== 'string') {
-      console.log(`${NETLIFYDEVERR} Your function response must have a string body. You gave:`, lambdaResponse.body)
-      return handleErr('Incorrect function response body', response)
+    if (lambdaResponse.body) {
+      if(typeof lambdaResponse.body !== 'string'){
+        console.log(`${NETLIFYDEVERR} Your function response must have a string body. You gave:`, lambdaResponse.body)
+        return handleErr('Incorrect function response body', response)
+      }
     }
 
     response.statusCode = lambdaResponse.statusCode

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -66,7 +66,9 @@ function createCallback(response) {
       const items = lambdaResponse.multiValueHeaders[key]
       response.setHeader(key, items)
     }
-    response.write(lambdaResponse.isBase64Encoded ? Buffer.from(lambdaResponse.body, 'base64') : lambdaResponse.body)
+    if (lambdaResponse.body) {
+      response.write(lambdaResponse.isBase64Encoded ? Buffer.from(lambdaResponse.body, 'base64') : lambdaResponse.body)
+    }
     response.end()
   }
 }

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -52,11 +52,9 @@ function createCallback(response) {
       )
       return handleErr('Incorrect function response statusCode', response)
     }
-    if (lambdaResponse.body) {
-      if(typeof lambdaResponse.body !== 'string'){
-        console.log(`${NETLIFYDEVERR} Your function response must have a string body. You gave:`, lambdaResponse.body)
-        return handleErr('Incorrect function response body', response)
-      }
+    if (lambdaResponse.body && typeof lambdaResponse.body !== 'string') {
+      console.log(`${NETLIFYDEVERR} Your function response must have a string body. You gave:`, lambdaResponse.body)
+      return handleErr('Incorrect function response body', response)
     }
 
     response.statusCode = lambdaResponse.statusCode

--- a/tests/dev.test.js
+++ b/tests/dev.test.js
@@ -105,6 +105,16 @@ test('functions rewrite echo with body', async t => {
   t.deepEqual(response.queryStringParameters, { ding: 'dong' })
 })
 
+test('functions: no body', async t => {
+  const response = await fetch(`http://${host}/api/no-body?ding=dong`, {
+    method: 'POST',
+    body: 'some=thing',
+  })
+
+  t.is(await response.text(), '')
+  t.is(response.status, 200)
+})
+
 test('functions rewrite echo with Form body', async t => {
   const form = new FormData()
   form.append('some', 'thing')

--- a/tests/dummy-site/functions/no-body.js
+++ b/tests/dummy-site/functions/no-body.js
@@ -1,0 +1,5 @@
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
This PR fixes #977 that occurred because [this line](https://github.com/netlify/cli/blob/16fc9342d5134b7add18a65923110810109d6375/src/utils/serve-functions.js#L55) only detects when the request body is a string type. It should process normally both for when it has no body(undefined) and the body is not string type. [Refer to this case.](https://community.netlify.com/t/i-got-function-invocation-failed-incorrect-function-response-body-error-from-lambda-function/17772)


<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
The reason I've edited this code is that I found this [code is actually from ZISI](https://github.com/netlify/netlify-dev-plugin/commit/27da1184d35f2ecc2f4c8af9fa3c74ea86009baf) and originally created in [Netlify lambda repo](https://github.com/netlify/netlify-lambda/commit/a528e439cc3fec6973d6b0eb097cb035b193a9cb) and I noticed that It has been maintained separately. So I thought that there could be a discrepancy between them. Looks like Dev plugin is the [latest version of `createCallback`](https://github.com/netlify/netlify-dev-plugin/commit/ff3e8a1cd85d64e0c5943d7d32bd3bf3973818b7) than [lambda's](https://github.com/netlify/netlify-lambda/commit/4bdcfcd05b72bdb85f83f6066a120c4d5ab842ab). Since the dev plugin has the issue. I've just decided to add one line of code instead of bringing the lambda's code. 
I've changed the code of local cli's code manually and sent a request without body(undefined).

![Screen Shot 2020-07-03 at 3 29 56 PM](https://user-images.githubusercontent.com/65737603/86494238-6ba9c200-bd42-11ea-8ed4-e6c7c9463540.png)


<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
This will check if the body is `undefined`.
```
+    if (lambdaResponse.body) {
+      if(typeof lambdaResponse.body !== 'string'){
+        console.log(`${NETLIFYDEVERR} Your function response must have a string body. You gave:`, lambdaResponse.body)
+        return handleErr('Incorrect function response body', response)
+      }
     }
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![funny-panda-aaj-agnieszkaajargiello](https://user-images.githubusercontent.com/65737603/86494366-d529d080-bd42-11ea-8477-71bf844a6809.jpg)
