### PR TITLE
Feat: edge handlers deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@netlify/build": "^4.0.1",
     "@netlify/config": "^2.0.9",
+    "@netlify/plugin-edge-handlers": "^1.1.0",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@netlify/build": "^4.0.1",
     "@netlify/config": "^2.0.9",
-    "@netlify/plugin-edge-handlers": "^1.1.0",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -177,7 +177,6 @@ const runDeploy = async ({
     const silent = flags.json || flags.silent
     await deployEdgeHandlers({
       site,
-      edgeHandlersFolder: flags.edgeHandlers,
       deployId,
       api,
       silent,
@@ -484,11 +483,6 @@ DeployCommand.flags = {
   functions: flags.string({
     char: 'f',
     description: 'Specify a functions folder to deploy',
-  }),
-  edgeHandlers: flags.string({
-    char: 'e',
-    description: 'Edge Handlers bundle location',
-    hidden: true,
   }),
   prod: flags.boolean({
     char: 'p',

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -134,6 +134,7 @@ const validateFolders = async ({ deployFolder, functionsFolder, error, log }) =>
 const runDeploy = async ({
   flags,
   deployToProduction,
+  site,
   siteData,
   api,
   siteId,
@@ -175,6 +176,7 @@ const runDeploy = async ({
 
     const silent = flags.json || flags.silent
     await deployEdgeHandlers({
+      site,
       edgeHandlersFolder: flags.edgeHandlers,
       deployId,
       api,
@@ -369,6 +371,7 @@ class DeployCommand extends Command {
     const results = await runDeploy({
       flags,
       deployToProduction,
+      site,
       siteData,
       api,
       siteId,

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -177,9 +177,10 @@ const runDeploy = async ({
     await deployEdgeHandlers({
       edgeHandlersFolder: flags.edgeHandlers,
       deployId,
-      apiToken: api.accessToken,
+      api,
       silent,
       error,
+      warn,
     })
     results = await api.deploy(siteId, deployFolder, {
       configPath,

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -14,8 +14,8 @@ const isObject = require('lodash.isobject')
 const SitesCreateCommand = require('./sites/create')
 const LinkCommand = require('./link')
 const { NETLIFYDEV, NETLIFYDEVLOG, NETLIFYDEVERR } = require('../utils/logo')
-const uploadEdgeHandlersBundle = require('@netlify/plugin-edge-handlers/src/upload')
-const { statAsync, readFileAsyncCatchError } = require('../lib/fs')
+const { statAsync } = require('../lib/fs')
+const { deployEdgeHandlers } = require('../utils/edge-handlers')
 
 const DEFAULT_DEPLOY_TIMEOUT = 1.2e6
 
@@ -131,82 +131,6 @@ const validateFolders = async ({ deployFolder, functionsFolder, error, log }) =>
   return { deployFolderStat, functionsFolderStat }
 }
 
-const validateEdgeHandlerFolder = async ({ edgeHandlersFolder, error }) => {
-  try {
-    const resolvedFolder = path.resolve(process.cwd(), edgeHandlersFolder || '.netlify/edge-handlers')
-    const stat = await statAsync(resolvedFolder)
-    if (!stat.isDirectory()) {
-      error(`Edge Handlers folder ${edgeHandlersFolder} must be a path to a directory`)
-    }
-    return resolvedFolder
-  } catch (e) {
-    // only error if edgeHandlers was passed as an argument
-    if (edgeHandlersFolder) {
-      if (e.code === 'ENOENT') {
-        return error(`No such directory ${edgeHandlersFolder}!`)
-      }
-      // Improve the message of permission errors
-      if (e.code === 'EACCES') {
-        return error('Permission error when trying to access Edge Handlers folder')
-      }
-      throw e
-    }
-  }
-}
-
-const manifestFilename = 'manifest.json'
-
-const readBundleAndManifest = async ({ edgeHandlersResolvedFolder, error }) => {
-  const manifestPath = path.resolve(edgeHandlersResolvedFolder, manifestFilename)
-  const { content: manifest, error: manifestError } = await readFileAsyncCatchError(manifestPath)
-  if (manifestError) {
-    error(`Could not read Edge Handlers manifest file ${manifestPath}: ${manifestError.message}`)
-  }
-
-  let manifestJson
-  try {
-    manifestJson = JSON.parse(manifest)
-  } catch (e) {
-    error(`Edge Handlers manifest file is not a valid JSON file: ${e.message}`)
-  }
-
-  if (!manifestJson.sha) {
-    error(`Edge Handlers manifest file is missing the 'sha' property`)
-  }
-
-  const bundlePath = path.resolve(edgeHandlersResolvedFolder, manifestJson.sha)
-  const { content: bundle, error: bundleError } = await readFileAsyncCatchError(bundlePath)
-
-  if (bundleError) {
-    error(`Could not read Edge Handlers bundle file ${bundlePath}: ${bundleError.message}`)
-  }
-
-  return { bundle, manifest: manifestJson }
-}
-
-const deployEdgeHandlers = async ({ edgeHandlersFolder, deployId, apiToken, silent, error }) => {
-  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ edgeHandlersFolder, error })
-  if (edgeHandlersResolvedFolder) {
-    try {
-      const spinner = silent
-        ? null
-        : ora({
-            text: `Deploying Edge Handlers from directory ${edgeHandlersResolvedFolder}`,
-          }).start()
-
-      const { bundle, manifest } = await readBundleAndManifest({ edgeHandlersResolvedFolder, error })
-      await uploadEdgeHandlersBundle(bundle, manifest, deployId, apiToken)
-      spinner &&
-        spinner.stopAndPersist({
-          text: `Finished deploying Edge Handlers from directory: ${edgeHandlersResolvedFolder}`,
-          symbol: logSymbols.success,
-        })
-    } catch (e) {
-      error(`Failed deploying Edge Handlers: ${e.message}`)
-    }
-  }
-}
-
 const runDeploy = async ({
   flags,
   deployToProduction,
@@ -245,9 +169,8 @@ const runDeploy = async ({
     }
 
     const draft = !deployToProduction && !alias
-    const branch = alias
     const title = flags.message
-    results = await api.createSiteDeploy({ siteId, title, body: { draft, branch } })
+    results = await api.createSiteDeploy({ siteId, title, body: { draft, branch: alias } })
     const deployId = results.id
 
     const silent = flags.json || flags.silent

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,78 @@
+// This file should be used to wrap API methods that are not part of our open API spec yet
+// Once they become part of the spec, js-client should be used
+const fetch = require('node-fetch')
+
+const getHeaders = ({ token }) => {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  }
+}
+
+const getErrorMessage = async ({ response }) => {
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    const json = await response.json()
+    return json.message
+  } else {
+    const text = await response.text()
+    return text
+  }
+}
+
+const checkResponse = async ({ response }) => {
+  if (!response.ok) {
+    const message = await getErrorMessage({ response }).catch(() => undefined)
+    const errorPostfix = message && message ? ` and message '${message}'` : ''
+    throw new Error(`Request failed with status '${response.status}'${errorPostfix}`)
+  }
+}
+
+const getApiUrl = ({ api }) => {
+  return `${api.scheme}://${api.host}${api.pathPrefix}`
+}
+
+const apiPost = async ({ api, path, data }) => {
+  const apiUrl = getApiUrl({ api })
+  const response = await fetch(`${apiUrl}/${path}`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+    headers: getHeaders({ token: api.accessToken }),
+    agent: api.agent,
+  })
+
+  await checkResponse({ response })
+
+  return response
+}
+
+const uploadEdgeHandlers = async ({ api, deployId, bundleBuffer, manifest }) => {
+  const response = await apiPost({ api, path: `deploys/${deployId}/edge_handlers`, data: manifest })
+  const { error, exists, upload_url: uploadUrl } = await response.json()
+  if (error) {
+    throw new Error(error)
+  }
+
+  if (exists) {
+    return false
+  }
+
+  if (!uploadUrl) {
+    throw new Error('Missing upload URL')
+  }
+
+  const putResponse = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: bundleBuffer,
+    headers: {
+      'Content-Type': 'application/javascript',
+    },
+    agent: api.agent,
+  })
+
+  await checkResponse({ response: putResponse })
+
+  return true
+}
+
+module.exports = { uploadEdgeHandlers }

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -6,10 +6,21 @@ const readFileAsync = promisify(fs.readFile)
 const writeFileAsync = promisify(fs.writeFile)
 const accessAsync = promisify(fs.access)
 
-const readFileAsyncCatchError = filepath => {
-  return readFileAsync(filepath)
-    .then(content => ({ content }))
-    .catch(error => ({ error }))
+const readFileAsyncCatchError = async filepath => {
+  try {
+    return { content: await readFileAsync(filepath) }
+  } catch (error) {
+    return { error }
+  }
 }
 
-module.exports = { statAsync, readFileAsync, readFileAsyncCatchError, writeFileAsync, accessAsync }
+const fileExistsAsync = async filePath => {
+  try {
+    await accessAsync(filePath, fs.F_OK)
+    return true
+  } catch (_) {
+    return false
+  }
+}
+
+module.exports = { statAsync, readFileAsync, readFileAsyncCatchError, writeFileAsync, fileExistsAsync }

--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const { promisify } = require('util')
+
+const statAsync = promisify(fs.stat)
+const readFileAsync = promisify(fs.readFile)
+const writeFileAsync = promisify(fs.writeFile)
+const accessAsync = promisify(fs.access)
+
+const readFileAsyncCatchError = filepath => {
+  return readFileAsync(filepath)
+    .then(content => ({ content }))
+    .catch(error => ({ error }))
+}
+
+module.exports = { statAsync, readFileAsync, readFileAsyncCatchError, writeFileAsync, accessAsync }

--- a/src/lib/spinner.js
+++ b/src/lib/spinner.js
@@ -1,0 +1,21 @@
+const ora = require('ora')
+const logSymbols = require('log-symbols')
+
+const startSpinner = ({ text }) => {
+  return ora({
+    text,
+  }).start()
+}
+
+const stopSpinner = ({ spinner, text, error }) => {
+  if (!spinner) {
+    return
+  }
+  const symbol = error ? logSymbols.error : logSymbols.success
+  spinner.stopAndPersist({
+    text,
+    symbol,
+  })
+}
+
+module.exports = { startSpinner, stopSpinner }

--- a/src/utils/edge-handlers.js
+++ b/src/utils/edge-handlers.js
@@ -6,9 +6,9 @@ const uploadEdgeHandlersBundle = require('@netlify/plugin-edge-handlers/src/uplo
 
 const MANIFEST_FILENAME = 'manifest.json'
 
-const validateEdgeHandlerFolder = async ({ edgeHandlersFolder, error }) => {
+const validateEdgeHandlerFolder = async ({ site, edgeHandlersFolder, error }) => {
   try {
-    const resolvedFolder = path.resolve(process.cwd(), edgeHandlersFolder || '.netlify/edge-handlers')
+    const resolvedFolder = path.resolve(site.root, edgeHandlersFolder || '.netlify/edge-handlers')
     const stat = await statAsync(resolvedFolder)
     if (!stat.isDirectory()) {
       error(`Edge Handlers folder ${edgeHandlersFolder} must be a path to a directory`)
@@ -67,8 +67,8 @@ const updateProgress = (spinner, text, symbol) => {
   })
 }
 
-const deployEdgeHandlers = async ({ edgeHandlersFolder, deployId, api, silent, error, warn }) => {
-  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ edgeHandlersFolder, error })
+const deployEdgeHandlers = async ({ site, edgeHandlersFolder, deployId, api, silent, error, warn }) => {
+  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ site, edgeHandlersFolder, error })
   if (edgeHandlersResolvedFolder) {
     let spinner
     try {

--- a/src/utils/edge-handlers.js
+++ b/src/utils/edge-handlers.js
@@ -1,0 +1,92 @@
+const path = require('path')
+const ora = require('ora')
+const logSymbols = require('log-symbols')
+const { statAsync, readFileAsyncCatchError } = require('../lib/fs')
+const uploadEdgeHandlersBundle = require('@netlify/plugin-edge-handlers/src/upload')
+
+const MANIFEST_FILENAME = 'manifest.json'
+
+const validateEdgeHandlerFolder = async ({ edgeHandlersFolder, error }) => {
+  try {
+    const resolvedFolder = path.resolve(process.cwd(), edgeHandlersFolder || '.netlify/edge-handlers')
+    const stat = await statAsync(resolvedFolder)
+    if (!stat.isDirectory()) {
+      error(`Edge Handlers folder ${edgeHandlersFolder} must be a path to a directory`)
+    }
+    return resolvedFolder
+  } catch (e) {
+    // only error if edgeHandlers was passed as an argument
+    if (edgeHandlersFolder) {
+      if (e.code === 'ENOENT') {
+        return error(`No such directory ${edgeHandlersFolder}!`)
+      }
+      // Improve the message of permission errors
+      if (e.code === 'EACCES') {
+        return error('Permission error when trying to access Edge Handlers folder')
+      }
+      throw e
+    }
+  }
+}
+
+const readBundleAndManifest = async ({ edgeHandlersResolvedFolder, error }) => {
+  const manifestPath = path.resolve(edgeHandlersResolvedFolder, MANIFEST_FILENAME)
+  const { content: manifest, error: manifestError } = await readFileAsyncCatchError(manifestPath)
+  if (manifestError) {
+    error(`Could not read Edge Handlers manifest file ${manifestPath}: ${manifestError.message}`)
+  }
+
+  let manifestJson
+  try {
+    manifestJson = JSON.parse(manifest)
+  } catch (e) {
+    error(`Edge Handlers manifest file is not a valid JSON file: ${e.message}`)
+  }
+
+  if (!manifestJson.sha) {
+    error(`Edge Handlers manifest file is missing the 'sha' property`)
+  }
+
+  const bundlePath = path.resolve(edgeHandlersResolvedFolder, manifestJson.sha)
+  const { content: bundle, error: bundleError } = await readFileAsyncCatchError(bundlePath)
+
+  if (bundleError) {
+    error(`Could not read Edge Handlers bundle file ${bundlePath}: ${bundleError.message}`)
+  }
+
+  return { bundle, manifest: manifestJson }
+}
+
+const deployEdgeHandlers = async ({ edgeHandlersFolder, deployId, apiToken, silent, error }) => {
+  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ edgeHandlersFolder, error })
+  if (edgeHandlersResolvedFolder) {
+    try {
+      const spinner = silent
+        ? null
+        : ora({
+            text: `Deploying Edge Handlers from directory ${edgeHandlersResolvedFolder}`,
+          }).start()
+
+      const { bundle, manifest } = await readBundleAndManifest({ edgeHandlersResolvedFolder, error })
+      // returns false if the bundle exists, true on success, throws on error
+      const success = await uploadEdgeHandlersBundle(bundle, manifest, deployId, apiToken)
+      if (!success) {
+        spinner &&
+          spinner.stopAndPersist({
+            text: `Skipped deploying Edge Handlers since the bundle already exists`,
+            symbol: logSymbols.success,
+          })
+      } else {
+        spinner &&
+          spinner.stopAndPersist({
+            text: `Finished deploying Edge Handlers from directory: ${edgeHandlersResolvedFolder}`,
+            symbol: logSymbols.success,
+          })
+      }
+    } catch (e) {
+      error(`Failed deploying Edge Handlers: ${e.message}`)
+    }
+  }
+}
+
+module.exports = { deployEdgeHandlers }

--- a/src/utils/edge-handlers.js
+++ b/src/utils/edge-handlers.js
@@ -4,27 +4,20 @@ const { uploadEdgeHandlers } = require('../lib/api')
 const { startSpinner, stopSpinner } = require('../lib/spinner')
 
 const MANIFEST_FILENAME = 'manifest.json'
+const EDGE_HANDLERS_FOLDER = '.netlify/edge-handlers'
 
-const validateEdgeHandlerFolder = async ({ site, edgeHandlersFolder, error }) => {
+const validateEdgeHandlerFolder = async ({ site, error }) => {
   try {
-    const resolvedFolder = path.resolve(site.root, edgeHandlersFolder || '.netlify/edge-handlers')
+    const resolvedFolder = path.resolve(site.root, EDGE_HANDLERS_FOLDER)
     const stat = await statAsync(resolvedFolder)
     if (!stat.isDirectory()) {
-      error(`Edge Handlers folder ${edgeHandlersFolder} must be a path to a directory`)
+      error(`Edge Handlers folder ${EDGE_HANDLERS_FOLDER} must be a path to a directory`)
     }
     return resolvedFolder
   } catch (e) {
-    // only error if edgeHandlers was passed as an argument
-    if (edgeHandlersFolder) {
-      if (e.code === 'ENOENT') {
-        return error(`No such directory ${edgeHandlersFolder}!`)
-      }
-      // Improve the message of permission errors
-      if (e.code === 'EACCES') {
-        return error('Permission error when trying to access Edge Handlers folder')
-      }
-      throw e
-    }
+    // ignore errors at the moment
+    // TODO: report error if 'edge_handlers' config exists after
+    // https://github.com/netlify/build/pull/1829 is published
   }
 }
 
@@ -56,8 +49,8 @@ const readBundleAndManifest = async ({ edgeHandlersResolvedFolder, error }) => {
   return { bundleBuffer, manifest: manifestJson }
 }
 
-const deployEdgeHandlers = async ({ site, edgeHandlersFolder, deployId, api, silent, error, warn }) => {
-  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ site, edgeHandlersFolder, error })
+const deployEdgeHandlers = async ({ site, deployId, api, silent, error, warn }) => {
+  const edgeHandlersResolvedFolder = await validateEdgeHandlerFolder({ site, error })
   if (edgeHandlersResolvedFolder) {
     let spinner
     try {

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,10 +1,6 @@
 const path = require('path')
-const fs = require('fs')
-const { promisify } = require('util')
 const dotenv = require('dotenv')
-
-const fileStat = promisify(fs.stat)
-const readFile = promisify(fs.readFile)
+const { statAsync, readFileAsync } = require('../lib/fs')
 
 async function getEnvSettings(projectDir) {
   const envDevelopmentFile = path.resolve(projectDir, '.env.development')
@@ -13,17 +9,17 @@ async function getEnvSettings(projectDir) {
   const settings = {}
 
   try {
-    if ((await fileStat(envFile)).isFile()) settings.file = envFile
+    if ((await statAsync(envFile)).isFile()) settings.file = envFile
   } catch (err) {
     // nothing
   }
   try {
-    if ((await fileStat(envDevelopmentFile)).isFile()) settings.file = envDevelopmentFile
+    if ((await statAsync(envDevelopmentFile)).isFile()) settings.file = envDevelopmentFile
   } catch (err) {
     // nothing
   }
 
-  if (settings.file) settings.vars = dotenv.parse(await readFile(settings.file)) || {}
+  if (settings.file) settings.vars = dotenv.parse(await readFileAsync(settings.file)) || {}
 
   return settings
 }

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -1,18 +1,11 @@
 const path = require('path')
-const fs = require('fs')
 const parseIgnore = require('parse-gitignore')
 
-const { readFileAsync, writeFileAsync, accessAsync } = require('../lib/fs')
-
-function fileExists(filePath) {
-  return accessAsync(filePath, fs.F_OK)
-    .then(() => true)
-    .catch(() => false)
-}
+const { readFileAsync, writeFileAsync, fileExistsAsync } = require('../lib/fs')
 
 async function hasGitIgnore(dir) {
   const gitIgnorePath = path.join(dir, '.gitignore')
-  const hasIgnore = await fileExists(gitIgnorePath)
+  const hasIgnore = await fileExistsAsync(gitIgnorePath)
   return hasIgnore
 }
 

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -1,17 +1,13 @@
 const path = require('path')
 const fs = require('fs')
 const parseIgnore = require('parse-gitignore')
-const { promisify } = require('util')
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
+
+const { readFileAsync, writeFileAsync, accessAsync } = require('../lib/fs')
 
 function fileExists(filePath) {
-  return new Promise((resolve, reject) => {
-    fs.access(filePath, fs.F_OK, err => {
-      if (err) return resolve(false)
-      return resolve(true)
-    })
-  })
+  return accessAsync(filePath, fs.F_OK)
+    .then(() => true)
+    .catch(() => false)
 }
 
 async function hasGitIgnore(dir) {
@@ -89,14 +85,14 @@ async function ensureNetlifyIgnore(dir) {
 
   /* No .gitignore file. Create one and ignore .netlify folder */
   if (!(await hasGitIgnore(dir))) {
-    await writeFile(gitIgnorePath, ignoreContent, 'utf8')
+    await writeFileAsync(gitIgnorePath, ignoreContent, 'utf8')
     return false
   }
 
   let gitIgnoreContents
   let ignorePatterns
   try {
-    gitIgnoreContents = await readFile(gitIgnorePath, 'utf8')
+    gitIgnoreContents = await readFileAsync(gitIgnorePath, 'utf8')
     ignorePatterns = parseIgnore.parse(gitIgnoreContents)
   } catch (e) {
     // ignore
@@ -104,7 +100,7 @@ async function ensureNetlifyIgnore(dir) {
   /* Not ignoring .netlify folder. Add to .gitignore */
   if (!ignorePatterns || !ignorePatterns.patterns.includes('.netlify')) {
     const newContents = `${gitIgnoreContents}\n${ignoreContent}`
-    await writeFile(gitIgnorePath, newContents, 'utf8')
+    await writeFileAsync(gitIgnorePath, newContents, 'utf8')
   }
 }
 

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -1,0 +1,133 @@
+const test = require('ava')
+const { getToken } = require('../src/utils/command')
+const fetch = require('node-fetch')
+const { withSiteBuilder } = require('./utils/siteBuilder')
+const callCli = require('./utils/callCli')
+const { generateSiteName, createLiveTestSite } = require('./utils/createLiveTestSite')
+
+const siteName = generateSiteName('netlify-test-deploy-')
+
+const validateDeploy = async ({ deploy, siteName, content, t }) => {
+  t.truthy(deploy.site_name)
+  t.truthy(deploy.deploy_url)
+  t.truthy(deploy.deploy_id)
+  t.truthy(deploy.logs)
+  t.is(deploy.site_name, siteName)
+
+  const actualContent = await fetch(deploy.deploy_url)
+    .then(r => r.text())
+    .catch(() => undefined)
+
+  t.is(actualContent, content)
+}
+
+if (process.env.IS_FORK !== 'true') {
+  test.before(async t => {
+    const siteId = await createLiveTestSite(siteName)
+    t.context.siteId = siteId
+  })
+
+  test.serial('should deploy site when dir flag is passed', async t => {
+    await withSiteBuilder('site-with-public-folder', async builder => {
+      const content = '<h1>⊂◉‿◉つ</h1>'
+      builder.withContentFile({
+        path: 'public/index.html',
+        content,
+      })
+
+      await builder.buildAsync()
+
+      const deploy = await callCli(['deploy', '--json', '--dir', 'public'], {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      }).then(output => JSON.parse(output))
+
+      validateDeploy({ deploy, siteName, content, t })
+    })
+  })
+
+  test.serial('should deploy site when publish directory set in netlify.toml', async t => {
+    await withSiteBuilder('site-with-public-folder', async builder => {
+      const content = '<h1>⊂◉‿◉つ</h1>'
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content,
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public' },
+          },
+        })
+
+      await builder.buildAsync()
+
+      const deploy = await callCli(['deploy', '--json'], {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      }).then(output => JSON.parse(output))
+
+      validateDeploy({ deploy, siteName, content, t })
+    })
+  })
+
+  test.only('should deploy edge handlers when directory exists', async t => {
+    await withSiteBuilder('site-with-public-folder', async builder => {
+      const content = '<h1>⊂◉‿◉つ</h1>'
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content,
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public', command: 'echo "no op"' },
+          },
+        })
+        .withEdgeHandlers({
+          handlers: {
+            onRequest: event => {
+              console.log(`Incoming request for ${event.request.url}`)
+            },
+          },
+        })
+
+      await builder.buildAsync()
+
+      const options = {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      }
+      // build the edge handlers first
+      await callCli(['build'], options)
+      const deploy = await callCli(['deploy', '--json'], options).then(output => JSON.parse(output))
+
+      validateDeploy({ deploy, siteName, content, t })
+
+      // validate edge handlers
+      // use this until we can use `netlify api`
+      const [apiToken] = getToken()
+      const resp = await fetch(`https://api.netlify.com/api/v1/deploys/${deploy.deploy_id}/edge_handlers`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiToken}`,
+        },
+      })
+
+      t.is(resp.status, 200)
+      const { created_at, sha, ...rest } = await resp.json()
+      t.deepEqual(rest, {
+        content_length: 445,
+        content_type: 'application/javascript',
+        handlers: ['index'],
+        valid: true,
+      })
+    })
+  })
+
+  test.after('cleanup', async t => {
+    const { siteId } = t.context
+    console.log(`deleting test site "${siteName}". ${siteId}`)
+    await callCli(['sites:delete', siteId, '--force'])
+  })
+}

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -118,13 +118,13 @@ if (process.env.IS_FORK !== 'true') {
         })
 
         t.is(resp.status, 200)
-        const { created_at, sha, ...rest } = await resp.json()
+        const { created_at, sha, content_length, ...rest } = await resp.json()
         t.deepEqual(rest, {
-          content_length: 445,
           content_type: 'application/javascript',
           handlers: ['index'],
           valid: true,
         })
+        t.is(content_length > 400, true)
       })
     })
   }

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -71,59 +71,63 @@ if (process.env.IS_FORK !== 'true') {
     })
   })
 
-  test.only('should deploy edge handlers when directory exists', async t => {
-    await withSiteBuilder('site-with-public-folder', async builder => {
-      const content = '<h1>⊂◉‿◉つ</h1>'
-      builder
-        .withContentFile({
-          path: 'public/index.html',
-          content,
-        })
-        .withNetlifyToml({
-          config: {
-            build: { publish: 'public', command: 'echo "no op"' },
-          },
-        })
-        .withEdgeHandlers({
-          handlers: {
-            onRequest: event => {
-              console.log(`Incoming request for ${event.request.url}`)
+  // the edge handlers plugin only works on node >= 10 and not on windows at the moment
+  const version = parseInt(process.version.substring(1).split('.')[0])
+  if (process.platform !== 'win32' && version >= 10) {
+    test.serial('should deploy edge handlers when directory exists', async t => {
+      await withSiteBuilder('site-with-public-folder', async builder => {
+        const content = '<h1>⊂◉‿◉つ</h1>'
+        builder
+          .withContentFile({
+            path: 'public/index.html',
+            content,
+          })
+          .withNetlifyToml({
+            config: {
+              build: { publish: 'public', command: 'echo "no op"' },
             },
+          })
+          .withEdgeHandlers({
+            handlers: {
+              onRequest: event => {
+                console.log(`Incoming request for ${event.request.url}`)
+              },
+            },
+          })
+
+        await builder.buildAsync()
+
+        const options = {
+          cwd: builder.directory,
+          env: { NETLIFY_SITE_ID: t.context.siteId },
+        }
+        // build the edge handlers first
+        await callCli(['build'], options)
+        const deploy = await callCli(['deploy', '--json'], options).then(output => JSON.parse(output))
+
+        validateDeploy({ deploy, siteName, content, t })
+
+        // validate edge handlers
+        // use this until we can use `netlify api`
+        const [apiToken] = getToken()
+        const resp = await fetch(`https://api.netlify.com/api/v1/deploys/${deploy.deploy_id}/edge_handlers`, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiToken}`,
           },
         })
 
-      await builder.buildAsync()
-
-      const options = {
-        cwd: builder.directory,
-        env: { NETLIFY_SITE_ID: t.context.siteId },
-      }
-      // build the edge handlers first
-      await callCli(['build'], options)
-      const deploy = await callCli(['deploy', '--json'], options).then(output => JSON.parse(output))
-
-      validateDeploy({ deploy, siteName, content, t })
-
-      // validate edge handlers
-      // use this until we can use `netlify api`
-      const [apiToken] = getToken()
-      const resp = await fetch(`https://api.netlify.com/api/v1/deploys/${deploy.deploy_id}/edge_handlers`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiToken}`,
-        },
-      })
-
-      t.is(resp.status, 200)
-      const { created_at, sha, ...rest } = await resp.json()
-      t.deepEqual(rest, {
-        content_length: 445,
-        content_type: 'application/javascript',
-        handlers: ['index'],
-        valid: true,
+        t.is(resp.status, 200)
+        const { created_at, sha, ...rest } = await resp.json()
+        t.deepEqual(rest, {
+          content_length: 445,
+          content_type: 'application/javascript',
+          handlers: ['index'],
+          valid: true,
+        })
       })
     })
-  })
+  }
 
   test.after('cleanup', async t => {
     const { siteId } = t.context

--- a/tests/utils/callCli.js
+++ b/tests/utils/callCli.js
@@ -2,7 +2,8 @@ const execa = require('execa')
 const cliPath = require('./cliPath')
 
 async function callCli(args, execOptions) {
-  return (await execa(cliPath, args, execOptions)).stdout
+  const { stdout } = await execa(cliPath, args, { windowsHide: true, windowsVerbatimArguments: true, ...execOptions })
+  return stdout
 }
 
 module.exports = callCli

--- a/tests/utils/createLiveTestSite.js
+++ b/tests/utils/createLiveTestSite.js
@@ -25,15 +25,17 @@ async function createLiveTestSite(siteName) {
 
   const isSiteCreated = /Site Created/.test(cliResponse)
   if (!isSiteCreated) {
-    return null
+    throw new Error(`Failed creating site: ${cliResponse}`)
   }
 
   const matches = /Site ID:\s+([a-zA-Z0-9-]+)/m.exec(stripAnsi(cliResponse))
   if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
-    return matches[1]
+    const siteId = matches[1]
+    console.log(`Done creating site ${siteName} for account '${accountSlug}'. Site Id: ${siteId}`)
+    return siteId
   }
 
-  return null
+  throw new Error(`Failed creating site: ${cliResponse}`)
 }
 
 module.exports = { generateSiteName, createLiveTestSite }

--- a/tests/utils/siteBuilder.js
+++ b/tests/utils/siteBuilder.js
@@ -43,6 +43,19 @@ const createSiteBuilder = ({ siteName }) => {
       })
       return builder
     },
+    withEdgeHandlers: ({ handlers }) => {
+      const dest = path.join(directory, 'edge-handlers', 'index.js')
+      tasks.push(async () => {
+        await fs.ensureFile(dest)
+        const content = Object.entries(handlers)
+          .map(([event, handler]) => {
+            return `export const ${event} = ${handler.toString()}`
+          })
+          .join('\n')
+        await fs.writeFile(dest, content)
+      })
+      return builder
+    },
     withRedirectsFile: ({ redirects = [], pathPrefix = '' }) => {
       const dest = path.join(directory, pathPrefix, '_redirects')
       tasks.push(async () => {


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1236

This is a draft PR not to be reviewed yet (needs some cleanup and tests).
Opening for visibility.

Depends on https://github.com/netlify/js-client/pull/155 and branched out from https://github.com/netlify/cli/pull/1240

The flow is:
1. Create the deploy (used to be in `js-client`)
2. Upload Edge Handlers if  `.netlify/edge-handlers` exists or passed as an argument via `--edgeHandlers`
3. Run `deploy` from `js-client` with the created `deployId`

Will add comments after https://github.com/netlify/cli/pull/1240 is merged and I do a rebase.

**- Test plan**

- [x] Going to add dedicated tests for the deploy command (similar to `addons` and `env`).

**- Description for the changelog**

Support deploying Edge Handlers as a part of the deploy command.

**- A picture of a cute animal (not mandatory but encouraged)**

🐻 
