### PR TITLE
feat(dev): add trace subcommand to simulate redirects

### DIFF
--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -17,7 +17,7 @@ class TraceCommand extends Command {
 
 TraceCommand.description = `Trace command
 Simulates Netlify's Edge routing logic to match specific requests. 
-This command is designed to mimic cURL's command line, so the flags are more familar.
+This command is designed to mimic cURL's command line, so the flags are more familiar.
 `
 
 TraceCommand.examples = [

--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -30,5 +30,6 @@ TraceCommand.examples = [
 
 TraceCommand.strict = false
 TraceCommand.parse = false
+TraceCommand.hidden = true
 
 module.exports = TraceCommand

--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -1,0 +1,34 @@
+const Command = require('../../utils/command')
+const { runProcess } = require('../../utils/traffic-mesh')
+
+class TraceCommand extends Command {
+  async run() {
+    const args = ['trace'].concat(this.argv)
+    await runProcess({ log: this.log, args })
+
+    await this.config.runHook('analytics', {
+      eventName: 'command',
+      payload: {
+        command: 'dev:trace',
+      },
+    })
+  }
+}
+
+TraceCommand.description = `Trace command
+Simulates Netlify's Edge routing logic to match specific requests. 
+This command is designed to mimic cURL's command line, so the flags are more familar.
+`
+
+TraceCommand.examples = [
+  '$ netlify dev:trace http://localhost/routing-path',
+  '$ netlify dev:trace -w dist-directory http://localhost/routing-path',
+  '$ netlify dev:trace -X POST http://localhost/routing-path',
+  '$ netlify dev:trace -H "Accept-Language es" http://localhost/routing-path',
+  '$ netlify dev:trace --cookie nf_jwt=token http://localhost/routing-path',
+]
+
+TraceCommand.strict = false
+TraceCommand.parse = false
+
+module.exports = TraceCommand

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -34,7 +34,6 @@ const installTrafficMesh = async ({ log }) => {
 }
 
 const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDir, log, debug }) => {
-  await installTrafficMesh({ log })
   const args = [
     'start',
     'local',
@@ -56,8 +55,7 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
     args.push('--debug')
   }
 
-  const execPath = path.join(getBinPath(), EXEC_NAME)
-  const subprocess = execa(execPath, args, { stdio: 'inherit' })
+  const subprocess = await runProcess({ log, args })
 
   subprocess.on('close', process.exit)
   subprocess.on('SIGINT', process.exit)
@@ -82,4 +80,11 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
   }
 }
 
-module.exports = { startForwardProxy }
+const runProcess = async ({ log, args }) => {
+  await installTrafficMesh({ log })
+
+  const execPath = path.join(getBinPath(), EXEC_NAME)
+  execa(execPath, args, { stdio: 'inherit' })
+}
+
+module.exports = { runProcess, startForwardProxy }

--- a/tests/command.dev.trace.js
+++ b/tests/command.dev.trace.js
@@ -1,0 +1,30 @@
+const test = require('ava')
+const { withSiteBuilder } = require('./utils/siteBuilder')
+const callCli = require('./utils/callCli')
+
+test('should not match redirect for empty site', async t => {
+  await withSiteBuilder('empty-site', async builder => {
+    await builder.buildAsync()
+
+    const output = await callCli(['dev:trace', 'http://localhost/routing-path'], {
+      cwd: builder.directory,
+    })
+
+    t.is(output.includes("request didn't match any rule"), true)
+  })
+})
+
+test('should match redirect when url matches', async t => {
+  await withSiteBuilder('site-with-redirects', async builder => {
+    builder.withRedirectsFile({
+      redirects: [{ from: '/*', to: `/index.html`, status: 200 }],
+    })
+    await builder.buildAsync()
+
+    const output = await callCli(['dev:trace', 'http://localhost/routing-path'], {
+      cwd: builder.directory,
+    })
+
+    t.is(output.includes('mapped remap found'), true)
+  })
+})


### PR DESCRIPTION
This new subcommand allows checking whether a request will match
a remap rule directly from the cli.
It requires the new traffic mesh agent.

Closes https://github.com/netlify/product/issues/584

Signed-off-by: David Calavera <david.calavera@gmail.com>
