### PR TITLE
refactor: clean up addEnvVariables function

### DIFF
--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -15,9 +15,8 @@ class ExecCommand extends Command {
     const { site, api } = this.netlify
     if (site.id) {
       this.log(`${NETLIFYDEVLOG} Checking your site's environment variables...`) // just to show some visual response first
-      const accessToken = api.accessToken
       const { addEnvVariables } = require('../../utils/dev')
-      await addEnvVariables(api, site, accessToken)
+      await addEnvVariables(api, site)
     } else {
       this.log(
         `${NETLIFYDEVERR} No Site ID detected. You probably forgot to run \`netlify link\` or \`netlify init\`. `

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -470,6 +470,19 @@ const getAddonsUrlsAndAddEnvVariablesToProcessEnv = async ({ api, site, flags })
   }
 }
 
+const addDotFileEnvs = async ({ site }) => {
+  const envSettings = await getEnvSettings(site.root)
+  if (envSettings.file) {
+    console.log(
+      `${NETLIFYDEVLOG} Overriding the following env variables with ${chalk.blue(
+        path.relative(site.root, envSettings.file)
+      )} file:`,
+      chalk.yellow(Object.keys(envSettings.vars))
+    )
+    Object.entries(envSettings.vars).forEach(([key, val]) => (process.env[key] = val))
+  }
+}
+
 class DevCommand extends Command {
   async run() {
     this.log(`${NETLIFYDEV}`)
@@ -488,19 +501,8 @@ class DevCommand extends Command {
     }
 
     const addonUrls = await getAddonsUrlsAndAddEnvVariablesToProcessEnv({ api, site, flags })
-
     process.env.NETLIFY_DEV = 'true'
-    // Override env variables with .env file
-    const envSettings = await getEnvSettings(site.root)
-    if (envSettings.file) {
-      console.log(
-        `${NETLIFYDEVLOG} Overriding the following env variables with ${chalk.blue(
-          path.relative(site.root, envSettings.file)
-        )} file:`,
-        chalk.yellow(Object.keys(envSettings.vars))
-      )
-      Object.entries(envSettings.vars).forEach(([key, val]) => (process.env[key] = val))
-    }
+    await addDotFileEnvs({ site })
 
     let settings = {}
     try {

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -246,7 +246,7 @@ async function downloadFromURL(flags, args, functionsDir) {
 
     await installAddons.call(this, addons, path.resolve(fnFolder))
     if (onComplete) {
-      await addEnvVariables(this.netlify.api, this.netlify.site, this.netlify.api.accessToken)
+      await addEnvVariables(this.netlify.api, this.netlify.site)
       await onComplete.call(this)
     }
     fs.unlinkSync(fnTemplateFile) // delete
@@ -329,7 +329,7 @@ async function scaffoldFromTemplate(flags, args, functionsDir) {
 
       installAddons.call(this, addons, path.resolve(functionPath))
       if (onComplete) {
-        await addEnvVariables(this.netlify.api, this.netlify.site, this.netlify.api.accessToken)
+        await addEnvVariables(this.netlify.api, this.netlify.site)
         await onComplete.call(this)
       }
     })
@@ -357,7 +357,7 @@ async function installAddons(addons = [], fnPath) {
               // spinner.success("installed addon: " + addonName);
               if (addonDidInstall) {
                 const { addEnvVariables } = require('../../utils/dev')
-                await addEnvVariables(api, site, accessToken)
+                await addEnvVariables(api, site)
                 const { confirmPostInstall } = await inquirer.prompt([
                   {
                     type: 'confirm',

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -15,18 +15,17 @@ const {
  *
  * ```
  * // usage example
- * const { site, api } = this.netlify
+ * const { api, site } = this.netlify
  * if (site.id) {
- *   const accessToken = api.accessToken
- *   const addonUrls = await addEnvVariables(site, accessToken)
+ *   const addonUrls = await addEnvVariables(api, site)
  *   // addonUrls is only for startProxy in netlify dev:index
  * }
  * ```
  */
-async function addEnvVariables(api, site, accessToken) {
+async function addEnvVariables(api, site) {
   /** from addons */
   const addonUrls = {}
-  const addons = await getAddons(site.id, accessToken).catch(error => {
+  const addons = await getAddons(site.id, api.accessToken).catch(error => {
     console.error(error)
     switch (error.status) {
       default:


### PR DESCRIPTION
This extracts some code into functions (with descriptive names) and removes a redundant argument to `addEnvVariables`