### PR TITLE
fix(command-deploy): pass buffer: true to build if --json or --silent

### DIFF
--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -6,7 +6,9 @@ const build = require('@netlify/build')
 const getBuildOptions = ({ netlify, token, flags }) => {
   const cachedConfig = JSON.stringify(netlify.cachedConfig)
   const { dry, debug } = flags
-  return { cachedConfig, token, dry, debug, mode: 'cli', telemetry: false }
+  // buffer = true will not stream output
+  const buffer = flags.json || flags.silent
+  return { cachedConfig, token, dry, debug, mode: 'cli', telemetry: false, buffer }
 }
 
 const runBuild = async options => {

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -163,6 +163,31 @@ if (process.env.IS_FORK !== 'true') {
     })
   })
 
+  test.serial('should return valid json when both --build and --json are passed', async t => {
+    await withSiteBuilder('site-with-public-folder', async builder => {
+      const content = '<h1>⊂◉‿◉つ</h1>'
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content,
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public' },
+          },
+        })
+
+      await builder.buildAsync()
+
+      const output = await callCli(['deploy', '--build', '--json'], {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      })
+
+      JSON.parse(output)
+    })
+  })
+
   test.serial('should deploy hidden public folder but ignore hidden/__MACOSX files', async t => {
     await withSiteBuilder('site-with-a-dedicated-publish-folder', async builder => {
       builder


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1332

**- Test plan**

Added a test case

**- Description for the changelog**

pass `buffer: true` to Netlify build if `--json` or `--silent`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/26760571/95191273-309faa80-07d9-11eb-805d-4f99494c2b75.png)
