### PR TITLE
feat(env): add command to list/get/set/import environment variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the [CLI command line reference](https://cli.netlify.com/commands/) to get s
   * [build](#build)
   * [deploy](#deploy)
   * [dev](#dev)
+  * [env](#env)
   * [functions](#functions)
   * [init](#init)
   * [link](#link)
@@ -100,6 +101,18 @@ Local dev server
 | Subcommand | description  |
 |:--------------------------- |:-----|
 | [`dev:exec`](/docs/commands/dev.md#devexec) | Exec command  |
+
+
+### [env](/docs/commands/env.md)
+
+Control environment variables for the current site
+
+| Subcommand | description  |
+|:--------------------------- |:-----|
+| [`env:get`](/docs/commands/env.md#envget) | Get resolved value of specified environment variable (includes netlify.toml)  |
+| [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
+| [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
+| [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
 
 
 ### [functions](/docs/commands/functions.md)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Local dev server
 
 ### [env](/docs/commands/env.md)
 
-Control environment variables for the current site
+(Beta) Control environment variables for the current site
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Control environment variables for the current site
 | [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
 | [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
 | [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+| [`env:unset`](/docs/commands/env.md#envunset) | Unset an environment variable which removes it from the UI  |
 
 
 ### [functions](/docs/commands/functions.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Local dev server
 
 ### [env](/docs/commands/env.md)
 
-Control environment variables for the current site
+(Beta) Control environment variables for the current site
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,18 @@ Local dev server
 | [`dev:exec`](/docs/commands/dev.md#devexec) | Exec command  |
 
 
+### [env](/docs/commands/env.md)
+
+Control environment variables for the current site
+
+| Subcommand | description  |
+|:--------------------------- |:-----|
+| [`env:get`](/docs/commands/env.md#envget) | Get resolved value of specified environment variable (includes netlify.toml)  |
+| [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
+| [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
+| [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+
+
 ### [functions](/docs/commands/functions.md)
 
 Manage netlify functions

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ Control environment variables for the current site
 | [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
 | [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
 | [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+| [`env:unset`](/docs/commands/env.md#envunset) | Unset an environment variable which removes it from the UI  |
 
 
 ### [functions](/docs/commands/functions.md)

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -6,7 +6,7 @@ description: Control environment variables for the current site
 # `env`
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
-Control environment variables for the current site
+(Beta) Control environment variables for the current site
 
 **Usage**
 

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -1,0 +1,115 @@
+---
+title: Netlify CLI env command
+description: Control environment variables for the current site
+---
+
+# `env`
+
+<!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
+Control environment variables for the current site
+
+**Usage**
+
+```bash
+netlify env
+```
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+
+| Subcommand | description  |
+|:--------------------------- |:-----|
+| [`env:get`](/docs/commands/env.md#envget) | Get resolved value of specified environment variable (includes netlify.toml)  |
+| [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
+| [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
+| [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+
+
+**Examples**
+
+```bash
+netlify env:list
+netlify env:get VAR_NAME
+netlify env:set VAR_NAME value
+netlify env:delete VAR_NAME
+netlify env:import fileName
+```
+
+---
+## `env:get`
+
+Get resolved value of specified environment variable (includes netlify.toml)
+
+**Usage**
+
+```bash
+netlify env:get
+```
+
+**Arguments**
+
+- name - Environment variable name
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+
+---
+## `env:import`
+
+Import and set environment variables from .env file
+
+**Usage**
+
+```bash
+netlify env:import
+```
+
+**Arguments**
+
+- fileName - .env file to import
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+- `replaceExisting` (*boolean*) - Replace all existing variables instead of merging them with the current ones
+
+---
+## `env:list`
+
+Lists resolved environment variables for site (includes netlify.toml)
+
+**Usage**
+
+```bash
+netlify env:list
+```
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+
+---
+## `env:set`
+
+Set value of environment variable
+
+**Usage**
+
+```bash
+netlify env:set
+```
+
+**Arguments**
+
+- name - Environment variable name
+- value - Value to set to (leave empty to delete)
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+
+---
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -24,6 +24,7 @@ netlify env
 | [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
 | [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
 | [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+| [`env:unset`](/docs/commands/env.md#envunset) | Unset an environment variable which removes it from the UI  |
 
 
 **Examples**
@@ -32,7 +33,7 @@ netlify env
 netlify env:list
 netlify env:get VAR_NAME
 netlify env:set VAR_NAME value
-netlify env:delete VAR_NAME
+netlify env:unset VAR_NAME
 netlify env:import fileName
 ```
 
@@ -104,7 +105,26 @@ netlify env:set
 **Arguments**
 
 - name - Environment variable name
-- value - Value to set to (leave empty to delete)
+- value - Value to set to
+
+**Flags**
+
+- `debug` (*boolean*) - Print debugging information
+
+---
+## `env:unset`
+
+Unset an environment variable which removes it from the UI
+
+**Usage**
+
+```bash
+netlify env:unset
+```
+
+**Arguments**
+
+- name - Environment variable name
 
 **Flags**
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -56,7 +56,7 @@ Local dev server
 
 ### [env](/docs/commands/env.md)
 
-Control environment variables for the current site
+(Beta) Control environment variables for the current site
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -64,6 +64,7 @@ Control environment variables for the current site
 | [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
 | [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
 | [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+| [`env:unset`](/docs/commands/env.md#envunset) | Unset an environment variable which removes it from the UI  |
 
 
 ### [functions](/docs/commands/functions.md)

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -54,6 +54,18 @@ Local dev server
 | [`dev:exec`](/docs/commands/dev.md#devexec) | Exec command  |
 
 
+### [env](/docs/commands/env.md)
+
+Control environment variables for the current site
+
+| Subcommand | description  |
+|:--------------------------- |:-----|
+| [`env:get`](/docs/commands/env.md#envget) | Get resolved value of specified environment variable (includes netlify.toml)  |
+| [`env:import`](/docs/commands/env.md#envimport) | Import and set environment variables from .env file  |
+| [`env:list`](/docs/commands/env.md#envlist) | Lists resolved environment variables for site (includes netlify.toml)  |
+| [`env:set`](/docs/commands/env.md#envset) | Set value of environment variable  |
+
+
 ### [functions](/docs/commands/functions.md)
 
 Manage netlify functions

--- a/site/src/_app.js
+++ b/site/src/_app.js
@@ -40,6 +40,7 @@ const navOrder = [
   'build',
   'deploy',
   'dev',
+  'env',
   'functions',
   'init',
   'link',

--- a/src/commands/env/get.js
+++ b/src/commands/env/get.js
@@ -1,0 +1,53 @@
+const Command = require('../../utils/command')
+
+class EnvGetCommand extends Command {
+  async run() {
+    const { args, flags } = this.parse(EnvGetCommand)
+    const { api, site, config } = this.netlify
+    const siteId = site.id
+
+    if (!siteId) {
+      this.log('No site id found, please run inside a site folder or `netlify link`')
+      return false
+    }
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'env:get',
+      },
+    })
+
+    const siteData = await api.getSite({ siteId })
+    const {
+      build: { environment = {} },
+    } = config
+
+    const { name } = args
+    const value = environment[name] || ''
+
+    // Return json response for piping commands
+    if (flags.json) {
+      this.logJson({ [name]: value })
+      return false
+    }
+
+    if (!value) {
+      this.log(`Environment variable ${name} not set for site ${siteData.name}`)
+      return false
+    }
+
+    this.log(value)
+  }
+}
+
+EnvGetCommand.description = `Get resolved value of specified environment variable (includes netlify.toml)`
+EnvGetCommand.args = [
+  {
+    name: 'name',
+    required: true,
+    description: 'Environment variable name',
+  },
+]
+
+module.exports = EnvGetCommand

--- a/src/commands/env/get.js
+++ b/src/commands/env/get.js
@@ -24,11 +24,11 @@ class EnvGetCommand extends Command {
     } = config
 
     const { name } = args
-    const value = environment[name] || ''
+    const value = environment[name]
 
     // Return json response for piping commands
     if (flags.json) {
-      this.logJson({ [name]: value })
+      this.logJson(!value ? {} : { [name]: value })
       return false
     }
 

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -65,9 +65,9 @@ class EnvImportCommand extends Command {
       },
     })
 
-    // Return updated site object if using json flag
+    // Return new environment variables of site if using json flag
     if (flags.json) {
-      this.logJson(siteResult)
+      this.logJson(siteResult.build_settings.env)
       return false
     }
 

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -1,0 +1,95 @@
+const AsciiTable = require('ascii-table')
+const Command = require('../../utils/command')
+const dotenv = require('dotenv')
+const fs = require('fs')
+const isEmpty = require('lodash.isempty')
+
+class EnvImportCommand extends Command {
+  async run() {
+    const { args, flags } = this.parse(EnvImportCommand)
+    const { api, site } = this.netlify
+    const siteId = site.id
+
+    if (!siteId) {
+      this.log('No site id found, please run inside a site folder or `netlify link`')
+      return false
+    }
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'env:import',
+      },
+    })
+
+    const siteData = await api.getSite({ siteId })
+
+    // Get current environment variables set in the UI
+    const {
+      build_settings: { env = {} },
+    } = siteData
+
+    const newEnv = env
+
+    // Import environment variables from specified .env file
+    const { fileName } = args
+    let importedEnv = {}
+    try {
+      const envFileContents = fs.readFileSync(fileName)
+      importedEnv = dotenv.parse(envFileContents)
+    } catch (e) {
+      this.error(e)
+    }
+
+    if (isEmpty(importedEnv)) {
+      this.log(`No environment variables found in file ${fileName} to import`)
+      return false
+    }
+
+    // Merge imported variables with the existing ones
+    for (const [key, value] of Object.entries(importedEnv)) {
+      if (!value.trim()) {
+        delete newEnv[key] // delete variable if value is unset
+      } else {
+        newEnv[key] = value
+      }
+    }
+
+    // Apply environment variable updates
+    const siteResult = await api.updateSite({
+      siteId,
+      body: {
+        build_settings: {
+          env: newEnv,
+        },
+      },
+    })
+
+    // Return updated site object if using json flag
+    if (flags.json) {
+      this.logJson(siteResult)
+      return false
+    }
+
+    // List newly imported environment variables in a table
+    this.log(`site: ${siteData.name}`)
+    const table = new AsciiTable(`Imported environment variables`)
+
+    table.setHeading('Key', 'Value')
+    for (const [key, value] of Object.entries(importedEnv)) {
+      table.addRow(key, value)
+    }
+    this.log(table.toString())
+  }
+}
+
+EnvImportCommand.description = `Import and set environment variables from .env file`
+EnvImportCommand.args = [
+  {
+    name: 'fileName',
+    required: true,
+    description: '.env file to import',
+  },
+]
+
+module.exports = EnvImportCommand

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -5,18 +5,6 @@ const dotenv = require('dotenv')
 const fs = require('fs')
 const isEmpty = require('lodash.isempty')
 
-function mergeEnvVars(sourceEnv, mergeEnv) {
-  const result = sourceEnv
-  for (const [key, value] of Object.entries(mergeEnv)) {
-    if (!value.trim()) {
-      delete result[key] // delete variable if value is unset
-    } else {
-      result[key] = value
-    }
-  }
-  return result
-}
-
 class EnvImportCommand extends Command {
   async run() {
     const { args, flags } = this.parse(EnvImportCommand)
@@ -62,7 +50,9 @@ class EnvImportCommand extends Command {
       siteId,
       body: {
         build_settings: {
-          env: flags.replaceExisting ? importedEnv : mergeEnvVars(env, importedEnv),
+          // Only set imported variables if --replaceExisting or otherwise merge
+          // imported ones with the current environment variables.
+          env: flags.replaceExisting ? importedEnv : { ...env, ...importedEnv },
         },
       },
     })

--- a/src/commands/env/index.js
+++ b/src/commands/env/index.js
@@ -21,7 +21,7 @@ class EnvCommand extends Command {
   }
 }
 
-EnvCommand.description = `Control environment variables for the current site`
+EnvCommand.description = `(Beta) Control environment variables for the current site`
 EnvCommand.examples = [
   'netlify env:list',
   'netlify env:get VAR_NAME',

--- a/src/commands/env/index.js
+++ b/src/commands/env/index.js
@@ -26,7 +26,7 @@ EnvCommand.examples = [
   'netlify env:list',
   'netlify env:get VAR_NAME',
   'netlify env:set VAR_NAME value',
-  'netlify env:delete VAR_NAME',
+  'netlify env:unset VAR_NAME',
   'netlify env:import fileName',
 ]
 

--- a/src/commands/env/index.js
+++ b/src/commands/env/index.js
@@ -1,0 +1,34 @@
+const Command = require('../../utils/command')
+const showHelp = require('../../utils/show-help')
+const { isEmptyCommand } = require('../../utils/check-command-inputs')
+
+class EnvCommand extends Command {
+  async run() {
+    const { flags, args } = this.parse(EnvCommand)
+
+    // Show help on empty sub command
+    if (isEmptyCommand(flags, args)) {
+      showHelp(this.id)
+      this.exit()
+    }
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'env',
+      },
+    })
+  }
+}
+
+EnvCommand.description = `Control environment variables for the current site`
+EnvCommand.examples = [
+  'netlify env:list',
+  'netlify env:get VAR_NAME',
+  'netlify env:set VAR_NAME value',
+  'netlify env:delete VAR_NAME',
+  'netlify env:import fileName',
+  // 'netlify env:export file-name'
+]
+
+module.exports = EnvCommand

--- a/src/commands/env/index.js
+++ b/src/commands/env/index.js
@@ -28,7 +28,6 @@ EnvCommand.examples = [
   'netlify env:set VAR_NAME value',
   'netlify env:delete VAR_NAME',
   'netlify env:import fileName',
-  // 'netlify env:export file-name'
 ]
 
 module.exports = EnvCommand

--- a/src/commands/env/list.js
+++ b/src/commands/env/list.js
@@ -1,0 +1,53 @@
+const AsciiTable = require('ascii-table')
+const Command = require('../../utils/command')
+const isEmpty = require('lodash.isempty')
+
+class EnvListCommand extends Command {
+  async run() {
+    const { flags } = this.parse(EnvListCommand)
+    const { api, site, config } = this.netlify
+    const siteId = site.id
+
+    if (!siteId) {
+      this.log('No site id found, please run inside a site folder or `netlify link`')
+      return false
+    }
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'env:list',
+      },
+    })
+
+    const siteData = await api.getSite({ siteId })
+    const {
+      build: { environment = {} },
+    } = config
+
+    // Return json response for piping commands
+    if (flags.json) {
+      this.logJson(environment)
+      return false
+    }
+
+    if (isEmpty(environment)) {
+      this.log(`No environment variables set for site ${siteData.name}`)
+      return false
+    }
+
+    // List environment variables using a table
+    this.log(`site: ${siteData.name}`)
+    const table = new AsciiTable(`Environment variables`)
+
+    table.setHeading('Key', 'Value')
+    for (const [key, value] of Object.entries(environment)) {
+      table.addRow(key, value)
+    }
+    this.log(table.toString())
+  }
+}
+
+EnvListCommand.description = `Lists resolved environment variables for site (includes netlify.toml)`
+
+module.exports = EnvListCommand

--- a/src/commands/env/set.js
+++ b/src/commands/env/set.js
@@ -1,0 +1,77 @@
+const Command = require('../../utils/command')
+
+class EnvSetCommand extends Command {
+  async run() {
+    const { args, flags } = this.parse(EnvSetCommand)
+    const { api, site } = this.netlify
+    const siteId = site.id
+
+    if (!siteId) {
+      this.log('No site id found, please run inside a site folder or `netlify link`')
+      return false
+    }
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'env:set',
+      },
+    })
+
+    const siteData = await api.getSite({ siteId })
+
+    // Get current environment variables set in the UI
+    const {
+      build_settings: { env = {} },
+    } = siteData
+
+    const newEnv = env
+
+    // Set or delete environment variable from current variables
+    const { name, value } = args
+    const shouldDelete = !value.trim()
+    if (shouldDelete) {
+      delete newEnv[name]
+    } else {
+      newEnv[name] = value
+    }
+
+    // Apply environment variable updates
+    const siteResult = await api.updateSite({
+      siteId,
+      body: {
+        build_settings: {
+          env: newEnv,
+        },
+      },
+    })
+
+    // Return updated site object if using json flag
+    if (flags.json) {
+      this.logJson(siteResult)
+      return false
+    }
+
+    const operationMessage = !shouldDelete
+      ? `Set environment variable ${name}=${value}`
+      : `Deleted environment variable ${name}`
+    this.log(operationMessage + ` for site ${siteData.name}`)
+  }
+}
+
+EnvSetCommand.description = `Set value of environment variable`
+EnvSetCommand.args = [
+  {
+    name: 'name',
+    required: true,
+    description: 'Environment variable name',
+  },
+  {
+    name: 'value',
+    required: false,
+    default: '',
+    description: 'Value to set to (leave empty to delete)',
+  },
+]
+
+module.exports = EnvSetCommand

--- a/src/commands/env/set.js
+++ b/src/commands/env/set.js
@@ -46,9 +46,9 @@ class EnvSetCommand extends Command {
       },
     })
 
-    // Return updated site object if using json flag
+    // Return new environment variables of site if using json flag
     if (flags.json) {
-      this.logJson(siteResult)
+      this.logJson(siteResult.build_settings.env)
       return false
     }
 

--- a/src/commands/env/unset.js
+++ b/src/commands/env/unset.js
@@ -1,10 +1,11 @@
 const Command = require('../../utils/command')
 
-class EnvSetCommand extends Command {
+class EnvUnsetCommand extends Command {
   async run() {
-    const { args, flags } = this.parse(EnvSetCommand)
+    const { args, flags } = this.parse(EnvUnsetCommand)
     const { api, site } = this.netlify
     const siteId = site.id
+    const name = args.name
 
     if (!siteId) {
       this.log('No site id found, please run inside a site folder or `netlify link`')
@@ -14,7 +15,7 @@ class EnvSetCommand extends Command {
     await this.config.runHook('analytics', {
       eventName: 'command',
       payload: {
-        command: 'env:set',
+        command: 'env:unset',
       },
     })
 
@@ -25,12 +26,10 @@ class EnvSetCommand extends Command {
       build_settings: { env = {} },
     } = siteData
 
-    // Merge new enviroment variable with currently set variables
-    const { name, value } = args
-    const newEnv = {
-      ...env,
-      [name]: value,
-    }
+    const newEnv = env
+
+    // Delete environment variable from current variables
+    delete newEnv[args.name]
 
     // Apply environment variable updates
     const siteResult = await api.updateSite({
@@ -48,23 +47,18 @@ class EnvSetCommand extends Command {
       return false
     }
 
-    this.log(`Set environment variable ${name}=${value} for site ${siteData.name}`)
+    this.log(`Unset environment variable ${name} for site ${siteData.name}`)
   }
 }
 
-EnvSetCommand.description = `Set value of environment variable`
-EnvSetCommand.args = [
+EnvUnsetCommand.description = `Unset an environment variable which removes it from the UI`
+EnvUnsetCommand.aliases = ['env:delete', 'env:remove']
+EnvUnsetCommand.args = [
   {
     name: 'name',
     required: true,
     description: 'Environment variable name',
   },
-  {
-    name: 'value',
-    required: false,
-    default: '',
-    description: 'Value to set to',
-  },
 ]
 
-module.exports = EnvSetCommand
+module.exports = EnvUnsetCommand

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -1,0 +1,193 @@
+const test = require('ava')
+const stripAnsi = require('strip-ansi')
+const cliPath = require('./utils/cliPath')
+const execa = require('execa')
+const { createSiteBuilder } = require('./utils/siteBuilder')
+const isObject = require('lodash.isobject')
+const isEmpty = require('lodash.isempty')
+
+const siteName =
+  'netlify-test-env-' +
+  Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, '')
+    .substr(0, 8)
+
+async function callCli(args, execOptions) {
+  return (await execa(cliPath, args, execOptions)).stdout
+}
+
+async function listAccounts() {
+  return JSON.parse(await callCli(['api', 'listAccountsForUser']))
+}
+
+async function createSite(siteName, accountSlug, execOptions) {
+  const cliResponse = await callCli(['sites:create', '--name', siteName, '--account-slug', accountSlug], execOptions)
+
+  const isSiteCreated = /Site Created/.test(cliResponse)
+  if (!isSiteCreated) {
+    return null
+  }
+
+  const matches = /Site ID:\s+([a-zA-Z0-9-]+)/m.exec(stripAnsi(cliResponse))
+  if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
+    return matches[1]
+  }
+
+  return null
+}
+
+async function addTestNetlifyToml(builder) {
+  const builderWithToml = builder.withNetlifyToml({
+    config: {
+      build: {
+        environment: {
+          SOME_VAR2: 'FOO_NETLIFY_TOML',
+        },
+      },
+    },
+  })
+  await builderWithToml.buildAsync()
+  return builderWithToml
+}
+
+if (process.env.IS_FORK !== 'true') {
+  test.before(async t => {
+    const accounts = await listAccounts()
+    t.is(Array.isArray(accounts), true)
+    t.truthy(accounts.length)
+
+    const account = accounts[0]
+
+    const builder = createSiteBuilder({ siteName: 'site-with-env-vars' }).withEnvFile({
+      path: '.env',
+      env: { SOME_VAR1: 'FOOBARBUZZ', SOME_VAR2: 'FOO' },
+    })
+    await builder.buildAsync()
+
+    const execOptions = {
+      cwd: builder.directory,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    }
+
+    console.log('creating new site for tests: ' + siteName)
+    const siteId = await createSite(siteName, account.slug, execOptions)
+    t.truthy(siteId != null)
+
+    t.context.execOptions = { ...execOptions, env: { ...process.env, NETLIFY_SITE_ID: siteId } }
+    t.context.builder = builder
+  })
+
+  test.serial('env:list --json should return empty object if no vars set', async t => {
+    const cliResponse = await callCli(['env:list', '--json'], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.true(isEmpty(json))
+  })
+
+  test.serial('env:get --json should return empty object if var not set', async t => {
+    const cliResponse = await callCli(['env:get', '--json', 'SOME_VAR'], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.true(isEmpty(json))
+  })
+
+  test.serial('env:set --json should create and return new var', async t => {
+    const name = 'SOME_VAR1'
+    const value = 'FOO'
+
+    const cliResponse = await callCli(['env:set', '--json', name, value], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(json[name], value)
+  })
+
+  test.serial('env:set --json should update existing var', async t => {
+    const name = 'SOME_VAR1'
+    const value = 'FOOBAR'
+
+    const cliResponse = await callCli(['env:set', '--json', name, value], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(json[name], value)
+  })
+
+  test.serial('env:get --json should return value of existing var', async t => {
+    const name = 'SOME_VAR1'
+    const value = 'FOOBAR'
+
+    const cliResponse = await callCli(['env:get', '--json', name], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(Object.keys(json).length, 1)
+    t.is(json[name], value)
+  })
+
+  test.serial('env:import should throw error if file not exists', async t => {
+    const fileName = '.env.unknown'
+
+    await t.throwsAsync(async () => {
+      await callCli(['env:import', fileName], t.context.execOptions)
+    })
+  })
+
+  test.serial('env:import --json should set new vars and update existing vars', async t => {
+    const fileName = '.env'
+
+    const cliResponse = await callCli(['env:import', '--json', fileName], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(json['SOME_VAR1'], 'FOOBARBUZZ') // updated var
+    t.is(json['SOME_VAR2'], 'FOO') // new var
+  })
+
+  test.serial('env:list --json should return list of vars with netlify.toml taking priority', async t => {
+    // Add netlify.toml before running all following tests as they check
+    // right behavior with netlify.toml.
+    t.context.builder = await addTestNetlifyToml(t.context.builder)
+
+    const cliResponse = await callCli(['env:list', '--json'], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(json['SOME_VAR1'], 'FOOBARBUZZ')
+    t.is(json['SOME_VAR2'], 'FOO_NETLIFY_TOML')
+  })
+
+  test.serial('env:get --json should return value of var from netlify.toml', async t => {
+    const cliResponse = await callCli(['env:get', '--json', 'SOME_VAR2'], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.is(Object.keys(json).length, 1)
+    t.is(json['SOME_VAR2'], 'FOO_NETLIFY_TOML')
+  })
+
+  test.serial('env:set --json should unset var if value is set empty', async t => {
+    const name = 'SOME_VAR1'
+
+    const cliResponse = await callCli(['env:set', '--json', name, ''], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.falsy(name in json)
+  })
+
+  test.after('cleanup', async t => {
+    const { execOptions, builder } = t.context
+
+    console.log('Performing cleanup')
+
+    console.log(`deleting test site "${siteName}". ${execOptions.env.NETLIFY_SITE_ID}`)
+    await callCli(['sites:delete', execOptions.env.NETLIFY_SITE_ID, '--force'], execOptions)
+
+    await builder.cleanupAsync()
+  })
+}

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -28,7 +28,8 @@ const ENV_VAR_STATES = {
     SOME_VAR2: 'FOO', // import new var
   },
   netlifyToml: { SOME_VAR2: 'FOO_NETLIFY_TOML' }, // should take priority over existing SOME_VAR2
-  unset: { SOME_VAR1: '' },
+  setEmpty: { SOME_VAR1: '' },
+  unset: { SOME_VAR1: null },
   importReplace: {
     SOME_VAR1: 'BAR1',
     SOME_VAR2: 'BAR2',
@@ -187,11 +188,22 @@ if (process.env.IS_FORK !== 'true') {
     checkResultState({ t, result: json, state: merged })
   })
 
-  test.serial('env:set --json should unset var if value is set empty', async t => {
-    const args = getArgsFromState(ENV_VAR_STATES.unset)
+  test.serial('env:set --json should be able to set var with empty value', async t => {
+    const args = getArgsFromState(ENV_VAR_STATES.setEmpty)
     const key = args[0]
 
     const cliResponse = await callCli(['env:set', '--json', ...args], t.context.execOptions)
+    const json = JSON.parse(cliResponse)
+
+    t.true(isObject(json))
+    t.truthy(key in json)
+    checkResultState({ t, result: json, state: ENV_VAR_STATES.setEmpty })
+  })
+
+  test.serial('env:unset --json should unset var if value is set empty', async t => {
+    const key = getArgsFromState(ENV_VAR_STATES.unset)[0]
+
+    const cliResponse = await callCli(['env:unset', '--json', key], t.context.execOptions)
     const json = JSON.parse(cliResponse)
 
     t.true(isObject(json))

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -200,7 +200,7 @@ if (process.env.IS_FORK !== 'true') {
     checkResultState({ t, result: json, state: ENV_VAR_STATES.setEmpty })
   })
 
-  test.serial('env:unset --json should unset var if value is set empty', async t => {
+  test.serial('env:unset --json should remove existing variable', async t => {
     const key = getArgsFromState(ENV_VAR_STATES.unset)[0]
 
     const cliResponse = await callCli(['env:unset', '--json', key], t.context.execOptions)

--- a/tests/utils/callCli.js
+++ b/tests/utils/callCli.js
@@ -1,0 +1,8 @@
+const execa = require('execa')
+const cliPath = require('./cliPath')
+
+async function callCli(args, execOptions) {
+  return (await execa(cliPath, args, execOptions)).stdout
+}
+
+module.exports = callCli

--- a/tests/utils/createLiveTestSite.js
+++ b/tests/utils/createLiveTestSite.js
@@ -1,0 +1,20 @@
+const stripAnsi = require('strip-ansi')
+const callCli = require('./callCli')
+
+async function createLiveTestSite(siteName, accountSlug, execOptions) {
+  const cliResponse = await callCli(['sites:create', '--name', siteName, '--account-slug', accountSlug], execOptions)
+
+  const isSiteCreated = /Site Created/.test(cliResponse)
+  if (!isSiteCreated) {
+    return null
+  }
+
+  const matches = /Site ID:\s+([a-zA-Z0-9-]+)/m.exec(stripAnsi(cliResponse))
+  if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
+    return matches[1]
+  }
+
+  return null
+}
+
+module.exports = createLiveTestSite


### PR DESCRIPTION
**- Summary**

Closes #1011

This PR introduces commands for managing environment variables from the CLI. It uses the Netlify API to set environment variables for the current site in the UI. 

| Command | Description |
| -------------- | --------------- |
| `netlify env:list` | Shows a table of env variables including those set in `netlify.toml`.  |
| `netlify env:get NAME` | Prints the value of a specified variable including those set in `netlify.toml`. |
| `netlify env:set NAME VALUE` | Sets an environment variable in the UI. |
| `netlify env:set NAME` | Removes an environment variable in the UI. |
| `netlify env:import FILE_NAME` | Imports environment variables from `.env` files and sets them in the UI. |
| `netlify env:import --replaceExisting FILE_NAME` | Imports environment variables from `.env` files while deleting any previously set variables in the UI. Can be useful for e.g. renaming variables. |

For the manipulation commands `netlify env:import` and `netlify env:set` with the `--json` flag it returns all variables which are afterwards present for the site in the UI.

**- Test plan**

Automated tests are available in `/tests/command.env.test.js`. They are run serial because they create a test site on Netlify for making use of the API. This is similar to what is done in the tests for addons. Therefore, I also moved two functions into `/tests/utils` for re-use.

Test execution (total execution time ~ 30s): 
```
npx ava --verbose command.env.test.js

creating new site for tests: netlify-test-env-ocanhpby
  ✔ env:list --json should return empty object if no vars set (2.1s)
  ✔ env:get --json should return empty object if var not set (2.1s)
  ✔ env:set --json should create and return new var (2.5s)
  ✔ env:set --json should update existing var (2.3s)
  ✔ env:get --json should return value of existing var (2.2s)
  ✔ env:import should throw error if file not exists (2s)
  ✔ env:import --json should import new vars and override existing vars (2.4s)
  ✔ env:get --json should return value of var from netlify.toml (2s)
  ✔ env:list --json should return list of vars with netlify.toml taking priority (2s)
  ✔ env:set --json should unset var if value is set empty (2.3s)
  ✔ env:import --json --replace-existing should replace all existing vars and return imported (2.5s)
Performing cleanup
deleting test site "netlify-test-env-ocanhpby". 9189194a-dfaf-4e3f-8e0d-9c9880035690

  11 tests passed
```

**- Description for the changelog**

feat(env): add command to list/get/set/import environment variables 

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_2019_AOJQW0312KMA](https://user-images.githubusercontent.com/4885581/91636550-cd647080-ea01-11ea-8882-c9e7d0a02c64.jpg)
