### PR TITLE
Simplify `port` in Netlify Dev

### DIFF
--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -8,7 +8,6 @@
 {
     framework: String, // e.g. gatsby, vue-cli
     command: String, // e.g. yarn, npm
-    port: Number, // e.g. 8888
     frameworkPort: Number, // e.g. 3000
     env: Object, // env variables, see examples
     possibleArgsArrs: [[String]], // e.g [['run develop]], so that the combined command is 'npm run develop', but we allow for multiple
@@ -52,7 +51,6 @@ module.exports = function() {
   return {
     framework: 'gitbook',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 4000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/angular.js
+++ b/src/detectors/angular.js
@@ -22,7 +22,6 @@ module.exports = function() {
   return {
     framework: 'angular',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 4200,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/brunch.js
+++ b/src/detectors/brunch.js
@@ -15,7 +15,6 @@ module.exports = function() {
   return {
     framework: 'brunch',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3333,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/create-react-app.js
+++ b/src/detectors/create-react-app.js
@@ -24,7 +24,6 @@ module.exports = function() {
   return {
     framework: 'create-react-app',
     command: getYarnOrNPMCommand(),
-    port: 8888, // the port that the Netlify Dev User will use
     frameworkPort: 3000, // the port that create-react-app normally outputs
     env: { ...process.env, BROWSER: 'none', PORT: 3000 },
     stdio: ['inherit', 'pipe', 'pipe'],

--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -15,7 +15,6 @@ module.exports = function() {
   return {
     framework: 'docusaurus',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/eleventy.js
+++ b/src/detectors/eleventy.js
@@ -10,7 +10,6 @@ module.exports = function() {
 
   return {
     framework: 'eleventy',
-    port: 8888,
     frameworkPort: 8080,
     env: { ...process.env },
     command: 'npx',

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -22,7 +22,6 @@ module.exports = function() {
   return {
     framework: 'ember',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 4200,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -23,7 +23,6 @@ module.exports = function() {
   return {
     framework: 'expo',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 19006,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -19,7 +19,6 @@ module.exports = function() {
   return {
     framework: 'gatsby',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8000,
     env: { ...process.env, GATSBY_LOGGER: 'yurnalist' },
     possibleArgsArrs,

--- a/src/detectors/gridsome.js
+++ b/src/detectors/gridsome.js
@@ -15,7 +15,6 @@ module.exports = function() {
   return {
     framework: 'gridsome',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/hexo.js
+++ b/src/detectors/hexo.js
@@ -19,7 +19,6 @@ module.exports = function() {
   return {
     framework: 'hexo',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 4000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/hugo.js
+++ b/src/detectors/hugo.js
@@ -7,7 +7,6 @@ module.exports = function() {
 
   return {
     framework: 'hugo',
-    port: 8888,
     frameworkPort: 1313,
     env: { ...process.env },
     command: 'hugo',

--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -7,7 +7,6 @@ module.exports = function() {
 
   return {
     framework: 'jekyll',
-    port: 8888,
     frameworkPort: 4000,
     env: { ...process.env },
     command: 'bundle',

--- a/src/detectors/middleman.js
+++ b/src/detectors/middleman.js
@@ -7,7 +7,6 @@ module.exports = function() {
 
   return {
     framework: 'middleman',
-    port: 8888,
     frameworkPort: 4567,
     env: { ...process.env },
     command: 'bundle',

--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -19,7 +19,6 @@ module.exports = function() {
   return {
     framework: 'next',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -21,7 +21,6 @@ module.exports = function() {
   return {
     framework: 'nuxt',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/parcel.js
+++ b/src/detectors/parcel.js
@@ -22,7 +22,6 @@ module.exports = function() {
   return {
     framework: 'parcel',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 1234,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/phenomic.js
+++ b/src/detectors/phenomic.js
@@ -15,7 +15,6 @@ module.exports = function() {
   return {
     framework: 'phenomic',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3333,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -22,7 +22,6 @@ module.exports = function() {
   return {
     framework: 'quasar-cli-v0.17',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -22,7 +22,6 @@ module.exports = function() {
   return {
     framework: 'quasar',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8081,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -19,7 +19,6 @@ module.exports = function() {
   return {
     framework: 'react-static',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -21,7 +21,6 @@ module.exports = function() {
   return {
     framework: 'sapper',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 3000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/stencil.js
+++ b/src/detectors/stencil.js
@@ -19,7 +19,6 @@ module.exports = function() {
   return {
     framework: 'stencil',
     command: getYarnOrNPMCommand(),
-    port: 8888, // the port that the Netlify Dev User will use
     frameworkPort: 3333, // the port that stencil normally outputs
     env: { ...process.env, BROWSER: 'none', PORT: 3000 },
     possibleArgsArrs,

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -23,7 +23,6 @@ module.exports = function() {
   return {
     framework: 'svelte',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 5000,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -21,7 +21,6 @@ module.exports = function() {
   return {
     framework: 'vue',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -21,7 +21,6 @@ module.exports = function() {
   return {
     framework: 'vuepress',
     command: getYarnOrNPMCommand(),
-    port: 8888,
     frameworkPort: 8080,
     env: { ...process.env },
     possibleArgsArrs,

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -144,17 +144,16 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
     throw new Error('Invalid "port" option specified. The value of "port" option must be an integer')
   }
 
-  settings.port = devConfig.port || settings.port
   if (devConfig.port && devConfig.port === settings.frameworkPort) {
     throw new Error(
       'The "port" option you specified conflicts with the port of your application. Please use a different value for "port"'
     )
   }
-  const port = await getPort({ port: settings.port || 8888 })
-  if (port !== settings.port && devConfig.port) {
-    throw new Error(`Could not acquire required "port": ${settings.port}`)
+  const triedPort = devConfig.port || DEFAULT_PORT
+  settings.port = await getPort({ port: triedPort })
+  if (triedPort !== settings.port && devConfig.port) {
+    throw new Error(`Could not acquire required "port": ${triedPort}`)
   }
-  settings.port = port
 
   settings.jwtRolePath = devConfig.jwtRolePath || 'app_metadata.authorization.roles'
   settings.functionsPort = await getPort({ port: settings.functionsPort || 0 })
@@ -162,6 +161,8 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
 
   return settings
 }
+
+const DEFAULT_PORT = 8888
 
 async function getStaticServerSettings(settings, flags, projectDir, log) {
   let dist = settings.dist
@@ -182,7 +183,6 @@ async function getStaticServerSettings(settings, flags, projectDir, log) {
   return {
     env: { ...process.env },
     noCmd: true,
-    port: 8888,
     frameworkPort: await getPort({ port: 3999 }),
     dist,
   }


### PR DESCRIPTION
Netlify Dev `settings.port` is always `8888` (before `getPort()` is called to see if the port is available), no matter how Netlify Dev was called, and no matter which detector was picked.

This PR simplifies the logic by making it a single constant instead.