### PR TITLE
ci: update node versions to 8,12,14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [8.x, 10.x, 12.x, 13.x]
+        node-version: [8.x, 12.x, 14.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Our current testing matrix uses 12 machines (4 node version * 3 OS).
This is redundant.
We should test on:
1. Node 8 since we still support it.
2. Node 12 since it LTS and default in Netlify.
3. Node 14 since it is the current version.