### PR TITLE
Simplify detectors watch command

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -389,15 +389,16 @@ async function startDevServer(settings, log) {
   }
 
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.framework || 'custom config'}`)
-  const commandBin = await which(settings.command).catch(err => {
+  const [watchCommand, ...watchCommandArgs] = settings.watchCommand.split(/\s+/)
+  const watchCommandBin = await which(watchCommand).catch(err => {
     if (err.code === 'ENOENT') {
       throw new Error(
-        `"${settings.command}" could not be found in your PATH. Please make sure that "${settings.command}" is installed and available in your PATH`
+        `"${watchCommand}" could not be found in your PATH. Please make sure that "${watchCommand}" is installed and available in your PATH`
       )
     }
     throw err
   })
-  const ps = child_process.spawn(commandBin, settings.args, {
+  const ps = child_process.spawn(watchCommandBin, watchCommandArgs, {
     env: { ...process.env, ...settings.env, FORCE_COLOR: 'true' },
     stdio: 'pipe',
   })
@@ -410,7 +411,7 @@ async function startDevServer(settings, log) {
   function handleProcessExit(code) {
     log(
       code > 0 ? NETLIFYDEVERR : NETLIFYDEVWARN,
-      `"${[settings.command, ...settings.args].join(' ')}" exited with code ${code}. Shutting down Netlify Dev server`
+      `"${settings.watchCommand}" exited with code ${code}. Shutting down Netlify Dev server`
     )
     process.exit(code)
   }

--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -32,7 +32,7 @@ not sure if we want to support gitbook yet
 requires a global install: https://github.com/GitbookIO/gitbook/blob/master/docs/setup.md
 
 ```js
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['README.md', 'SUMMARY.md'])) return false
@@ -41,18 +41,17 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = [['gitbook', 'serve']]
-  // scanScripts({
+  const watchCommands = ['gitbook serve']
+  // getWatchCommands({
   //   preferredScriptsArr: ["start", "dev", "develop"],
   //   preferredCommand: "hexo server"
   // });
 
   return {
     framework: 'gitbook',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 4000,
     env: { NAME: 'value' },
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/angular.js
+++ b/src/detectors/angular.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -9,16 +9,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within angular */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['serve', 'start', 'build'],
     preferredCommand: 'ng build --prod',
   })
 
   return {
     framework: 'angular',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 4200,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/brunch.js
+++ b/src/detectors/brunch.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'brunch-config.js'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start'],
     preferredCommand: 'brunch watch --server',
   })
 
   return {
     framework: 'brunch',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3333,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'app/assets',
   }
 }

--- a/src/detectors/create-react-app.js
+++ b/src/detectors/create-react-app.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 /**
  * detection logic - artificial intelligence!
@@ -11,18 +11,17 @@ module.exports = function() {
 
   /** everything below now assumes that we are within create-react-app */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start', 'serve', 'run'],
     preferredCommand: 'react-scripts start',
   })
 
   return {
     framework: 'create-react-app',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000, // the port that create-react-app normally outputs
     env: { BROWSER: 'none', PORT: 3000 },
     stdio: ['inherit', 'pipe', 'pipe'],
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'siteConfig.js'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start'],
     preferredCommand: 'docusaurus-start',
   })
 
   return {
     framework: 'docusaurus',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'static',
   }
 }

--- a/src/detectors/eleventy.js
+++ b/src/detectors/eleventy.js
@@ -11,8 +11,7 @@ module.exports = function() {
   return {
     framework: 'eleventy',
     frameworkPort: 8080,
-    command: 'npx',
-    possibleArgsArrs: [['eleventy', '--serve', '--watch']],
+    watchCommands: ['npx eleventy --serve --watch'],
     dist: '_site',
   }
 }

--- a/src/detectors/ember.js
+++ b/src/detectors/ember.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -9,16 +9,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within ember */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['serve', 'start', 'run'],
     preferredCommand: 'ember serve',
   })
 
   return {
     framework: 'ember',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 4200,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/expo.js
+++ b/src/detectors/expo.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'app.json'])) return false
@@ -7,7 +7,7 @@ module.exports = function() {
 
   /** everything below now assumes that we are within expo */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     // This script will run `expo start --web` in a new Expo project.
     // Note: Expo will automatically launch the browser with your app's
     // Webpack server listening on port 19006, but the instance proxied
@@ -18,9 +18,8 @@ module.exports = function() {
 
   return {
     framework: 'expo',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 19006,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'web-build',
   }
 }

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'gatsby-config.js'])) return false
@@ -7,17 +7,16 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start', 'develop', 'dev'],
     preferredCommand: 'gatsby develop',
   })
 
   return {
     framework: 'gatsby',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8000,
     env: { GATSBY_LOGGER: 'yurnalist' },
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/gridsome.js
+++ b/src/detectors/gridsome.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'gridsome.config.js'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gridsome */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['develop'],
     preferredCommand: 'gridsome develop',
   })
 
   return {
     framework: 'gridsome',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8080,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/hexo.js
+++ b/src/detectors/hexo.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', '_config.yml'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start', 'dev', 'develop'],
     preferredCommand: 'hexo server',
   })
 
   return {
     framework: 'hexo',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 4000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/hugo.js
+++ b/src/detectors/hugo.js
@@ -8,8 +8,7 @@ module.exports = function() {
   return {
     framework: 'hugo',
     frameworkPort: 1313,
-    command: 'hugo',
-    possibleArgsArrs: [['server', '-w']],
+    watchCommands: ['hugo server -w'],
     dist: 'public',
   }
 }

--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -8,8 +8,7 @@ module.exports = function() {
   return {
     framework: 'jekyll',
     frameworkPort: 4000,
-    command: 'bundle',
-    possibleArgsArrs: [['exec', 'jekyll', 'serve', '-w']],
+    watchCommands: ['bundle exec jekyll serve -w'],
     dist: '_site',
   }
 }

--- a/src/detectors/middleman.js
+++ b/src/detectors/middleman.js
@@ -8,8 +8,7 @@ module.exports = function() {
   return {
     framework: 'middleman',
     frameworkPort: 4567,
-    command: 'bundle',
-    possibleArgsArrs: [['exec', 'middleman', 'server']],
+    watchCommands: ['bundle exec middleman server'],
     dist: 'build',
   }
 }

--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['dev', 'develop', 'start'],
     preferredCommand: 'next',
   })
 
   return {
     framework: 'next',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'out',
   }
 }

--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,16 +8,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within vue */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['dev', 'start'],
     preferredCommand: 'nuxt',
   })
 
   return {
     framework: 'nuxt',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/parcel.js
+++ b/src/detectors/parcel.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   /* REQUIRED FILES */
@@ -9,16 +9,15 @@ module.exports = function() {
 
   /* Everything below now assumes that we are within parcel */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start', 'dev', 'run'],
     preferredCommand: 'parcel',
   })
 
   return {
     framework: 'parcel',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 1234,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/phenomic.js
+++ b/src/detectors/phenomic.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start'],
     preferredCommand: 'phenomic start',
   })
 
   return {
     framework: 'phenomic',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3333,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,7 +8,7 @@ module.exports = function() {
 
   /** everything below now assumes that we are within Quasar */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['serve', 'start', 'run', 'dev'],
     // NOTE: this is comented out as it was picking this up in cordova related scripts.
     // preferredCommand: "quasar dev"
@@ -16,9 +16,8 @@ module.exports = function() {
 
   return {
     framework: 'quasar-cli-v0.17',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8080,
-    possibleArgsArrs,
+    watchCommands,
     dist: '.quasar',
   }
 }

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,7 +8,7 @@ module.exports = function() {
 
   /** everything below now assumes that we are within Quasar */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['serve', 'start', 'run', 'dev'],
     // NOTE: this is comented out as it was picking this up in cordova related scripts.
     // preferredCommand: "quasar dev"
@@ -16,9 +16,8 @@ module.exports = function() {
 
   return {
     framework: 'quasar',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8081,
-    possibleArgsArrs,
+    watchCommands,
     dist: '.quasar',
   }
 }

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
   if (!hasRequiredFiles(['package.json', 'static.config.js'])) return false
@@ -7,16 +7,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within react-static */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start', 'develop', 'dev'],
     preferredCommand: 'react-static start',
   })
 
   return {
     framework: 'react-static',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,16 +8,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within Sapper */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['dev', 'start'],
     preferredCommand: 'sapper dev',
   })
 
   return {
     framework: 'sapper',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'static',
   }
 }

--- a/src/detectors/stencil.js
+++ b/src/detectors/stencil.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 /**
  * detection logic - artificial intelligence!
@@ -11,17 +11,16 @@ module.exports = function() {
 
   /** everything below now assumes that we are within stencil */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['start'],
     preferredCommand: 'stencil build --dev --watch --serve',
   })
 
   return {
     framework: 'stencil',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 3333, // the port that stencil normally outputs
     env: { BROWSER: 'none', PORT: 3000 },
-    possibleArgsArrs,
+    watchCommands,
     dist: 'www',
   }
 }

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -10,16 +10,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within svelte */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['dev', 'start', 'run'],
     preferredCommand: 'npm run dev',
   })
 
   return {
     framework: 'svelte',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 5000,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'public',
   }
 }

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,16 +8,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within vue */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['serve', 'start', 'run'],
     preferredCommand: 'vue-cli-service serve',
   })
 
   return {
     framework: 'vue',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8080,
-    possibleArgsArrs,
+    watchCommands,
     dist: 'dist',
   }
 }

--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -1,4 +1,4 @@
-const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+const { hasRequiredDeps, hasRequiredFiles, getWatchCommands } = require('./utils/jsdetect')
 
 module.exports = function() {
   // REQUIRED FILES
@@ -8,16 +8,15 @@ module.exports = function() {
 
   /** everything below now assumes that we are within vue */
 
-  const possibleArgsArrs = scanScripts({
+  const watchCommands = getWatchCommands({
     preferredScriptsArr: ['docs:dev', 'dev', 'run'],
     preferredCommand: 'vuepress dev',
   })
 
   return {
     framework: 'vuepress',
-    command: getYarnOrNPMCommand(),
     frameworkPort: 8080,
-    possibleArgsArrs,
+    watchCommands,
     dist: '.vuepress/dist',
   }
 }

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -48,24 +48,21 @@ test('serverSettings: "command" override npm', async t => {
   const devConfig = { framework: '#custom', command: 'npm run dev', targetPort: 1234 }
   const settings = await serverSettings(devConfig, {}, t.context.sitePath, () => {})
   t.is(settings.framework, devConfig.framework)
-  t.is(settings.command, devConfig.command.split(' ')[0])
-  t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
+  t.is(settings.watchCommand, devConfig.command)
 })
 
 test('serverSettings: "command" override yarn', async t => {
   const devConfig = { framework: '#custom', command: 'yarn dev', targetPort: 1234 }
   const settings = await serverSettings(devConfig, {}, t.context.sitePath, () => {})
   t.is(settings.framework, devConfig.framework)
-  t.is(settings.command, devConfig.command.split(' ')[0])
-  t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
+  t.is(settings.watchCommand, devConfig.command)
 })
 
 test('serverSettings: custom framework parameters', async t => {
   const devConfig = { framework: '#custom', command: 'yarn dev', targetPort: 3000, publish: t.context.sitePath }
   const settings = await serverSettings(devConfig, {}, t.context.sitePath, () => {})
   t.is(settings.framework, '#custom')
-  t.is(settings.command, devConfig.command.split(' ')[0])
-  t.deepEqual(settings.args, devConfig.command.split(' ').slice(1))
+  t.is(settings.watchCommand, devConfig.command)
   t.is(settings.targetPort, devConfig.frameworkPort)
   t.is(settings.dist, devConfig.publish)
 })


### PR DESCRIPTION
We currently split the Netlify Dev watch command into `settings.command` (the binary) and `settings.args` (the arguments array). Splitting those is usually done to escape whitespaces and delimitate tokens between the command and the arguments. However, in our case, it does not make much sense considering the watch command can only be either:
  - `npm run scriptName`
  - some framework-specific hardcoded string like `hugo server -w`, just never includes whitespaces in our frameworks

This also prevents us from potentially spawning the watch command in a subshell (like Bash), which prevents users from using shell features like variable expansion or globbing in their `dev.command`.

Finally, splitting those makes the code logic more complicated.

This PR merges those into a single `settings.watchCommand` instead.

It also simplifies some logic which was first passing `npm` as the watch command, then later on transforming it to `npm run`, by passing it as `npm run` directly instead.