### PR TITLE
Remove v from node engine version string

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Bret Comnes <bcomnes@gmail.com> (https://bret.io)"
   ],
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=8.17.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
**- Summary**

Trying to install the cli with [Volta](https://volta.sh) using `volta install netlify-cli` failed with `error: Could not parse version ">=v8.17.0"`. Removing the `v` from the version string should fix that.


**- Test plan**
I could install version `2.58.0` without any problems and when comparing diff of 2.59.0 I noticed the node engine change that added the `v`. 

**- Description for the changelog**

Remove unnecessary `v` from node engine version string.

![](https://media.giphy.com/media/s0k30jjI04THq/source.gif)
