### PR TITLE
refactor(command-dev-exec): don't mutate process.env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2895,6 +2895,11 @@
         "tsutils": "^3.17.1"
       }
     },
+    "@ungap/from-entries": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ungap/from-entries/-/from-entries-0.2.1.tgz",
+      "integrity": "sha512-CAqefTFAfnUPwYqsWHXpOxHaq1Zo5UQ3m9Zm2p09LggGe57rqHoBn3c++xcoomzXKynAUuiBMDUCQvKMnXjUpA=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@oclif/plugin-not-found": "^1.1.4",
     "@oclif/plugin-plugins": "^1.7.8",
     "@octokit/rest": "^16.28.1",
+    "@ungap/from-entries": "^0.2.1",
     "ansi-styles": "^4.0.0",
     "ascii-table": "0.0.9",
     "body-parser": "^1.19.0",

--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -1,5 +1,6 @@
 const execa = require('execa')
 const chalk = require('chalk')
+const fromEntries = require('@ungap/from-entries')
 const Command = require('../../utils/command')
 const {
   // NETLIFYDEV,
@@ -28,11 +29,11 @@ class ExecCommand extends Command {
         `${NETLIFYDEVLOG} Adding the following env variables from ${envSettings.files.map(f => chalk.blue(f))}:`,
         chalk.yellow(envSettings.vars.map(([key]) => key))
       )
-      envSettings.vars.forEach(([key, val]) => (process.env[key] = val))
     }
 
     execa(this.argv[0], this.argv.slice(1), {
       stdio: 'inherit',
+      env: fromEntries(envSettings.vars),
     })
     await this.config.runHook('analytics', {
       eventName: 'command',

--- a/tests/command.dev.exec.test.js
+++ b/tests/command.dev.exec.test.js
@@ -1,0 +1,18 @@
+const test = require('ava')
+const callCli = require('./utils/callCli')
+const { withSiteBuilder } = require('./utils/siteBuilder')
+
+test('should pass .env variables to exec command', async t => {
+  await withSiteBuilder('site-env-file', async builder => {
+    builder.withEnvFile({ env: { TEST: 'ENV_VAR' } })
+    await builder.buildAsync()
+
+    const cmd = process.platform === 'win32' ? 'set' : 'printenv'
+    const output = await callCli(['dev:exec', cmd], {
+      cwd: builder.directory,
+    })
+
+    t.is(output.includes('Adding the following env variables from .env: TEST'), true)
+    t.is(output.trim().endsWith('TEST=ENV_VAR'), true)
+  })
+})

--- a/tests/command.dev.exec.test.js
+++ b/tests/command.dev.exec.test.js
@@ -13,6 +13,6 @@ test('should pass .env variables to exec command', async t => {
     })
 
     t.is(output.includes('Adding the following env variables from .env: TEST'), true)
-    t.is(output.trim().endsWith('TEST=ENV_VAR'), true)
+    t.is(output.includes('TEST=ENV_VAR'), true)
   })
 })


### PR DESCRIPTION
**- Summary**

Follow up on https://github.com/netlify/cli/pull/1305 - don't mutate `process.env` when we can pass `env`
 to `execa`

**- Test plan**

Added a test case

**- Description for the changelog**

Don't mutate `process.env` in `commands/dev/exec.js`

**- A picture of a cute animal (not mandatory but encouraged)**

🐈 