### PR TITLE
chore(deps): ignore some more packages due to node 8 support

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,7 +11,23 @@
     },
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8
-      packageNames: ['eslint', 'ava', 'globby', '@octokit/rest', 'chalk', 'prettier'],
+      packageNames: [
+        '@octokit/rest',
+        'ava',
+        'chalk',
+        'concordance',
+        'cosmiconfig',
+        'eslint',
+        'execa',
+        'find-up',
+        'fs-extra',
+        'globby',
+        'log-symbols',
+        'npm-packlist',
+        'ora',
+        'prettier',
+        'wrap-ansi',
+      ],
       major: {
         enabled: false,
       },


### PR DESCRIPTION
Ignore some more packages since we can't update until we drop node 8.
I already updated those to the latest version supporting node 8.