### PR TITLE
chore: fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "postpack": "rm -f oclif.manifest.json && npm i",
     "release": "run-s release:*",
     "release:docs": "npm run docs && git add docs",
-    "release:changelog": "auto-changelog -p --template keepachangelog && git add README.md CHANGELOG.md",
     "release:standard-version": "standard-version --no-verify --skip.changelog --commit-all",
     "release:version": "git push && git push --tags && gh-release",
     "release:publish": "npm publish",
@@ -210,6 +209,11 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "standard-version": {
+    "scripts": {
+      "postbump": "auto-changelog -p --template keepachangelog && git add README.md CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
As a result of https://github.com/netlify/cli/pull/1214 the changelog was generated with the previous version and not the new one (see https://github.com/netlify/cli/commit/b8de9cc8b8de900795ef0fc7c0dde4daad149126#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR10)

This change fixes that issue.