### PR TITLE
fix(docs): hide hidden command flags from docs

### DIFF
--- a/scripts/generateCommandData.js
+++ b/scripts/generateCommandData.js
@@ -1,4 +1,7 @@
 const path = require('path')
+// This dependency is installed in `site/package.json`
+// eslint-disable-next-line node/no-extraneous-require
+const filterObj = require('filter-obj')
 const globby = require('markdown-magic').globby
 
 module.exports = function generateCommandData() {
@@ -8,16 +11,18 @@ module.exports = function generateCommandData() {
   const commands = globby.sync([`${commandsPath}/**/**.js`, `${netlifyDevPath}/**/**.js`])
 
   const allCommands = commands.map(file => {
-    const cmd = require(file)
+    const data = require(file)
     const command = commandFromPath(file)
     const parentCommand = command.split(':')[0]
     const parent = command === parentCommand ? true : false
+    // remove hidden flags
+    const flags = data.flags && filterObj(data.flags, (_, value) => value.hidden !== true)
     return {
       command,
       commandGroup: parentCommand,
       isParent: parent,
       path: file,
-      data: cmd,
+      data: { ...data, flags },
     }
   })
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1960,6 +1960,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4017,6 +4026,12 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "3.5.11",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
@@ -4032,6 +4047,12 @@
         "repeat-string": "^1.6.1",
         "to-regex-range": "^2.1.0"
       }
+    },
+    "filter-obj": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
+      "integrity": "sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==",
+      "dev": true
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -5969,6 +5990,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanoassert": {
       "version": "1.1.0",
@@ -9418,7 +9445,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/site/package.json
+++ b/site/package.json
@@ -33,6 +33,7 @@
     "styled-components": "^3.4.10"
   },
   "devDependencies": {
+    "filter-obj": "^2.0.1",
     "fs-extra": "^9.0.1",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
The `staticServerPort` flag added to the `dev` command [here](https://github.com/netlify/cli/pull/1188) is shown in the docs.

This PR fixes the code that generates the docs to remove hidden flags.