### PR TITLE
chore: ignore major updates for update-notifier

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -27,6 +27,7 @@
         'ora',
         'prettier',
         'wrap-ansi',
+        'update-notifier',
       ],
       major: {
         enabled: false,


### PR DESCRIPTION
Latest major version for this package requires node 10