### PR TITLE
fix(command-dev): pass publish directory to traffic mesh agent

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -122,7 +122,7 @@ const startProxyServer = async ({ flags, settings, site, log, exit, addonUrls })
       port: settings.port,
       frameworkPort: settings.frameworkPort,
       functionsPort: settings.functionsPort,
-      projectDir: site.root,
+      publishDir: settings.dist,
       log,
       debug: flags.debug,
     })

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -33,7 +33,7 @@ const installTrafficMesh = async ({ log }) => {
   })
 }
 
-const startForwardProxy = async ({ port, frameworkPort, functionsPort, projectDir, log, debug }) => {
+const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDir, log, debug }) => {
   await installTrafficMesh({ log })
   const args = [
     'start',
@@ -43,7 +43,7 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, projectDi
     '--forward-proxy',
     `http://localhost:${frameworkPort}`,
     '--watch',
-    projectDir,
+    publishDir,
     '--log-file',
     getPathInProject(['logs', 'traffic-mesh.log']),
   ]

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -772,6 +772,34 @@ testMatrix.forEach(({ args }) => {
     })
   })
 
+  test(testName('should source redirects file from publish directory', args), async t => {
+    await withSiteBuilder('site-redirects-file-inside-publish', async builder => {
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content: 'index',
+        })
+        .withRedirectsFile({
+          pathPrefix: 'public',
+          redirects: [{ from: '/*', to: `/index.html`, status: 200 }],
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public' },
+          },
+        })
+
+      await builder.buildAsync()
+
+      await withDevServer({ cwd: builder.directory, args }, async server => {
+        const response = await fetch(`${server.url}/test`)
+
+        t.is(response.status, 200)
+        t.is(await response.text(), 'index')
+      })
+    })
+  })
+
   test(testName('should redirect requests to an external server', args), async t => {
     await withSiteBuilder('site-redirects-file-to-external', async builder => {
       const server = startExternalServer()


### PR DESCRIPTION
**- Summary**

This PR changes the directory we're passing to the traffic mesh agent to be the publish directory.
This is done to support sourcing `_redirects` and `_headers` from the publish directory and the project directory (only the latter was supported).

**- Test plan**

Added a test for this, which is still disabled when running with `--trafficMesh` since there are still other bugs to be fixed.

**- Description for the changelog**

Pass publish directory to traffic mesh agent instead of project directory.

**- A picture of a cute animal (not mandatory but encouraged)**

🐶 