### PR TITLE
Docs: move global flags to bottom

### DIFF
--- a/docs/commands/addons.md
+++ b/docs/commands/addons.md
@@ -118,8 +118,8 @@ netlify addons:delete
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `force` (*boolean*) - delete without prompting (useful for CI)
+- `debug` (*boolean*) - Print debugging information
 
 ---
 ## `addons:list`
@@ -134,8 +134,8 @@ netlify addons:list
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `json` (*boolean*) - Output add-on data as JSON
+- `debug` (*boolean*) - Print debugging information
 
 ---
 

--- a/docs/commands/api.md
+++ b/docs/commands/api.md
@@ -24,9 +24,9 @@ netlify api
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `data` (*option*) - Data to use
 - `list` (*boolean*) - List out available API methods
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -15,9 +15,9 @@ netlify build
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `dry` (*boolean*) - Dry run: show instructions without running them
 - `context` (*option*) - Build context
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -84,7 +84,6 @@ netlify deploy
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `dir` (*option*) - Specify a folder to deploy
 - `functions` (*option*) - Specify a functions folder to deploy
 - `prod` (*boolean*) - Deploy to production
@@ -97,6 +96,7 @@ netlify deploy
 - `json` (*boolean*) - Output deployment data as JSON
 - `timeout` (*option*) - Timeout to wait for deployment to finish
 - `trigger` (*boolean*) - Trigger a new build of your site on Netlify without uploading local files
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -18,7 +18,6 @@ netlify dev
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `command` (*option*) - command to run
 - `port` (*option*) - port of netlify dev
 - `targetPort` (*option*) - port of target app server
@@ -26,6 +25,7 @@ netlify dev
 - `functions` (*option*) - Specify a functions folder to serve
 - `offline` (*boolean*) - disables any features that require network access
 - `live` (*boolean*) - Start a public live session
+- `debug` (*boolean*) - Print debugging information
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -73,8 +73,8 @@ netlify env:import
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `replaceExisting` (*boolean*) - Replace all existing variables instead of merging them with the current ones
+- `debug` (*boolean*) - Print debugging information
 
 ---
 ## `env:list`

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -44,9 +44,9 @@ netlify functions:build
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `functions` (*option*) - Specify a functions folder to build to
 - `src` (*option*) - Specify the source folder for the functions
+- `debug` (*boolean*) - Print debugging information
 
 ---
 ## `functions:create`
@@ -65,9 +65,9 @@ netlify functions:create
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `name` (*option*) - function name
 - `url` (*option*) - pull template from URL
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 
@@ -94,13 +94,13 @@ netlify functions:invoke
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `name` (*option*) - function name to invoke
 - `functions` (*option*) - Specify a functions folder to parse, overriding netlify.toml
 - `querystring` (*option*) - Querystring to add to your function invocation
 - `payload` (*option*) - Supply POST payload in stringified json, or a path to a json file
 - `identity` (*boolean*) - simulate Netlify Identity authentication JWT. pass --no-identity to affirm unauthenticated request
 - `port` (*option*) - Port where netlify dev is accessible. e.g. 8888
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -16,10 +16,10 @@ netlify init
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `manual` (*boolean*) - Manually configure a git remote for CI
 - `force` (*boolean*) - Reinitialize CI hooks if the linked site is already configured to use CI
 - `gitRemoteName` (*option*) - Name of Git remote to use. e.g. "origin"
+- `debug` (*boolean*) - Print debugging information
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/link.md
+++ b/docs/commands/link.md
@@ -16,10 +16,10 @@ netlify link
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `id` (*option*) - ID of site to link to
 - `name` (*option*) - Name of site to link to
 - `gitRemoteName` (*option*) - Name of Git remote to use. e.g. "origin"
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -19,8 +19,8 @@ netlify login
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `new` (*boolean*) - Login to new Netlify account
+- `debug` (*boolean*) - Print debugging information
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/sites.md
+++ b/docs/commands/sites.md
@@ -46,11 +46,11 @@ netlify sites:create
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `name` (*option*) - name of site
 - `account-slug` (*option*) - account slug to create the site under
 - `with-ci` (*boolean*) - initialize CI hooks during site creation
 - `manual` (*boolean*) - Force manual CI setup.  Used --with-ci flag
+- `debug` (*boolean*) - Print debugging information
 
 ---
 ## `sites:delete`
@@ -72,8 +72,8 @@ netlify sites:delete {site-id}
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `force` (*boolean*) - delete without prompting (useful for CI)
+- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 
@@ -94,8 +94,8 @@ netlify sites:list
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `json` (*boolean*) - Output site data as JSON
+- `debug` (*boolean*) - Print debugging information
 
 ---
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -16,8 +16,8 @@ netlify status
 
 **Flags**
 
-- `debug` (*boolean*) - Print debugging information
 - `verbose` (*boolean*) - Output system info
+- `debug` (*boolean*) - Print debugging information
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -94,11 +94,11 @@ Add-ons are a way to extend the functionality of your Netlify site
 AddonsDeleteCommand.strict = false
 AddonsDeleteCommand.aliases = ['addon:delete']
 AddonsDeleteCommand.flags = {
-  ...AddonsDeleteCommand.flags,
   force: flags.boolean({
     char: 'f',
     description: 'delete without prompting (useful for CI)',
   }),
+  ...AddonsDeleteCommand.flags,
 }
 AddonsDeleteCommand.args = [
   {

--- a/src/commands/addons/list.js
+++ b/src/commands/addons/list.js
@@ -64,10 +64,10 @@ class AddonsListCommand extends Command {
 AddonsListCommand.description = `List currently installed add-ons for site`
 AddonsListCommand.aliases = ['addon:list']
 AddonsListCommand.flags = {
-  ...AddonsListCommand.flags,
   json: flags.boolean({
     description: 'Output add-on data as JSON',
   }),
+  ...AddonsListCommand.flags,
 }
 
 module.exports = AddonsListCommand

--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -71,7 +71,6 @@ APICommand.args = [
 APICommand.examples = ['netlify api --list', 'netlify api getSite --data \'{ "site_id": "123456"}\'']
 
 APICommand.flags = {
-  ...APICommand.flags,
   data: oclif.flags.string({
     char: 'd',
     description: 'Data to use',
@@ -79,6 +78,7 @@ APICommand.flags = {
   list: oclif.flags.boolean({
     description: 'List out available API methods',
   }),
+  ...APICommand.flags,
 }
 
 APICommand.strict = false

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -47,13 +47,13 @@ class BuildCommand extends Command {
 
 // Netlify Build programmatic options
 BuildCommand.flags = {
-  ...BuildCommand.flags,
   dry: flags.boolean({
     description: 'Dry run: show instructions without running them',
   }),
   context: flags.string({
     description: 'Build context',
   }),
+  ...BuildCommand.flags,
 }
 
 BuildCommand.description = `(Beta) Build on your local machine`

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -373,7 +373,6 @@ DeployCommand.examples = [
 ]
 
 DeployCommand.flags = {
-  ...DeployCommand.flags,
   dir: flags.string({
     char: 'd',
     description: 'Specify a folder to deploy',
@@ -422,6 +421,7 @@ DeployCommand.flags = {
   trigger: flags.boolean({
     description: 'Trigger a new build of your site on Netlify without uploading local files',
   }),
+  ...DeployCommand.flags,
 }
 
 function deployProgressCb() {

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -243,7 +243,6 @@ DevCommand.examples = ['$ netlify dev', '$ netlify dev -c "yarn start"', '$ netl
 DevCommand.strict = false
 
 DevCommand.flags = {
-  ...DevCommand.flags,
   command: flags.string({
     char: 'c',
     description: 'command to run',
@@ -280,6 +279,7 @@ DevCommand.flags = {
     hidden: true,
     description: 'Uses Traffic Mesh for proxying requests',
   }),
+  ...DevCommand.flags,
 }
 
 module.exports = DevCommand

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -78,12 +78,12 @@ class EnvImportCommand extends Command {
 
 EnvImportCommand.description = `Import and set environment variables from .env file`
 EnvImportCommand.flags = {
-  ...EnvImportCommand.flags,
   replaceExisting: flags.boolean({
     char: 'r',
     description: 'Replace all existing variables instead of merging them with the current ones',
     default: false,
   }),
+  ...EnvImportCommand.flags,
 }
 EnvImportCommand.args = [
   {

--- a/src/commands/functions/build.js
+++ b/src/commands/functions/build.js
@@ -59,7 +59,6 @@ FunctionsBuildCommand.description = `Build functions locally
 `
 FunctionsBuildCommand.aliases = ['function:build']
 FunctionsBuildCommand.flags = {
-  ...FunctionsBuildCommand.flags,
   functions: flags.string({
     char: 'f',
     description: 'Specify a functions folder to build to',
@@ -68,6 +67,7 @@ FunctionsBuildCommand.flags = {
     char: 's',
     description: 'Specify the source folder for the functions',
   }),
+  ...FunctionsBuildCommand.flags,
 }
 
 module.exports = FunctionsBuildCommand

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -60,9 +60,9 @@ FunctionsCreateCommand.examples = [
 ]
 FunctionsCreateCommand.aliases = ['function:create']
 FunctionsCreateCommand.flags = {
-  ...FunctionsCreateCommand.flags,
   name: flags.string({ char: 'n', description: 'function name' }),
   url: flags.string({ char: 'u', description: 'pull template from URL' }),
+  ...FunctionsCreateCommand.flags,
 }
 module.exports = FunctionsCreateCommand
 

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -229,7 +229,6 @@ FunctionsInvokeCommand.args = [
 ]
 
 FunctionsInvokeCommand.flags = {
-  ...FunctionsInvokeCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'function name to invoke',
@@ -253,6 +252,7 @@ FunctionsInvokeCommand.flags = {
   port: flags.integer({
     description: 'Port where netlify dev is accessible. e.g. 8888',
   }),
+  ...FunctionsInvokeCommand.flags,
 }
 
 module.exports = FunctionsInvokeCommand

--- a/src/commands/functions/list.js
+++ b/src/commands/functions/list.js
@@ -94,7 +94,6 @@ NOT the same as listing the functions that have been deployed. For that info you
 `
 FunctionsListCommand.aliases = ['function:list']
 FunctionsListCommand.flags = {
-  ...FunctionsListCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'name to print',
@@ -106,6 +105,7 @@ FunctionsListCommand.flags = {
   json: flags.boolean({
     description: 'Output function data as JSON',
   }),
+  ...FunctionsListCommand.flags,
 }
 
 // TODO make visible once implementation complete

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -242,7 +242,6 @@ git remote add origin https://github.com/YourUserName/RepoName.git
 InitCommand.description = `Configure continuous deployment for a new or existing site`
 
 InitCommand.flags = {
-  ...InitCommand.flags,
   manual: flags.boolean({
     char: 'm',
     description: 'Manually configure a git remote for CI',
@@ -253,6 +252,7 @@ InitCommand.flags = {
   gitRemoteName: flags.string({
     description: 'Name of Git remote to use. e.g. "origin"',
   }),
+  ...InitCommand.flags,
 }
 
 module.exports = InitCommand

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -113,7 +113,6 @@ LinkCommand.description = `Link a local repo or project folder to an existing si
 LinkCommand.examples = ['netlify link', 'netlify link --id 123-123-123-123', 'netlify link --name my-site-name']
 
 LinkCommand.flags = {
-  ...LinkCommand.flags,
   id: flags.string({
     description: 'ID of site to link to',
   }),
@@ -123,6 +122,7 @@ LinkCommand.flags = {
   gitRemoteName: flags.string({
     description: 'Name of Git remote to use. e.g. "origin"',
   }),
+  ...LinkCommand.flags,
 }
 
 module.exports = LinkCommand

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -44,10 +44,10 @@ function msg(location) {
 }
 
 LoginCommand.flags = {
-  ...LoginCommand.flags,
   new: flags.boolean({
     description: 'Login to new Netlify account',
   }),
+  ...LoginCommand.flags,
 }
 LoginCommand.description = `Login to your Netlify account
 

--- a/src/commands/sites/config.js
+++ b/src/commands/sites/config.js
@@ -22,11 +22,11 @@ Extra documentation goes here
 `
 
 SitesConfigCommand.flags = {
-  ...SitesConfigCommand.flags,
   name: flags.string({
     char: 'n',
     description: 'name to print',
   }),
+  ...SitesConfigCommand.flags,
 }
 
 // TODO implement logic

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -200,7 +200,6 @@ Create a blank site that isn't associated with any git remote.  Does not link to
 `
 
 SitesCreateCommand.flags = {
-  ...SitesCreateCommand.flags,
   'name': flags.string({
     char: 'n',
     description: 'name of site',
@@ -217,6 +216,7 @@ SitesCreateCommand.flags = {
     char: 'm',
     description: 'Force manual CI setup.  Used --with-ci flag',
   }),
+  ...SitesCreateCommand.flags,
 }
 
 module.exports = SitesCreateCommand

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -109,11 +109,11 @@ SitesDeleteCommand.args = [
 ]
 
 SitesDeleteCommand.flags = {
-  ...SitesDeleteCommand.flags,
   force: flags.boolean({
     char: 'f',
     description: 'delete without prompting (useful for CI)',
   }),
+  ...SitesDeleteCommand.flags,
 }
 
 SitesDeleteCommand.examples = ['netlify sites:delete 1234-3262-1211']

--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -78,10 +78,10 @@ Count: ${logSites.length}
 SitesListCommand.description = `List all sites you have access to`
 
 SitesListCommand.flags = {
-  ...SitesListCommand.flags,
   json: flags.boolean({
     description: 'Output site data as JSON',
   }),
+  ...SitesListCommand.flags,
 }
 
 module.exports = SitesListCommand

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -107,10 +107,10 @@ class StatusCommand extends Command {
 StatusCommand.description = `Print status information`
 
 StatusCommand.flags = {
-  ...StatusCommand.flags,
   verbose: flags.boolean({
     description: 'Output system info',
   }),
+  ...StatusCommand.flags,
 }
 
 module.exports = StatusCommand


### PR DESCRIPTION
At the moment our docs show common flags (like `debug`) first:
![image](https://user-images.githubusercontent.com/26760571/92610259-2e246080-f2c0-11ea-8595-436d0d26b1d4.png)

I think it makes sense to show them last.
This is more evident in [this PR](https://github.com/netlify/cli/pull/1215):
![image](https://user-images.githubusercontent.com/26760571/92610438-5d3ad200-f2c0-11ea-9f00-017e9974f019.png)

This PR moves those flags to the end of the docs.
We might be able to do something a bit more sophisticated like specifying order for each flag, but that seems like too much at the moment.