### PR TITLE
fix(command-deploy): pass custom deploy dir to netlify client

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -209,6 +209,7 @@ class DeployCommand extends Command {
         deployTimeout: flags.timeout * 1000 || 1.2e6,
         syncFileLimit: 100,
         branch: alias,
+        deployDir: flags.dir,
       })
     } catch (e) {
       switch (true) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR aims to fix the issue described in [1227](https://github.com/netlify/cli/issues/1227).

The idea here is pretty simple, we pass the name of the custom deploy directory to the netlify js client via the `deployDir` option.

The rest is handled in [this PR](https://github.com/netlify/js-client/pull/150) in the `netlify/js-client` repo.

**- Test plan**

See the JS Client PR for testing information. The change here can exist entirely on it's own, but depends on that PR to actually change anything.

**- Description for the changelog**

fix(command-deploy): support hidden directories for deploy `-d` flag