### PR TITLE
docs: use 'string' instead of 'option' in docs

### DIFF
--- a/docs/commands/api.md
+++ b/docs/commands/api.md
@@ -24,7 +24,7 @@ netlify api
 
 **Flags**
 
-- `data` (*option*) - Data to use
+- `data` (*string*) - Data to use
 - `list` (*boolean*) - List out available API methods
 - `debug` (*boolean*) - Print debugging information
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -16,7 +16,7 @@ netlify build
 **Flags**
 
 - `dry` (*boolean*) - Dry run: show instructions without running them
-- `context` (*option*) - Build context
+- `context` (*string*) - Build context
 - `debug` (*boolean*) - Print debugging information
 
 **Examples**

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -84,17 +84,17 @@ netlify deploy
 
 **Flags**
 
-- `dir` (*option*) - Specify a folder to deploy
-- `functions` (*option*) - Specify a functions folder to deploy
+- `dir` (*string*) - Specify a folder to deploy
+- `functions` (*string*) - Specify a functions folder to deploy
 - `prod` (*boolean*) - Deploy to production
-- `alias` (*option*) - Specifies the alias for deployment. Useful for creating predictable deployment URL's
-- `branch` (*option*) - Serves the same functionality as --alias. Deprecated and will be removed in future versions
+- `alias` (*string*) - Specifies the alias for deployment. Useful for creating predictable deployment URL's
+- `branch` (*string*) - Serves the same functionality as --alias. Deprecated and will be removed in future versions
 - `open` (*boolean*) - Open site after deploy
-- `message` (*option*) - A short message to include in the deploy log
-- `auth` (*option*) - Netlify auth token to deploy with
-- `site` (*option*) - A site ID to deploy to
+- `message` (*string*) - A short message to include in the deploy log
+- `auth` (*string*) - Netlify auth token to deploy with
+- `site` (*string*) - A site ID to deploy to
 - `json` (*boolean*) - Output deployment data as JSON
-- `timeout` (*option*) - Timeout to wait for deployment to finish
+- `timeout` (*string*) - Timeout to wait for deployment to finish
 - `trigger` (*boolean*) - Trigger a new build of your site on Netlify without uploading local files
 - `debug` (*boolean*) - Print debugging information
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -18,11 +18,11 @@ netlify dev
 
 **Flags**
 
-- `command` (*option*) - command to run
-- `port` (*option*) - port of netlify dev
-- `targetPort` (*option*) - port of target app server
-- `dir` (*option*) - dir with static files
-- `functions` (*option*) - Specify a functions folder to serve
+- `command` (*string*) - command to run
+- `port` (*string*) - port of netlify dev
+- `targetPort` (*string*) - port of target app server
+- `dir` (*string*) - dir with static files
+- `functions` (*string*) - Specify a functions folder to serve
 - `offline` (*boolean*) - disables any features that require network access
 - `live` (*boolean*) - Start a public live session
 - `debug` (*boolean*) - Print debugging information

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -44,8 +44,8 @@ netlify functions:build
 
 **Flags**
 
-- `functions` (*option*) - Specify a functions folder to build to
-- `src` (*option*) - Specify the source folder for the functions
+- `functions` (*string*) - Specify a functions folder to build to
+- `src` (*string*) - Specify the source folder for the functions
 - `debug` (*boolean*) - Print debugging information
 
 ---
@@ -65,8 +65,8 @@ netlify functions:create
 
 **Flags**
 
-- `name` (*option*) - function name
-- `url` (*option*) - pull template from URL
+- `name` (*string*) - function name
+- `url` (*string*) - pull template from URL
 - `debug` (*boolean*) - Print debugging information
 
 **Examples**
@@ -94,12 +94,12 @@ netlify functions:invoke
 
 **Flags**
 
-- `name` (*option*) - function name to invoke
-- `functions` (*option*) - Specify a functions folder to parse, overriding netlify.toml
-- `querystring` (*option*) - Querystring to add to your function invocation
-- `payload` (*option*) - Supply POST payload in stringified json, or a path to a json file
+- `name` (*string*) - function name to invoke
+- `functions` (*string*) - Specify a functions folder to parse, overriding netlify.toml
+- `querystring` (*string*) - Querystring to add to your function invocation
+- `payload` (*string*) - Supply POST payload in stringified json, or a path to a json file
 - `identity` (*boolean*) - simulate Netlify Identity authentication JWT. pass --no-identity to affirm unauthenticated request
-- `port` (*option*) - Port where netlify dev is accessible. e.g. 8888
+- `port` (*string*) - Port where netlify dev is accessible. e.g. 8888
 - `debug` (*boolean*) - Print debugging information
 
 **Examples**

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -18,7 +18,7 @@ netlify init
 
 - `manual` (*boolean*) - Manually configure a git remote for CI
 - `force` (*boolean*) - Reinitialize CI hooks if the linked site is already configured to use CI
-- `gitRemoteName` (*option*) - Name of Git remote to use. e.g. "origin"
+- `gitRemoteName` (*string*) - Name of Git remote to use. e.g. "origin"
 - `debug` (*boolean*) - Print debugging information
 
 

--- a/docs/commands/link.md
+++ b/docs/commands/link.md
@@ -16,9 +16,9 @@ netlify link
 
 **Flags**
 
-- `id` (*option*) - ID of site to link to
-- `name` (*option*) - Name of site to link to
-- `gitRemoteName` (*option*) - Name of Git remote to use. e.g. "origin"
+- `id` (*string*) - ID of site to link to
+- `name` (*string*) - Name of site to link to
+- `gitRemoteName` (*string*) - Name of Git remote to use. e.g. "origin"
 - `debug` (*boolean*) - Print debugging information
 
 **Examples**

--- a/docs/commands/sites.md
+++ b/docs/commands/sites.md
@@ -46,8 +46,8 @@ netlify sites:create
 
 **Flags**
 
-- `name` (*option*) - name of site
-- `account-slug` (*option*) - account slug to create the site under
+- `name` (*string*) - name of site
+- `account-slug` (*string*) - account slug to create the site under
 - `with-ci` (*boolean*) - initialize CI hooks during site creation
 - `manual` (*boolean*) - Force manual CI setup.  Used --with-ci flag
 - `debug` (*boolean*) - Print debugging information

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1999,6 +1999,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2424,6 +2433,13 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        }
       }
     },
     "camelize": {
@@ -4148,6 +4164,12 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.5.11",
@@ -5874,9 +5896,10 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -6378,6 +6401,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanoassert": {
       "version": "1.1.0",
@@ -9925,7 +9954,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/site/package.json
+++ b/site/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "filter-obj": "^2.0.1",
     "fs-extra": "^9.0.1",
+    "map-obj": "^4.1.0",
     "markdown-magic": "^1.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.0",

--- a/site/scripts/generateCommandData.js
+++ b/site/scripts/generateCommandData.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const filterObj = require('filter-obj')
+const mapObj = require('map-obj')
 const globby = require('markdown-magic').globby
 
 module.exports = function generateCommandData() {
@@ -14,7 +15,12 @@ module.exports = function generateCommandData() {
     const parentCommand = command.split(':')[0]
     const parent = command === parentCommand ? true : false
     // remove hidden flags
-    const flags = data.flags && filterObj(data.flags, (_, value) => value.hidden !== true)
+    const flags =
+      data.flags &&
+      mapObj(
+        filterObj(data.flags, (_, value) => value.hidden !== true),
+        (flag, flagData) => [flag, { ...flagData, type: flagData.type === 'option' ? 'string' : flagData.type }]
+      )
     return {
       command,
       commandGroup: parentCommand,


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1220

**- Test plan**

See deploy preview of docs site

**- Description for the changelog**

Our docs were generated based on the object returned from `flags.string`:
https://github.com/netlify/cli/blob/aef62e9e6e8a035936c692e5a1382b8890ae9f78/site/scripts/docs.js#L150
https://github.com/netlify/cli/blob/aef62e9e6e8a035936c692e5a1382b8890ae9f78/src/commands/build/index.js#L53

Which returns `type: option`.

This PR uses a more common `string` type.

**- A picture of a cute animal (not mandatory but encouraged)**

🐩 