### PR TITLE
fix(command-dev): allow netlify-lambda build parameters

### DIFF
--- a/src/function-builder-detectors/netlify-lambda.js
+++ b/src/function-builder-detectors/netlify-lambda.js
@@ -1,34 +1,19 @@
-const { existsSync, readFileSync } = require('fs')
-
 const execa = require('execa')
 
-/**
- * Function builder detector for netlify-lambda.
- *
- * @param {object} [packageSettings] npm package.json format, if not provided, defaults to reading package.json from the file system.
- */
-module.exports = function handler(packageSettings) {
-  if (!packageSettings) {
-    if (!existsSync('package.json')) {
-      return false
-    }
+const { fileExistsAsync, readFileAsync } = require('../lib/fs')
 
-    packageSettings = JSON.parse(readFileSync('package.json', { encoding: 'utf8' }))
-  }
-
-  const { dependencies, devDependencies, scripts } = packageSettings
+const detectNetlifyLambda = async function ({ dependencies, devDependencies, scripts } = {}) {
   if (!((dependencies && dependencies['netlify-lambda']) || (devDependencies && devDependencies['netlify-lambda']))) {
     return false
   }
 
-  const yarnExists = existsSync('yarn.lock')
+  const yarnExists = await fileExistsAsync('yarn.lock')
   const settings = {}
 
   for (const key in scripts) {
     const script = scripts[key]
 
     const match = script.match(/netlify-lambda build.* (\S+)\s*$/)
-    console.log(match)
     if (match) {
       const [, src] = match
       settings.src = src
@@ -43,3 +28,15 @@ module.exports = function handler(packageSettings) {
     return settings
   }
 }
+
+module.exports = async function handler() {
+  const exists = await fileExistsAsync('package.json')
+  if (!exists) {
+    return false
+  }
+
+  const content = await readFileAsync('package.json')
+  const packageSettings = JSON.parse(content, { encoding: 'utf8' })
+  return detectNetlifyLambda(packageSettings)
+}
+module.exports.detectNetlifyLambda = detectNetlifyLambda

--- a/src/function-builder-detectors/netlify-lambda.test.js
+++ b/src/function-builder-detectors/netlify-lambda.test.js
@@ -129,7 +129,8 @@ test(`should use the value of the parameter if no directory was provided`, t => 
 test(`should ignore spaces in the directory name`, t => {
   const packageJson = {
     scripts: {
-      'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js some directory/name',
+      'some-build-step':
+        'netlify-lambda build -s --another-option --config config/webpack.config.js some directory/name',
     },
     dependencies: {},
     devDependencies: {
@@ -144,4 +145,3 @@ test(`should ignore spaces in the directory name`, t => {
   t.is(match.builderName, 'netlify-lambda')
   t.is(match.npmScript, 'some-build-step')
 })
-

--- a/src/function-builder-detectors/netlify-lambda.test.js
+++ b/src/function-builder-detectors/netlify-lambda.test.js
@@ -1,0 +1,147 @@
+const test = require('ava')
+
+const netlifyLambda = require('./netlify-lambda')
+
+test(`should not find netlify-lambda from netlify-cli package.json`, t => {
+  t.is(netlifyLambda(), false)
+})
+
+test(`should not match if netlify-lambda is missing from dependencies`, t => {
+  const packageJson = {
+    dependencies: {},
+    devDependencies: {},
+  }
+  t.is(netlifyLambda(packageJson), false)
+})
+
+test(`should match if netlify-lambda is listed in dependencies and is mentioned in scripts`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build some/directory',
+    },
+    dependencies: {
+      'netlify-lambda': 'ignored',
+    },
+    devDependencies: {},
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'some/directory')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+
+test(`should match if netlify-lambda is listed in devDependencies and is mentioned in scripts`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build some/directory',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'some/directory')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+
+test(`should not match if netlify-lambda misses function directory`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, true)
+})
+
+test(`should match if netlify-lambda is configured with an additional option`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build --config config/webpack.config.js some/directory',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'some/directory')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+
+test(`should match if netlify-lambda is configured with multiple additional options`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js some/directory',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'some/directory')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+
+// Note that this is less than ideal, but I preferred to keep it simple and not actually parse the arguments with a library
+test(`should use the value of the parameter if no directory was provided`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'config/webpack.config.js')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+
+// Again, less than ideal, but it seems impossible to have @oclif/parser to parse a complete string instead of argv[]
+test(`should ignore spaces in the directory name`, t => {
+  const packageJson = {
+    scripts: {
+      'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js some directory/name',
+    },
+    dependencies: {},
+    devDependencies: {
+      'netlify-lambda': 'ignored',
+    },
+  }
+
+  const match = netlifyLambda(packageJson)
+  t.not(match, false)
+
+  t.is(match.src, 'directory/name')
+  t.is(match.builderName, 'netlify-lambda')
+  t.is(match.npmScript, 'some-build-step')
+})
+

--- a/src/function-builder-detectors/tests/netlify-lambda.test.js
+++ b/src/function-builder-detectors/tests/netlify-lambda.test.js
@@ -1,20 +1,20 @@
 const test = require('ava')
 
-const netlifyLambda = require('./netlify-lambda')
+const { detectNetlifyLambda } = require('../netlify-lambda')
 
-test(`should not find netlify-lambda from netlify-cli package.json`, t => {
-  t.is(netlifyLambda(), false)
+test(`should not find netlify-lambda from netlify-cli package.json`, async (t) => {
+  t.is(await detectNetlifyLambda(), false)
 })
 
-test(`should not match if netlify-lambda is missing from dependencies`, t => {
+test(`should not match if netlify-lambda is missing from dependencies`, async (t) => {
   const packageJson = {
     dependencies: {},
     devDependencies: {},
   }
-  t.is(netlifyLambda(packageJson), false)
+  t.is(await detectNetlifyLambda(packageJson), false)
 })
 
-test(`should match if netlify-lambda is listed in dependencies and is mentioned in scripts`, t => {
+test(`should match if netlify-lambda is listed in dependencies and is mentioned in scripts`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build some/directory',
@@ -25,7 +25,7 @@ test(`should match if netlify-lambda is listed in dependencies and is mentioned 
     devDependencies: {},
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'some/directory')
@@ -33,7 +33,7 @@ test(`should match if netlify-lambda is listed in dependencies and is mentioned 
   t.is(match.npmScript, 'some-build-step')
 })
 
-test(`should match if netlify-lambda is listed in devDependencies and is mentioned in scripts`, t => {
+test(`should match if netlify-lambda is listed in devDependencies and is mentioned in scripts`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build some/directory',
@@ -44,7 +44,7 @@ test(`should match if netlify-lambda is listed in devDependencies and is mention
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'some/directory')
@@ -52,7 +52,7 @@ test(`should match if netlify-lambda is listed in devDependencies and is mention
   t.is(match.npmScript, 'some-build-step')
 })
 
-test(`should not match if netlify-lambda misses function directory`, t => {
+test(`should not match if netlify-lambda misses function directory`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build',
@@ -63,11 +63,11 @@ test(`should not match if netlify-lambda misses function directory`, t => {
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, true)
 })
 
-test(`should match if netlify-lambda is configured with an additional option`, t => {
+test(`should match if netlify-lambda is configured with an additional option`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build --config config/webpack.config.js some/directory',
@@ -78,7 +78,7 @@ test(`should match if netlify-lambda is configured with an additional option`, t
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'some/directory')
@@ -86,7 +86,7 @@ test(`should match if netlify-lambda is configured with an additional option`, t
   t.is(match.npmScript, 'some-build-step')
 })
 
-test(`should match if netlify-lambda is configured with multiple additional options`, t => {
+test(`should match if netlify-lambda is configured with multiple additional options`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js some/directory',
@@ -97,7 +97,7 @@ test(`should match if netlify-lambda is configured with multiple additional opti
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'some/directory')
@@ -106,7 +106,7 @@ test(`should match if netlify-lambda is configured with multiple additional opti
 })
 
 // Note that this is less than ideal, but I preferred to keep it simple and not actually parse the arguments with a library
-test(`should use the value of the parameter if no directory was provided`, t => {
+test(`should use the value of the parameter if no directory was provided`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step': 'netlify-lambda build -s --another-option --config config/webpack.config.js',
@@ -117,7 +117,7 @@ test(`should use the value of the parameter if no directory was provided`, t => 
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'config/webpack.config.js')
@@ -126,7 +126,7 @@ test(`should use the value of the parameter if no directory was provided`, t => 
 })
 
 // Again, less than ideal, but it seems impossible to have @oclif/parser to parse a complete string instead of argv[]
-test(`should ignore spaces in the directory name`, t => {
+test(`should ignore spaces in the directory name`, async (t) => {
   const packageJson = {
     scripts: {
       'some-build-step':
@@ -138,7 +138,7 @@ test(`should ignore spaces in the directory name`, t => {
     },
   }
 
-  const match = netlifyLambda(packageJson)
+  const match = await detectNetlifyLambda(packageJson)
   t.not(match, false)
 
   t.is(match.src, 'directory/name')


### PR DESCRIPTION
**- Summary**

Having a Netlify project with the following package.json doesn't work. 

```
{
  "name": "project",
  "private": true,
  "scripts": {
    "start": "netlify dev",
    "build": "run-p build:**",
    "build:lambda": "netlify-lambda build --config config/webpack.functions.js src/lambda/",
  }
}
```

It does not find the functions folder properly, as per the logs:

```
◈ Function builder netlify-lambda detected: Running npm script build:lambda
 ›   Warning: ◈ This is a beta feature, please give us feedback on how to improve at https://github.com/netlify/cli/
◈ Function builder netlify-lambda building functions from directory --config
```
**- Test plan**

See test cases.

**- Description for the changelog**

netlify-lambda build step in package.json now allows the use of command line arguments like --config. 

**- A picture of a cute animal (not mandatory but encouraged)**
