### PR TITLE
Improve Netlify Dev command parsing

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -100,8 +100,9 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
     settings.args.unshift('run')
   }
   if (!settings.noCmd && devConfig.command) {
-    settings.command = assignLoudly(devConfig.command.split(/\s/)[0], settings.command || null, 'command') // if settings.command is empty, its bc no settings matched
-    settings.args = assignLoudly(devConfig.command.split(/\s/).slice(1), [], 'command') // if settings.command is empty, its bc no settings matched
+    const [devConfigCommand, ...devConfigArgs] = devConfig.command.split(/\s+/)
+    settings.command = assignLoudly(devConfigCommand, settings.command || null, 'command') // if settings.command is empty, its bc no settings matched
+    settings.args = assignLoudly(devConfigArgs, [], 'command') // if settings.command is empty, its bc no settings matched
   }
   settings.dist = flags.dir || devConfig.publish || settings.dist // dont loudassign if they dont need it
 


### PR DESCRIPTION
This improves how `devConfig.command` is handled, by simplifying the code a little.

It also handles the case where arguments are separated by multiple spaces instead of one, by improving the RegExp.

Note that splitting by whitespace is not great, since arguments might be quoted strings with spaces in them. The command itself might have a space: this is especially common on Windows due to `C:\Program Files\`. We might want to improve that parsing later.