### PR TITLE
Fix invalid static parameters

### DIFF
--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -146,7 +146,7 @@ async function serveRedirect(req, res, proxy, match, options) {
       req.hostname}`
   )
 
-  const staticFile = await getStatic(reqUrl.pathname, options.publicFolder)
+  const staticFile = await getStatic(decodeURIComponent(reqUrl.pathname), options.publicFolder)
   if (staticFile) req.url = staticFile + reqUrl.search
   if (match.force404) {
     res.writeHead(404)


### PR DESCRIPTION
**- Summary**

There is a [bug in the next-on-netlify](https://github.com/netlify/next-on-netlify/issues/41) package being caused by this. Requests are being routed to a catch-all page, when they shouldn't be. This fixes that!

**- Test plan**

(see linked issue above)

**- Description for the changelog**

Fix: Request URL for static pathnames decoded properly

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1454517/93688907-7e4cb100-fa7e-11ea-8aa1-ed25cda1eb0c.png)

