### PR TITLE
fix(command-dev): pass functions server uri to traffic mesh

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -121,6 +121,7 @@ const startProxyServer = async ({ flags, settings, site, log, exit, addonUrls })
     url = await startForwardProxy({
       port: settings.port,
       frameworkPort: settings.frameworkPort,
+      functionsPort: settings.functionsPort,
       projectDir: site.root,
       log,
       debug: flags.debug,

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -162,8 +162,10 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
   }
 
   settings.jwtRolePath = devConfig.jwtRolePath || 'app_metadata.authorization.roles'
-  settings.functionsPort = await getPort({ port: settings.functionsPort || 0 })
   settings.functions = devConfig.functions || settings.functions
+  if (settings.functions) {
+    settings.functionsPort = await getPort({ port: settings.functionsPort || 0 })
+  }
 
   return settings
 }

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -35,7 +35,16 @@ const installTrafficMesh = async ({ log }) => {
 
 const startForwardProxy = async ({ port, frameworkPort, functionsPort, projectDir, log, debug }) => {
   await installTrafficMesh({ log })
-  const args = ['start', 'local', '--port', port, '--forward-proxy', `http://localhost:${frameworkPort}`, '--watch', projectDir]
+  const args = [
+    'start',
+    'local',
+    '--port',
+    port,
+    '--forward-proxy',
+    `http://localhost:${frameworkPort}`,
+    '--watch',
+    projectDir,
+  ]
 
   if (functionsPort) {
     args.push('--local-services-uri', `http://localhost:${functionsPort}`)

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -35,7 +35,7 @@ const installTrafficMesh = async ({ log }) => {
 
 const startForwardProxy = async ({ port, frameworkPort, functionsPort, projectDir, log, debug }) => {
   await installTrafficMesh({ log })
-  const args = ['start', '--port', port, '--forward-proxy', `http://localhost:${frameworkPort}`, '--watch', projectDir]
+  const args = ['start', 'local', '--port', port, '--forward-proxy', `http://localhost:${frameworkPort}`, '--watch', projectDir]
 
   if (functionsPort) {
     args.push('--local-services-uri', `http://localhost:${functionsPort}`)

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -33,9 +33,13 @@ const installTrafficMesh = async ({ log }) => {
   })
 }
 
-const startForwardProxy = async ({ port, frameworkPort, projectDir, log, debug }) => {
+const startForwardProxy = async ({ port, frameworkPort, functionsPort, projectDir, log, debug }) => {
   await installTrafficMesh({ log })
   const args = ['start', '--port', port, '--forward-proxy', `http://localhost:${frameworkPort}`, '--watch', projectDir]
+
+  if (functionsPort) {
+    args.push('--local-services-uri', `http://localhost:${functionsPort}`)
+  }
 
   if (debug) {
     args.push('--debug')


### PR DESCRIPTION
Adds support for functions redirects when using `--trafficMesh`.

Pending a new release of https://github.com/netlify/traffic-mesh-agent