### PR TITLE
Simplify Netlify Dev detectors `env`

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -398,7 +398,7 @@ async function startDevServer(settings, log) {
     throw err
   })
   const ps = child_process.spawn(commandBin, settings.args, {
-    env: { ...settings.env, FORCE_COLOR: 'true' },
+    env: { ...process.env, ...settings.env, FORCE_COLOR: 'true' },
     stdio: 'pipe',
   })
 

--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -54,7 +54,7 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 4000,
-    env: { ...process.env },
+    env: { NAME: 'value' },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),
     dist: 'public',

--- a/src/detectors/angular.js
+++ b/src/detectors/angular.js
@@ -24,7 +24,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 4200,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4200}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/brunch.js
+++ b/src/detectors/brunch.js
@@ -17,7 +17,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3333,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3333}(/)?`, 'g'),
     dist: 'app/assets',

--- a/src/detectors/create-react-app.js
+++ b/src/detectors/create-react-app.js
@@ -26,7 +26,7 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888, // the port that the Netlify Dev User will use
     frameworkPort: 3000, // the port that create-react-app normally outputs
-    env: { ...process.env, BROWSER: 'none', PORT: 3000 },
+    env: { BROWSER: 'none', PORT: 3000 },
     stdio: ['inherit', 'pipe', 'pipe'],
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),

--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -17,7 +17,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'static',

--- a/src/detectors/eleventy.js
+++ b/src/detectors/eleventy.js
@@ -12,7 +12,6 @@ module.exports = function() {
     framework: 'eleventy',
     port: 8888,
     frameworkPort: 8080,
-    env: { ...process.env },
     command: 'npx',
     possibleArgsArrs: [['eleventy', '--serve', '--watch']],
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -24,7 +24,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 4200,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4200}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -25,7 +25,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 19006,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${19006}(/)?`, 'g'),
     dist: 'web-build',

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -21,7 +21,7 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8000,
-    env: { ...process.env, GATSBY_LOGGER: 'yurnalist' },
+    env: { GATSBY_LOGGER: 'yurnalist' },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8000}(/)?`, 'g'),
     dist: 'public',

--- a/src/detectors/gridsome.js
+++ b/src/detectors/gridsome.js
@@ -17,7 +17,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8080,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/hexo.js
+++ b/src/detectors/hexo.js
@@ -21,7 +21,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 4000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),
     dist: 'public',

--- a/src/detectors/hugo.js
+++ b/src/detectors/hugo.js
@@ -9,7 +9,6 @@ module.exports = function() {
     framework: 'hugo',
     port: 8888,
     frameworkPort: 1313,
-    env: { ...process.env },
     command: 'hugo',
     possibleArgsArrs: [['server', '-w']],
     urlRegexp: new RegExp(`(http://)([^:]+:)${1313}(/)?`, 'g'),

--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -9,7 +9,6 @@ module.exports = function() {
     framework: 'jekyll',
     port: 8888,
     frameworkPort: 4000,
-    env: { ...process.env },
     command: 'bundle',
     possibleArgsArrs: [['exec', 'jekyll', 'serve', '-w']],
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),

--- a/src/detectors/middleman.js
+++ b/src/detectors/middleman.js
@@ -9,7 +9,6 @@ module.exports = function() {
     framework: 'middleman',
     port: 8888,
     frameworkPort: 4567,
-    env: { ...process.env },
     command: 'bundle',
     possibleArgsArrs: [['exec', 'middleman', 'server']],
     urlRegexp: new RegExp(`(http://)([^:]+:)${4567}(/)?`, 'g'),

--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -21,7 +21,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'out',

--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -23,7 +23,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/parcel.js
+++ b/src/detectors/parcel.js
@@ -24,7 +24,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 1234,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${1234}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/phenomic.js
+++ b/src/detectors/phenomic.js
@@ -17,7 +17,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3333,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3333}(/)?`, 'g'),
     dist: 'public',

--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -24,7 +24,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8080,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: '.quasar',

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -24,7 +24,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8081,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: '.quasar',

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -21,7 +21,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -23,7 +23,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 3000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'static',

--- a/src/detectors/stencil.js
+++ b/src/detectors/stencil.js
@@ -21,7 +21,7 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888, // the port that the Netlify Dev User will use
     frameworkPort: 3333, // the port that stencil normally outputs
-    env: { ...process.env, BROWSER: 'none', PORT: 3000 },
+    env: { BROWSER: 'none', PORT: 3000 },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, 'g'),
     dist: 'www',

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -25,7 +25,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 5000,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${5000}(/)?`, 'g'),
     dist: 'public',

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -23,7 +23,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8080,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: 'dist',

--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -23,7 +23,6 @@ module.exports = function() {
     command: getYarnOrNPMCommand(),
     port: 8888,
     frameworkPort: 8080,
-    env: { ...process.env },
     possibleArgsArrs,
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: '.vuepress/dist',

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -7,7 +7,7 @@ const fuzzy = require('fuzzy')
 const fs = require('fs')
 
 module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
-  let settings = { env: { ...process.env } }
+  let settings = {}
   const detectorsFiles = fs.readdirSync(path.join(__dirname, '..', 'detectors')).filter(x => x.endsWith('.js')) // only accept .js detector files
 
   if (typeof devConfig.framework !== 'string') throw new Error('Invalid "framework" option provided in config')
@@ -180,7 +180,6 @@ async function getStaticServerSettings(settings, flags, projectDir, log) {
   }
   log(`${NETLIFYDEVWARN} Running static server from "${path.relative(path.dirname(projectDir), dist)}"`)
   return {
-    env: { ...process.env },
     noCmd: true,
     port: 8888,
     frameworkPort: await getPort({ port: 3999 }),

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -18,9 +18,7 @@ test('loadDetector: invalid', t => {
 })
 
 test('serverSettings: minimal config', async t => {
-  const env = { ...process.env }
   const settings = await serverSettings({ framework: '#auto' }, {}, sitePath, () => {})
-  t.deepEqual(settings.env, env)
   t.is(settings.framework, undefined)
 })
 
@@ -37,33 +35,27 @@ test('serverSettings: throw if "port" not available', async t => {
 })
 
 test('serverSettings: "command" override npm', async t => {
-  const env = { ...process.env }
   const devConfig = { framework: '#custom', command: 'npm run dev', targetPort: 1234 }
   const settings = await serverSettings(devConfig, {}, sitePath, () => {})
   t.is(settings.framework, devConfig.framework)
   t.is(settings.command, devConfig.command.split(' ')[0])
   t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
-  t.deepEqual(settings.env, env)
 })
 
 test('serverSettings: "command" override yarn', async t => {
-  const env = { ...process.env }
   const devConfig = { framework: '#custom', command: 'yarn dev', targetPort: 1234 }
   const settings = await serverSettings(devConfig, {}, sitePath, () => {})
   t.is(settings.framework, devConfig.framework)
   t.is(settings.command, devConfig.command.split(' ')[0])
   t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
-  t.deepEqual(settings.env, env)
 })
 
 test('serverSettings: custom framework parameters', async t => {
-  const env = { ...process.env }
   const devConfig = { framework: '#custom', command: 'yarn dev', targetPort: 3000, publish: sitePath }
   const settings = await serverSettings(devConfig, {}, sitePath, () => {})
   t.is(settings.framework, '#custom')
   t.is(settings.command, devConfig.command.split(' ')[0])
   t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
-  t.deepEqual(settings.env, env)
   t.is(settings.targetPort, devConfig.frameworkPort)
   t.is(settings.dist, devConfig.publish)
 })


### PR DESCRIPTION
Only 3 detectors set some `env`. This PR simplifies the code by not requiring that `env` object to include `process.env`. `process.env` is passed later on instead (when the server is spawned). The behavior should not change, this just simplifies code.