### PR TITLE
test: set random static server port for tests

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -623,6 +623,10 @@ DevCommand.flags = {
   targetPort: flags.integer({
     description: 'port of target app server',
   }),
+  staticServerPort: flags.integer({
+    description: 'port of the static app server used when no framework is detected',
+    hidden: true,
+  }),
   dir: flags.string({
     char: 'd',
     description: 'dir with static files',

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -188,7 +188,7 @@ async function getStaticServerSettings(settings, flags, projectDir, log) {
   log(`${NETLIFYDEVWARN} Running static server from "${path.relative(path.dirname(projectDir), dist)}"`)
   return {
     noCmd: true,
-    frameworkPort: await getPort({ port: 3999 }),
+    frameworkPort: await getPort({ port: flags.staticServerPort || 3999 }),
     dist,
   }
 }

--- a/tests/utils/devServer.js
+++ b/tests/utils/devServer.js
@@ -20,7 +20,7 @@ const startServer = async ({ cwd, env = {} }) => {
   const host = 'localhost'
   const url = `http://${host}:${port}`
   console.log(`Starting dev server on port: ${port} in directory ${path.basename(cwd)}`)
-  const ps = execa(cliPath, ['dev', '-p', port], {
+  const ps = execa(cliPath, ['dev', '-p', port, '--staticServerPort', port + 1000], {
     cwd,
     env,
   })


### PR DESCRIPTION
This is an attempt to make the tests more stable.
The static server port is currently hard coded (that port is used when no framework is detected and we just server files statically from the publish folder).
Added a hidden flag to be used in tests for the sake of randomising the port.