### PR TITLE
refactor: remove open-browser code duplication

### DIFF
--- a/src/commands/addons/auth.js
+++ b/src/commands/addons/auth.js
@@ -49,7 +49,7 @@ class AddonsAuthCommand extends Command {
     this.log()
     this.log(currentAddon.auth_url)
     this.log()
-    await openBrowser(currentAddon.auth_url)
+    await openBrowser({ url: currentAddon.auth_url, log: this.log })
     this.exit()
   }
 }

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -433,7 +433,7 @@ class DeployCommand extends Command {
 
     if (flags.open) {
       const urlToOpen = deployToProduction ? results.siteUrl : results.deployUrl
-      await openBrowser(urlToOpen)
+      await openBrowser({ url: urlToOpen, log })
       exit()
     }
   }

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -8,7 +8,7 @@ const { serverSettings } = require('../../utils/detect-server')
 const { startFunctionsServer } = require('../../utils/serve-functions')
 const Command = require('../../utils/command')
 const chalk = require('chalk')
-const open = require('open')
+const openBrowser = require('../../utils/open-browser')
 const { NETLIFYDEV, NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require('../../utils/logo')
 const boxen = require('boxen')
 const { startLiveTunnel } = require('../../utils/live-tunnel')
@@ -152,16 +152,6 @@ const handleLiveTunnel = async ({ flags, site, api, settings, log }) => {
   }
 }
 
-const openBrowser = async ({ devConfig, url, warn }) => {
-  if (devConfig.autoLaunch !== false && process.env.BROWSER !== 'none') {
-    try {
-      await open(url)
-    } catch (err) {
-      warn(NETLIFYDEVWARN, 'Error while opening dev server URL in browser', err.message)
-    }
-  }
-}
-
 const reportAnalytics = async ({ config, settings }) => {
   await config.runHook('analytics', {
     eventName: 'command',
@@ -223,7 +213,9 @@ class DevCommand extends Command {
     const liveTunnelUrl = await handleLiveTunnel({ flags, site, api, settings, log })
     url = liveTunnelUrl || url
 
-    await openBrowser({ devConfig, url, warn })
+    if (devConfig.autoLaunch !== false) {
+      await openBrowser({ url, log, silentBrowserNoneError: true })
+    }
 
     await reportAnalytics({ config: this.config, settings })
 

--- a/src/commands/open/admin.js
+++ b/src/commands/open/admin.js
@@ -42,7 +42,7 @@ Run \`netlify link\` to connect to this folder to a site`)
       this.error(e)
     }
 
-    await openBrowser(siteData.admin_url)
+    await openBrowser({ url: siteData.admin_url, log: this.log })
     this.exit()
   }
 }

--- a/src/commands/open/site.js
+++ b/src/commands/open/site.js
@@ -36,7 +36,7 @@ Run \`netlify link\` to connect to this folder to a site`)
       this.error(e)
     }
 
-    await openBrowser(url)
+    await openBrowser({ url, log: this.log })
     this.exit()
   }
 }

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -222,7 +222,7 @@ class BaseCommand extends Command {
     const authLink = `${webUI}/authorize?response_type=ticket&ticket=${ticket.id}`
 
     this.log(`Opening ${authLink}`)
-    await openBrowser(authLink)
+    await openBrowser({ url: authLink, log: this.log })
 
     const accessToken = await this.netlify.api.getAccessToken(ticket)
 

--- a/src/utils/gh-auth.js
+++ b/src/utils/gh-auth.js
@@ -3,14 +3,14 @@ const { Octokit } = require('@octokit/rest')
 const inquirer = require('inquirer')
 const querystring = require('querystring')
 const get = require('lodash.get')
-const open = require('open')
+const openBrowser = require('./open-browser')
 const http = require('http')
 const getPort = require('get-port')
 
 module.exports = getGitHubToken
 
-async function getGitHubToken(opts) {
-  console.log('')
+async function getGitHubToken({ opts, log }) {
+  log('')
 
   opts = Object.assign(
     {
@@ -89,13 +89,7 @@ async function getGitHubToken(opts) {
         provider: 'github',
       })
 
-    try {
-      await open(url)
-    } catch (err) {
-      console.log(
-        'Netlify CLI could not open the browser for you.' + ' Please visit this URL in a browser on this device: ' + url
-      )
-    }
+    await openBrowser({ url, log })
 
     return await deferredPromise
   } else {

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -20,9 +20,12 @@ async function configGithub(ctx, site, repo) {
 
   if (!ghtoken || !ghtoken.user || !ghtoken.token) {
     const newToken = await ghauth({
-      scopes: ['admin:org', 'admin:public_key', 'repo', 'user'],
-      userAgent: UA,
-      note: `Netlify CLI ${os.userInfo().username}@${os.hostname()}`,
+      opts: {
+        scopes: ['admin:org', 'admin:public_key', 'repo', 'user'],
+        userAgent: UA,
+        note: `Netlify CLI ${os.userInfo().username}@${os.hostname()}`,
+      },
+      log: ctx.log,
     })
     globalConfig.set(`users.${current}.auth.github`, newToken)
     ghtoken = newToken

--- a/src/utils/open-browser.js
+++ b/src/utils/open-browser.js
@@ -1,31 +1,32 @@
-const cli = require('cli-ux').default
+const open = require('open')
 const chalk = require('chalk')
 const isDockerContainer = require('is-docker')
 
-function unableToOpenBrowserMessage(url, err) {
-  // https://github.com/sindresorhus/log-symbols
-  console.log('---------------------------')
-  const errMsg = err ? `\n${err.message}` : ''
-  const msg = `Error: Unable to open browser automatically${errMsg}\n`
-  console.log(`${chalk.redBright(msg)}`)
-  console.log(chalk.greenBright('Please open your browser & open the URL below to login:'))
-  console.log(chalk.whiteBright(url))
-  console.log('---------------------------')
-  return Promise.resolve()
+function unableToOpenBrowserMessage({ url, log, message }) {
+  log('---------------------------')
+  log(chalk.redBright(`Error: Unable to open browser automatically: ${message}`))
+  log(chalk.cyan('Please open your browser and open the URL below:'))
+  log(chalk.bold(url))
+  log('---------------------------')
 }
 
-async function openBrowser(url) {
-  let browser = process.env.BROWSER
-  if (browser === 'none' || isDockerContainer()) {
-    return unableToOpenBrowserMessage(url)
+async function openBrowser({ url, log, silentBrowserNoneError }) {
+  if (isDockerContainer()) {
+    unableToOpenBrowserMessage({ url, log, message: 'Running inside a docker container' })
+    return
   }
-  if (process.platform === 'darwin' && browser === 'open') {
-    browser = undefined
+  if (process.env.BROWSER === 'none') {
+    if (!silentBrowserNoneError) {
+      unableToOpenBrowserMessage({ url, log, message: "BROWSER environment variable is set to 'none'" })
+    }
+    return
   }
 
-  await cli.open(url).catch(err => {
-    unableToOpenBrowserMessage(url, err)
-  })
+  try {
+    await open(url)
+  } catch (error) {
+    unableToOpenBrowserMessage({ url, log, message: error.message })
+  }
 }
 
 module.exports = openBrowser


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1212, follow up on https://github.com/netlify/cli/pull/1144

More context - not only we had duplicate code around this, we were using 2 different dependencies to do so. I removed the usage of https://github.com/oclif/cli-ux/blob/515570bbeb40bcd28698b6b7af53cc9bfdf86279/src/open.ts#L12 as it seems like an out of date version of https://github.com/sindresorhus/open/blob/f3748e4f5a04a41e27034aff1eb08e8b86d01c1c/index.js#L34

**- Test plan**

Tested manually the different commands related to opening browsers (`login,dev,deploy,init,open,sites:create --with-ci`).

**- Description for the changelog**

Remove open browser code duplication

**- A picture of a cute animal (not mandatory but encouraged)**

🐕 