### PR TITLE
fix(command-deploy): align file filtering with buildbot

### DIFF
--- a/tests/utils/siteBuilder.js
+++ b/tests/utils/siteBuilder.js
@@ -86,6 +86,10 @@ const createSiteBuilder = ({ siteName }) => {
       })
       return builder
     },
+    withContentFiles: files => {
+      files.forEach(file => builder.withContentFile(file))
+      return builder
+    },
     withEnvFile: ({ path: filePath = '.env', pathPrefix = '', env = {} }) => {
       const dest = path.join(directory, pathPrefix, filePath)
       tasks.push(async () => {

--- a/tests/utils/siteBuilder.js
+++ b/tests/utils/siteBuilder.js
@@ -87,7 +87,7 @@ const createSiteBuilder = ({ siteName }) => {
       return builder
     },
     withContentFiles: files => {
-      files.forEach(file => builder.withContentFile(file))
+      files.forEach(builder.withContentFile)
       return builder
     },
     withEnvFile: ({ path: filePath = '.env', pathPrefix = '', env = {} }) => {


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/js-client/issues/157 and https://github.com/netlify/cli/issues/1227.

Fixes https://github.com/netlify/cli/issues/1225#issuecomment-696957186

The CLI deploy command relies on `js-client` default filter to skip some files when deploying.
This is done here:
https://github.com/netlify/js-client/blob/55650048fc7fe6288816c1dc172b27024cbd1586/src/deploy/util.js#L8 

and trying to emulate the code here:
https://github.com/netlify/open-api/blob/e72e2eb2d7eedf02bccc5916fc0330022f7f823b/go/porcelain/deploy.go#L692

This PR fixes a few discrepancies with our buildbot:
1. Allows publishing a hidden directory (e.g. `.public`) - fixes part of https://github.com/netlify/cli/issues/1227.
2. Allows deploying `node_modules` when inside a publish folder. Fixes https://github.com/netlify/cli/issues/1225#issuecomment-696957186 and matches buildbot behaviour. Only difference is that `node_modules` are ignored if a user tries to publish the current project dir.
3. Splits the regular expression here https://github.com/netlify/js-client/blob/55650048fc7fe6288816c1dc172b27024cbd1586/src/deploy/util.js#L13 into string operations. Also I believe the `\/__MACOSX` part wasn't working as I'm not sure how `basename` can result in a string containing a `/`.

**- Test plan**

Added tests

**- Description for the changelog**

Align deploy file filtering with buildbot

**- A picture of a cute animal (not mandatory but encouraged)**

🐴 