### PR TITLE
Simplify detectors a little more

### DIFF
--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -74,18 +74,14 @@ function scanScripts({ preferredScriptsArr, preferredCommand }) {
    *  */
   // this is very simplistic logic, we can offer far more intelligent logic later
   // eg make a dependency tree of npm scripts and offer the parentest node first
-  const possibleArgsArrs = preferredScriptsArr
-    .filter(s => Object.keys(scripts).includes(s))
-    .filter(s => !scripts[s].includes('netlify dev')) // prevent netlify dev calling netlify dev
-    .map(x => [x]) // make into arr of arrs
-
-  Object.entries(scripts)
-    .filter(([k]) => !preferredScriptsArr.includes(k))
-    .forEach(([k, v]) => {
-      if (v.includes(preferredCommand)) possibleArgsArrs.push([k])
-    })
-
-  return possibleArgsArrs
+  return Object.entries(scripts)
+    .filter(
+      ([scriptName, scriptCommand]) =>
+        (preferredScriptsArr.includes(scriptName) || scriptCommand.includes(preferredCommand)) &&
+        // prevent netlify dev calling netlify dev
+        !scriptCommand.includes('netlify dev')
+    )
+    .map(([scriptName]) => [scriptName])
 }
 
 module.exports = {


### PR DESCRIPTION
This simplifies some common logic used by detectors a little more.

This should not change the logic, except for one small bug that this is fixing: we have some logic that prevents triggering a `package.json` `scripts` whose command includes `netlify dev` (to prevent infinite recursion). However, it was still possible to have `netlify dev` triggered by Netlify Dev when the script included one of the frameworks' `preferredCommand`. For example:

```json
"scripts": {
  "build": "netlify dev && gatsby develop"
}
```