### PR TITLE
Fix: Use 404.html page in publish folder

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -380,7 +380,7 @@ async function startDevServer(settings, log) {
       name: 'netlify-dev',
       port: settings.frameworkPort,
       templates: {
-        notFound: '404.html',
+        notFound: path.join(settings.dist, '404.html'),
       },
     })
 

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -658,6 +658,31 @@ test('should return 404.html if exists for non existing routes', async t => {
   })
 })
 
+test('should return 404.html from publish folder if exists for non existing routes', async t => {
+  await withSiteBuilder('site-with-shadowing-404-in-publish-folder', async builder => {
+    builder
+      .withContentFile({
+        path: 'public/404.html',
+        content: '<h1>404 - My Custom 404 Page</h1>',
+      })
+      .withNetlifyToml({
+        config: {
+          build: {
+            publish: 'public/',
+          },
+        },
+      })
+
+    await builder.buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async server => {
+      const response = await fetch(`${server.url}/non-existent`)
+      t.is(response.status, 404)
+      t.is(await response.text(), '<h1>404 - My Custom 404 Page</h1>')
+    })
+  })
+})
+
 test('should return 404 for redirect', async t => {
   await withSiteBuilder('site-with-shadowing-404-redirect', async builder => {
     builder


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

In Netlify, you can set a custom 404 page by putting a 404.html file inside the publish folder (e.g., public or whatever is specified in netlify.toml).

Until now, this custom 404 page was not picked up by netlify dev. For it to work in netlify dev, the custom 404.html file had to be in the root folder.

This PR makes the behavior of netlify dev consistent with Netlify in production by using the custom 404.html page in the publish folder.

Fixes: https://github.com/netlify/cli/issues/1158

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

I first added a test to tests/command.dev.test.js. I ran the test and confirmed that it failed. Then I implemented the fix. I reran the test and the test passed.

![Screenshot from 2020-08-27 21-09-15](https://user-images.githubusercontent.com/7606194/91486252-48b40e00-e8ac-11ea-87ac-c809d781c1f7.png)

![Screenshot from 2020-08-27 21-17-13](https://user-images.githubusercontent.com/7606194/91486257-4a7dd180-e8ac-11ea-8f85-9964b81cc90a.png)

I ran npm run test and everything came back green.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Fix: Use 404.html page in publish folder (#1158)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![WhatsApp Image 2019-12-25 at 2 04 28 PM (3)](https://user-images.githubusercontent.com/7606194/91486371-71d49e80-e8ac-11ea-9ac9-6f3f7f232fab.jpeg)

