### PR TITLE
test(frameworks): add detection tests

### DIFF
--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -5,7 +5,7 @@ module.exports = function() {
   // REQUIRED DEPS
   if (!hasRequiredDeps(['next'])) return false
 
-  /** everything below now assumes that we are within gatsby */
+  /** everything below now assumes that we are within next */
 
   const possibleArgsArrs = scanScripts({
     preferredScriptsArr: ['dev', 'develop', 'start'],

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -14,7 +14,7 @@ function getPkgJSON() {
   if (pkgJSON) {
     return pkgJSON
   }
-  if (!existsSync('package.json')) throw new Error('dont call this method unless you already checked for pkg json')
+  if (!existsSync('package.json')) throw new Error("don't call this method unless you already checked for pkg json")
   pkgJSON = JSON.parse(readFileSync('package.json', { encoding: 'utf8' }))
   return pkgJSON
 }

--- a/src/utils/detect-server.frameworks.test.js
+++ b/src/utils/detect-server.frameworks.test.js
@@ -1,0 +1,161 @@
+const test = require('ava')
+const execa = require('execa')
+const sinon = require('sinon')
+const path = require('path')
+const { serverSettings } = require('./detect-server')
+const { withSiteBuilder } = require('../../tests/utils/siteBuilder')
+
+const setupFrameworkSite = async (command, options) => {
+  const parts = command.split(' ')
+  const file = parts[0]
+  await execa(file, parts.slice(1), options)
+}
+
+const frameworks = [
+  {
+    name: 'angular',
+    getSetupData: baseDirectory => ({
+      command: `npx -p @angular/cli@6 ng new angular-site --skip-install --directory=${baseDirectory} --minimal=true --skipGit=true --defaults=true`,
+    }),
+    expectedSettings: {
+      framework: 'angular',
+      command: 'npm',
+      frameworkPort: 4200,
+      possibleArgsArrs: [['start'], ['build']],
+      dist: 'dist',
+      args: ['start'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+    },
+  },
+  {
+    name: 'eleventy',
+    getSetupData: baseDirectory => ({
+      command: `git clone https://github.com/11ty/eleventy-base-blog.git ${baseDirectory}`,
+    }),
+    expectedSettings: {
+      framework: 'eleventy',
+      command: 'npx',
+      frameworkPort: 8080,
+      possibleArgsArrs: [['eleventy', '--serve', '--watch']],
+      dist: '_site',
+      args: ['eleventy', '--serve', '--watch'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+    },
+  },
+  {
+    name: 'gatsby',
+    getSetupData: baseDirectory => ({
+      command: `git clone https://github.com/gatsbyjs/gatsby-starter-hello-world.git ${baseDirectory}`,
+    }),
+    expectedSettings: {
+      framework: 'gatsby',
+      command: 'yarn',
+      frameworkPort: 8000,
+      possibleArgsArrs: [['develop'], ['start']],
+      dist: 'public',
+      args: ['develop'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+      env: { GATSBY_LOGGER: 'yurnalist' },
+    },
+  },
+  {
+    name: 'next',
+    getSetupData: baseDirectory => ({
+      command: `git clone https://github.com/vercel/next-learn-starter ${baseDirectory}`,
+      projectDir: 'learn-starter',
+    }),
+    expectedSettings: {
+      framework: 'next',
+      command: 'npm',
+      frameworkPort: 3000,
+      possibleArgsArrs: [['run', 'dev'], ['build'], ['start']],
+      dist: 'out',
+      args: ['run', 'dev'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+    },
+  },
+  {
+    name: 'svelte',
+    getSetupData: baseDirectory => ({
+      command: `git clone https://github.com/sveltejs/template.git ${baseDirectory}`,
+    }),
+    expectedSettings: {
+      framework: 'svelte',
+      command: 'npm',
+      frameworkPort: 5000,
+      possibleArgsArrs: [['run', 'dev'], ['start']],
+      dist: 'public',
+      args: ['run', 'dev'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+    },
+  },
+  {
+    name: 'vue',
+    getSetupData: baseDirectory => ({
+      command: `npx -p @vue/cli@3 vue create ${baseDirectory} --default --no-git --bare --force`,
+    }),
+    expectedSettings: {
+      framework: 'vue',
+      command: 'yarn',
+      frameworkPort: 8080,
+      possibleArgsArrs: [['serve']],
+      dist: 'dist',
+      args: ['serve'],
+      port: 8888,
+      jwtRolePath: 'app_metadata.authorization.roles',
+      functions: undefined,
+    },
+  },
+]
+
+test.before(t => {
+  t.context.clock = sinon.useFakeTimers()
+})
+
+test.beforeEach(t => {
+  // this is required since `get-port` locks ports for 15-30 seconds
+  t.context.clock.tick(30 * 1000)
+})
+
+frameworks.forEach(framework => {
+  // detectors run in the current directory at the moment, so we can't run tests in parallel
+  test.serial(`should detect framework ${framework.name}`, async t => {
+    await withSiteBuilder(`framework-site-${framework.name}`, async builder => {
+      await builder.buildAsync()
+      const { command, projectDir = '' } = framework.getSetupData(path.basename(builder.directory))
+      const siteDir = path.join(builder.directory, projectDir)
+      await setupFrameworkSite(command, { cwd: path.dirname(builder.directory) })
+
+      const cwd = process.cwd()
+      try {
+        // TODO: refactor detectors not to rely on the current working directory
+        process.chdir(siteDir)
+
+        // functionsPort is randomized
+        const settings = await serverSettings({ framework: '#auto' }, {}, siteDir, () => {})
+        t.deepEqual(settings, framework.expectedSettings)
+      } finally {
+        process.chdir(cwd)
+        // clear modules cache since running the detection memoizes the site's package.json at the module level
+        // TODO: refactor detectors not to use module level variables
+        Object.keys(require.cache).forEach(key => {
+          delete require.cache[key]
+        })
+      }
+    })
+  })
+})
+
+test.after(t => {
+  t.context.clock.restore()
+})


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/1093

This PR adds a framework detection tests, based on starter projects for those frameworks.

The tests have a few limitations:
1. Can only run serially since detectors assume running the current directory - we should [refactor the detectors in the future](https://github.com/netlify/cli/issues/1119).
2. Need to clear node require cache after each test (see https://github.com/netlify/cli/issues/1119)
3. Some of the tests are slow since they use the framework CLIs (this is intensified by the first limitation).
4. Use an older version of some of the frameworks CLIs due to node 8 support.
5. Not all frameworks are tested at the moment to avoid adding too much time to CI.

Hopefully we can improve this in the future once we do some refactoring.