### PR TITLE
Handle contentType not being set in netlify dev

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -214,11 +214,11 @@ async function startProxy(settings = {}, addonUrls, configPath, projectDir, func
 
       if (match) return serveRedirect(req, res, proxy, match, options)
 
-      const ct = req.headers['content-type'] ? contentType.parse(req) : {}
+      const ct = req.headers['content-type'] ? contentType.parse(req).type : ''
       if (
         req.method === 'POST' &&
         !isInternal(req.url) &&
-        (ct.type.endsWith('/x-www-form-urlencoded') || ct.type === 'multipart/form-data')
+        (ct.endsWith('/x-www-form-urlencoded') || ct === 'multipart/form-data')
       ) {
         return proxy.web(req, res, { target: functionsServer })
       }
@@ -338,12 +338,12 @@ async function serveRedirect(req, res, proxy, match, options) {
       return handler(req, res, {})
     }
 
-    const ct = req.headers['content-type'] ? contentType.parse(req) : {}
+    const ct = req.headers['content-type'] ? contentType.parse(req).type : ''
     if (
       req.method === 'POST' &&
       !isInternal(req.url) &&
       !isInternal(destURL) &&
-      (ct.type.endsWith('/x-www-form-urlencoded') || ct.type === 'multipart/form-data')
+      (ct.endsWith('/x-www-form-urlencoded') || ct === 'multipart/form-data')
     ) {
       return proxy.web(req, res, { target: options.functionsServer })
     }


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

`netlify dev` was failing for me consistently with the following error message:

```
◈ Netlify Dev ◈
◈ No app server detected and no "command" specified
◈ Using current working directory
◈ Unable to determine public folder to serve files from
◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
◈ Running static server from "mybinder.term"

◈ Server listening to 3999

   ┌─────────────────────────────────────────────────┐
   │                                                 │
   │   ◈ Server now ready on http://localhost:8888   │
   │                                                 │
   └─────────────────────────────────────────────────┘

TypeError: Cannot read property 'endsWith' of undefined
    at serveRedirect (/usr/local/lib/node_modules/netlify-cli/src/commands/dev/index.js:344:16)
TypeError: Cannot read property 'endsWith' of undefined
    at serveRedirect (/usr/local/lib/node_modules/netlify-cli/src/commands/dev/index.js:344:16)

/usr/local/lib/node_modules/netlify-cli/node_modules/netlify-redirector/lib/redirects.js:116
      throw ex;
      ^
abort({}) at Error
    at jsStackTrace (/usr/local/lib/node_modules/netlify-cli/node_modules/netlify-redirector/lib/redirects.js:1070:13)
    at stackTrace (/usr/local/lib/node_modules/netlify-cli/node_modules/netlify-redirector/lib/redirects.js:1087:12)
    at process.abort (/usr/local/lib/node_modules/netlify-cli/node_modules/netlify-redirector/lib/redirects.js:8502:44)
    at process.emit (events.js:314:20)
    at processPromiseRejections (internal/process/promises.js:245:33)
    at processTicksAndRejections (internal/process/task_queues.js:94:32)
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```

The code was setting `ct` to be an empty object if no content-type header was
set, but then accessing `.type` on the object unconditionally. With this PR,
we set `ct` to be the content-type itself, avoiding any attribute access that
might cause undefined attribute access.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

- Fixes netlify dev crashes when requests don't have content-type set

**- A picture of a cute animal (not mandatory but encouraged)**
