### PR TITLE
feat(command-dev): Support Docusaurus V2

### DIFF
--- a/src/detectors/docusaurus.js
+++ b/src/detectors/docusaurus.js
@@ -1,16 +1,32 @@
 const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
 module.exports = function() {
   // REQUIRED FILES
-  if (!hasRequiredFiles(['package.json', 'siteConfig.js'])) return false
+  if (!hasRequiredFiles(['package.json'])) return false
+
+  const hasV1 = hasRequiredDeps(['docusaurus'])
+  const hasV2 = hasRequiredDeps(['@docusaurus/core'])
+
   // REQUIRED DEPS
-  if (!hasRequiredDeps(['docusaurus'])) return false
+  if (!hasV1 && !hasV2) return false
+
+  // REQUIRED CONFIG FILE
+  const hasConfigFile = hasV1 ? hasRequiredFiles(['siteConfig.js']) : hasRequiredFiles(['docusaurus.config.js'])
+
+  if (!hasConfigFile) return false
 
   /** everything below now assumes that we are within gatsby */
 
-  const possibleArgsArrs = scanScripts({
+  const v1Command = {
     preferredScriptsArr: ['start'],
     preferredCommand: 'docusaurus-start',
-  })
+  }
+
+  const v2Command = {
+    preferredScriptsArr: ['start'],
+    preferredCommand: 'docusaurus start',
+  }
+
+  const possibleArgsArrs = scanScripts(hasV1 ? v1Command : v2Command)
 
   return {
     framework: 'docusaurus',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR closes #1199. With Docusaurus V2, the dependencies and commands have changed. In order to support the new version I've updated the dependency check to look for either the V1 dependency or the V2 dependency. Depending on whether the V1 or V2 dependency is installed, the correct command will be added to the `scanScripts` call.

**- Test plan**

```sh
npx @docusaurus/init@next init my-website classic
cd my-website
netlify dev
```

With these changes, running `netlify dev` from within a Docusaurus V2 website will work as expected.

**- Description for the changelog**

`feat(command-dev): Support Docusaurus V2`

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_1304](https://user-images.githubusercontent.com/8846086/93006292-4211d180-f50f-11ea-907c-ce7d050d0795.jpg)



