### PR TITLE
Feat: run build command when deploying

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -96,6 +96,7 @@ netlify deploy
 - `json` (*boolean*) - Output deployment data as JSON
 - `timeout` (*string*) - Timeout to wait for deployment to finish
 - `trigger` (*boolean*) - Trigger a new build of your site on Netlify without uploading local files
+- `build` (*boolean*) - Run build command before deploying
 - `debug` (*boolean*) - Print debugging information
 - `httpProxy` (*string*) - Proxy server address to route requests through.
 - `httpProxyCertificateFilename` (*string*) - Certificate file to use when connecting using a proxy server

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -1,11 +1,16 @@
-const build = require('@netlify/build')
 const { flags } = require('@oclif/command')
 const Command = require('../../utils/command')
+const { getBuildOptions, runBuild } = require('../../lib/build')
 
 class BuildCommand extends Command {
   // Run Netlify Build
   async run() {
-    const options = this.getOptions()
+    // Retrieve Netlify Build options
+    const options = getBuildOptions({
+      netlify: this.netlify,
+      token: this.getConfigToken()[0],
+      flags: this.parse(BuildCommand).flags,
+    })
     this.checkOptions(options)
 
     await this.config.runHook('analytics', {
@@ -13,21 +18,8 @@ class BuildCommand extends Command {
       payload: { command: 'build', dry: Boolean(options.dry) },
     })
 
-    const { severityCode: exitCode } = await build(options)
+    const exitCode = await runBuild(options)
     this.exit(exitCode)
-  }
-
-  // Retrieve Netlify Build options
-  getOptions() {
-    // We have already resolved the configuration using `@netlify/config`
-    // This is stored as `this.netlify.cachedConfig` and can be passed to
-    // `@netlify/build --cachedConfig`.
-    const cachedConfig = JSON.stringify(this.netlify.cachedConfig)
-    const {
-      flags: { dry, debug },
-    } = this.parse(BuildCommand)
-    const [token] = this.getConfigToken()
-    return { cachedConfig, token, dry, debug, mode: 'cli' }
   }
 
   checkOptions({ cachedConfig, token }) {
@@ -58,5 +50,8 @@ BuildCommand.flags = {
 BuildCommand.description = `(Beta) Build on your local machine`
 
 BuildCommand.examples = ['netlify build']
+
+BuildCommand.getBuildOptions = getBuildOptions
+BuildCommand.runBuild = runBuild
 
 module.exports = BuildCommand

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -51,7 +51,4 @@ BuildCommand.description = `(Beta) Build on your local machine`
 
 BuildCommand.examples = ['netlify build']
 
-BuildCommand.getBuildOptions = getBuildOptions
-BuildCommand.runBuild = runBuild
-
 module.exports = BuildCommand

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -1,0 +1,17 @@
+const build = require('@netlify/build')
+
+// We have already resolved the configuration using `@netlify/config`
+// This is stored as `netlify.cachedConfig` and can be passed to
+// `@netlify/build --cachedConfig`.
+const getBuildOptions = ({ netlify, token, flags }) => {
+  const cachedConfig = JSON.stringify(netlify.cachedConfig)
+  const { dry, debug } = flags
+  return { cachedConfig, token, dry, debug, mode: 'cli' }
+}
+
+const runBuild = async options => {
+  const { severityCode: exitCode } = await build(options)
+  return exitCode
+}
+
+module.exports = { getBuildOptions, runBuild }

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -6,7 +6,7 @@ const build = require('@netlify/build')
 const getBuildOptions = ({ netlify, token, flags }) => {
   const cachedConfig = JSON.stringify(netlify.cachedConfig)
   const { dry, debug } = flags
-  return { cachedConfig, token, dry, debug, mode: 'cli' }
+  return { cachedConfig, token, dry, debug, mode: 'cli', telemetry: false }
 }
 
 const runBuild = async options => {

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -129,6 +129,31 @@ if (process.env.IS_FORK !== 'true') {
     })
   }
 
+  test.serial('should run build command before deploy when build flag is passed', async t => {
+    await withSiteBuilder('site-with-public-folder', async builder => {
+      const content = '<h1>⊂◉‿◉つ</h1>'
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content,
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public' },
+          },
+        })
+
+      await builder.buildAsync()
+
+      const output = await callCli(['deploy', '--build'], {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      })
+
+      t.is(output.includes('Netlify Build completed in'), true)
+    })
+  })
+
   test.after('cleanup', async t => {
     const { siteId } = t.context
     console.log(`deleting test site "${siteName}". ${siteId}`)


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/179

Adds a `--build` flag to run the build command before deploying.

**- Test plan**

- [x] Going to add a test case 

**- Description for the changelog**

Support running the build command before deploying

**- A picture of a cute animal (not mandatory but encouraged)**

😸 