### PR TITLE
fix(command-env): handle non existing import file on node 8

### DIFF
--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -37,7 +37,8 @@ class EnvImportCommand extends Command {
       const envFileContents = fs.readFileSync(fileName)
       importedEnv = dotenv.parse(envFileContents)
     } catch (e) {
-      this.error(e)
+      this.log(e.message)
+      this.exit(1)
     }
 
     if (isEmpty(importedEnv)) {


### PR DESCRIPTION
@Pyrax our default branch CI started failing after merging https://github.com/netlify/cli/pull/1162
https://github.com/netlify/cli/runs/1061075168?check_suite_focus=true#step:5:251

My guess it that one of the dependencies update broke the `error` command on node 8 (tried it locally and it is indeed broken).

This PR should fix it.