### PR TITLE
ci: change job time limit to 30 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]


### PR DESCRIPTION
Found out the default limit is 6 hours(!):
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

This PR changes it to 30 minutes