### PR TITLE
Removes unreachable code 

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -240,7 +240,6 @@ function formatSettingsArrForInquirer(settingsArr) {
 }
 // if first arg is undefined, use default, but tell user about it in case it is unintentional
 function assignLoudly(optionalValue, defaultValue, settingsField) {
-  if (defaultValue === undefined) throw new Error('must have a defaultValue')
   if (defaultValue !== optionalValue && optionalValue === undefined) {
     console.log(
       `${NETLIFYDEVLOG} Overriding ${chalk.yellow(settingsField)} with setting derived from netlify.toml [dev] block: `,


### PR DESCRIPTION
This removes an `if` branch whose condition can never be `true`.

In that function, `optionalValue` can never be `undefined`. The function is called only by two other functions.