### PR TITLE
chore: remove redundant await keywords

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
     ],
     "no-process-exit": 0,
     "object-shorthand": "error",
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "require-await": "error"
   },
   "overrides": [
     {
@@ -42,7 +43,8 @@
         "node/no-unsupported-features/es-builtins": 0,
         "node/no-unsupported-features/node-builtins": 0,
         "node/no-missing-require": 0,
-        "node/shebang": 0
+        "node/shebang": 0,
+        "require-await": 0
       }
     }
   ]

--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -12,7 +12,7 @@
       }
     }
   ],
-  "rules": { "react/prop-types": 0 },
+  "rules": { "react/prop-types": 0, "require-await": "error" },
   "settings": {
     "react": {
       "version": "16.13.1" // from @compositor/x0@6.0.7

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -127,7 +127,7 @@ async function pickTemplate() {
     message: 'Pick a template',
     type: 'autocomplete',
     // suggestOnly: true, // we can explore this for entering URL in future
-    async source(answersSoFar, input) {
+    source(answersSoFar, input) {
       if (!input || input === '') {
         // show separators
         return [
@@ -253,7 +253,7 @@ async function downloadFromURL(flags, args, functionsDir) {
   }
 }
 
-async function installDeps(functionPath) {
+function installDeps(functionPath) {
   return new Promise(resolve => {
     cp.exec('npm i', { cwd: path.join(functionPath) }, () => {
       resolve()
@@ -336,7 +336,7 @@ async function scaffoldFromTemplate(flags, args, functionsDir) {
   }
 }
 
-async function installAddons(addons = [], fnPath) {
+function installAddons(addons = [], fnPath) {
   if (addons.length > 0) {
     const { api, site } = this.netlify
     const siteId = site.id
@@ -346,7 +346,7 @@ async function installAddons(addons = [], fnPath) {
     }
     this.log(`${NETLIFYDEVLOG} checking Netlify APIs...`)
 
-    return api.getSite({ siteId }).then(async siteData => {
+    return api.getSite({ siteId }).then(siteData => {
       const accessToken = api.accessToken
       const arr = addons.map(({ addonName, addonDidInstall }) => {
         this.log(`${NETLIFYDEVLOG} installing addon: ` + chalk.yellow.inverse(addonName))

--- a/src/hooks/analytics.js
+++ b/src/hooks/analytics.js
@@ -1,6 +1,6 @@
 const { track } = require('../utils/telemetry')
 
-const hook = async function(options) {
+const hook = function(options) {
   track(options.eventName, options.payload)
 }
 module.exports = hook

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -200,7 +200,7 @@ class BaseCommand extends Command {
     return getToken(tokenFromFlag)
   }
 
-  async authenticate(tokenFromFlag) {
+  authenticate(tokenFromFlag) {
     const [token] = this.getConfigToken(tokenFromFlag)
     if (!token) {
       return this.expensivelyAuthenticate()

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -47,7 +47,7 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
         name: 'chosenSetting',
         message: `Multiple possible start commands found`,
         type: 'autocomplete',
-        async source(_, input) {
+        source(_, input) {
           if (!input || input === '') {
             return scriptInquirerOptions
           }

--- a/src/utils/gh-auth.js
+++ b/src/utils/gh-auth.js
@@ -120,7 +120,7 @@ async function getGitHubToken(opts) {
       auth: {
         username,
         password,
-        async on2fa() {
+        on2fa() {
           return promptForOTP()
         },
       },

--- a/src/utils/live-tunnel.js
+++ b/src/utils/live-tunnel.js
@@ -40,7 +40,7 @@ async function createTunnel({ siteId, netlifyApiToken, log }) {
   return data
 }
 
-async function connectTunnel({ session, netlifyApiToken, localPort, log }) {
+function connectTunnel({ session, netlifyApiToken, localPort, log }) {
   const execPath = getPathInHome(['tunnel', 'bin', EXEC_NAME])
   const args = ['connect', '-s', session.id, '-t', netlifyApiToken, '-l', localPort]
   if (process.env.DEBUG) {

--- a/src/utils/parse-raw-flags.test.js
+++ b/src/utils/parse-raw-flags.test.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const { parseRawFlags, aggressiveJSONParse } = require('./parse-raw-flags')
 
-test.serial('JSONTruthy works with various inputs', async t => {
+test.serial('JSONTruthy works with various inputs', t => {
   const testPairs = [
     {
       input: 'true',
@@ -26,7 +26,7 @@ test.serial('JSONTruthy works with various inputs', async t => {
   })
 })
 
-test.serial('parseRawFlags works', async t => {
+test.serial('parseRawFlags works', t => {
   const input = [
     { type: 'arg', input: 'FAUNA' },
     { type: 'arg', input: 'FOO' },

--- a/src/utils/read-repo-url.js
+++ b/src/utils/read-repo-url.js
@@ -22,7 +22,7 @@ async function readRepoURL(_url) {
   return folderContents
 }
 
-async function getRepoURLContents(repoHost, owner_and_repo, contents_path) {
+function getRepoURLContents(repoHost, owner_and_repo, contents_path) {
   // naive joining strategy for now
   if (repoHost === GITHUB) {
     // https://developer.github.com/v3/repos/contents/#get-contents

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -283,7 +283,7 @@ function createFormSubmissionHandler(siteInfo) {
   }
 }
 
-async function serveFunctions(dir, siteInfo = {}) {
+function serveFunctions(dir, siteInfo = {}) {
   const app = express()
   app.set('query parser', 'simple')
 


### PR DESCRIPTION
**- Summary**

This PR removes some redundant await keywords from our code base and adds a lint rule for it.

Haven't done it for our function templates yet, since removing `await` from some of them will make them not return a promise. I'll need to verify that pattern is supported first.

**- Test plan**

N/A

**- Description for the changelog**

Add a lint rule to track redundant `await` keywords.

**- A picture of a cute animal (not mandatory but encouraged)**

🐦 