### PR TITLE
Remove detectors code that is not currently working

### DIFF
--- a/src/detectors/angular.js
+++ b/src/detectors/angular.js
@@ -14,11 +14,6 @@ module.exports = function() {
     preferredCommand: 'ng build --prod',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // offer to run it when the user does not have any scripts setup! 🤯
-    possibleArgsArrs.push(['ng', 'build', '--prod'])
-  }
-
   return {
     framework: 'angular',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/create-react-app.js
+++ b/src/detectors/create-react-app.js
@@ -16,11 +16,6 @@ module.exports = function() {
     preferredCommand: 'react-scripts start',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['react-scripts', 'start'])
-  }
-
   return {
     framework: 'create-react-app',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -14,11 +14,6 @@ module.exports = function() {
     preferredCommand: 'ember serve',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['ember', 'serve'])
-  }
-
   return {
     framework: 'ember',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -16,10 +16,6 @@ module.exports = function() {
     preferredCommand: 'expo start --web',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['expo', 'start', '--web'])
-  }
   return {
     framework: 'expo',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -12,10 +12,6 @@ module.exports = function() {
     preferredCommand: 'gatsby develop',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['gatsby', 'develop'])
-  }
   return {
     framework: 'gatsby',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/hexo.js
+++ b/src/detectors/hexo.js
@@ -12,10 +12,6 @@ module.exports = function() {
     preferredCommand: 'hexo server',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['hexo', 'server'])
-  }
   return {
     framework: 'hexo',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -12,10 +12,6 @@ module.exports = function() {
     preferredCommand: 'next',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['next'])
-  }
   return {
     framework: 'next',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -13,11 +13,6 @@ module.exports = function() {
     preferredCommand: 'nuxt',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['nuxt'])
-  }
-
   return {
     framework: 'nuxt',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/parcel.js
+++ b/src/detectors/parcel.js
@@ -14,11 +14,6 @@ module.exports = function() {
     preferredCommand: 'parcel',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    /* Offer to run it when the user doesnt have any scripts setup! 🤯 */
-    possibleArgsArrs.push(['parcel'])
-  }
-
   return {
     framework: 'parcel',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -14,11 +14,6 @@ module.exports = function() {
     // preferredCommand: "quasar dev"
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run this default when the user doesnt have any matching scripts setup!
-    possibleArgsArrs.push(['quasar', 'dev'])
-  }
-
   return {
     framework: 'quasar-cli-v0.17',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -14,11 +14,6 @@ module.exports = function() {
     // preferredCommand: "quasar dev"
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // offer to run this default when the user doesnt have any matching scripts setup!
-    possibleArgsArrs.push(['quasar', 'dev', '-p 8081'])
-  }
-
   return {
     framework: 'quasar',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -12,10 +12,6 @@ module.exports = function() {
     preferredCommand: 'react-static start',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['react-static', 'start'])
-  }
   return {
     framework: 'react-static',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -13,11 +13,6 @@ module.exports = function() {
     preferredCommand: 'sapper dev',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['sapper', 'dev'])
-  }
-
   return {
     framework: 'sapper',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -15,11 +15,6 @@ module.exports = function() {
     preferredCommand: 'npm run dev',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['npm', 'dev'])
-  }
-
   return {
     framework: 'svelte',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -13,11 +13,6 @@ module.exports = function() {
     preferredCommand: 'vue-cli-service serve',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['vue-cli-service', 'serve'])
-  }
-
   return {
     framework: 'vue',
     command: getYarnOrNPMCommand(),

--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -13,11 +13,6 @@ module.exports = function() {
     preferredCommand: 'vuepress dev',
   })
 
-  if (possibleArgsArrs.length === 0) {
-    // ofer to run it when the user doesnt have any scripts setup! 🤯
-    possibleArgsArrs.push(['vuepress', 'dev'])
-  }
-
   return {
     framework: 'vuepress',
     command: getYarnOrNPMCommand(),


### PR DESCRIPTION
When we fail to detect the build command with Netlify Dev, many detectors are adding a default command.

The way this is currently done does not work. This is because the `possibleArgsArr` are the arguments passed to `command` which is `npm run` or `yarn`. For example, if `possibleArgsArr` is `['gatsby', 'develop']`, then `npm run gatsby develop` will be run instead of simply `gatsby develop`. 

A follow-up PR will fix how we assign a default build command. This PR just removes the code that is currently failing.