### PR TITLE
fix(command-dev): prevent Docusaurus from launching browser

### DIFF
--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -16,6 +16,7 @@ module.exports = function() {
     framework: 'docusaurus',
     command: getYarnOrNPMCommand(),
     frameworkPort: 3000,
+    env: { BROWSER: 'none' },
     possibleArgsArrs,
     dist: 'static',
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Docusaurus automatically launches a browser, but Netlify Dev does not prevent it, leading to confusing scenarios where you'll have the wrong server open in your browser and Netlify options like redirects won't work. This also brings the functionality in line with similar tools like create-react-app.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

I ran `bin/run` and Docusaurus did not launch the browser as I expected.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Disable Docusaurus' `BROWSER` environment variable.
