### PR TITLE
Lint Ava test files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,12 +5,14 @@
     "standard",
     "prettier",
     "prettier/standard",
+    "plugin:ava/recommended",
     "plugin:you-dont-need-lodash-underscore/all"
   ],
   "rules": {
     "no-process-exit": 0,
     "object-shorthand": "error",
-    "require-await": "error"
+    "require-await": "error",
+    "ava/no-skip-test": 0
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4672,6 +4672,12 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
+    "buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+      "dev": true
+    },
     "buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -6416,6 +6422,16 @@
         }
       }
     },
+    "core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+      "dev": true,
+      "requires": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      }
+    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -6880,6 +6896,15 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
+      "dev": true,
+      "requires": {
+        "core-assert": "^0.2.0"
+      }
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -7477,6 +7502,15 @@
         "once": "^1.4.0"
       }
     },
+    "enhance-visitors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+      "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
     "envinfo": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
@@ -7950,6 +7984,51 @@
           "requires": {
             "find-up": "^2.1.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-ava": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-11.0.0.tgz",
+      "integrity": "sha512-UMGedfl/gIKx1tzjGtAsTSJgowyAEZU2VWmpoWXYcuuV4B2H4Cu90yuMgMPEVt1mQlIZ21L7YM2CSpHUFJo/LQ==",
+      "dev": true,
+      "requires": {
+        "deep-strict-equal": "^0.2.0",
+        "enhance-visitors": "^1.0.0",
+        "eslint-utils": "^2.1.0",
+        "espree": "^7.2.0",
+        "espurify": "^2.0.1",
+        "import-modules": "^2.0.0",
+        "micro-spelling-correcter": "^1.1.1",
+        "pkg-dir": "^4.2.0",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "espree": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+          "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.3.0"
+          }
+        },
+        "espurify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/espurify/-/espurify-2.0.1.tgz",
+          "integrity": "sha512-7w/dUrReI/QbJFHRwfomTlkQOXaB1NuCrBRn5Y26HXn5gvh18/19AgLbayVrNxXQfkckvgrJloWyvZDuJ7dhEA==",
+          "dev": true
         }
       }
     },
@@ -10403,6 +10482,12 @@
         "resolve-cwd": "^3.0.0"
       }
     },
+    "import-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.0.0.tgz",
+      "integrity": "sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -12054,6 +12139,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-2.1.2.tgz",
       "integrity": "sha512-COjNutiFgnDHXZEIM/jYuZPwq2h8zMUeScf6Sh6so98a+REqdlpaNS7Cb2ffGfK5I+xfgoA3Rx49NGuNJTJq3w=="
+    },
+    "micro-spelling-correcter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+      "integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+      "dev": true
     },
     "micromatch": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-ava": "^11.0.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -7,11 +7,16 @@
     "standard",
     "prettier",
     "prettier/standard",
+    "plugin:ava/recommended",
     "plugin:react/recommended",
     "prettier/react",
     "plugin:you-dont-need-lodash-underscore/all"
   ],
-  "rules": { "react/prop-types": 0, "require-await": "error" },
+  "rules": {
+    "react/prop-types": 0,
+    "require-await": "error",
+    "ava/no-skip-test": 0
+  },
   "settings": {
     "react": {
       "version": "16.13.1" // from @compositor/x0@6.0.7

--- a/src/lib/exec-fetcher.test.js
+++ b/src/lib/exec-fetcher.test.js
@@ -10,6 +10,10 @@ test.beforeEach(t => {
   t.context.binPath = directory
 })
 
+test.afterEach(async t => {
+  await fs.remove(t.context.binPath)
+})
+
 test(`should postix exec with .exe on windows`, t => {
   const execName = 'some-binary-file'
   if (process.platform === 'win32') {
@@ -58,8 +62,4 @@ packages.forEach(({ packageName, execName, execArgs, pattern, extension }) => {
     const stats = await fs.stat(execPath)
     t.is(stats.size >= 5000, true)
   })
-})
-
-test.afterEach(async t => {
-  await fs.remove(t.context.binPath)
 })

--- a/src/lib/http-agent.test.js
+++ b/src/lib/http-agent.test.js
@@ -17,7 +17,7 @@ test(`should exit with error on invalid url`, async t => {
 
   await t.throwsAsync(getAgent({ httpProxy, log, exit }))
 
-  t.is('invalid_url is not a valid URL', log.getCall(0).args[1])
+  t.is(log.getCall(0).args[1], 'invalid_url is not a valid URL')
 })
 
 test(`should exit with error on when scheme is not http or https`, async t => {
@@ -28,7 +28,7 @@ test(`should exit with error on when scheme is not http or https`, async t => {
 
   await t.throwsAsync(getAgent({ httpProxy, log, exit }))
 
-  t.is('file://localhost must have a scheme of http or https', log.getCall(0).args[1])
+  t.is(log.getCall(0).args[1], 'file://localhost must have a scheme of http or https')
 })
 
 test(`should exit with error when proxy is no available`, async t => {
@@ -40,9 +40,9 @@ test(`should exit with error when proxy is no available`, async t => {
   await t.throwsAsync(getAgent({ httpProxy, log, exit }))
 
   if (process.platform === 'win32') {
-    t.is("Could not connect to 'https://unknown:7979'", log.getCall(0).args[1])
+    t.is(log.getCall(0).args[1], "Could not connect to 'https://unknown:7979'")
   } else {
-    t.is('https://unknown:7979 is not available.', log.getCall(0).args[1])
+    t.is(log.getCall(0).args[1], 'https://unknown:7979 is not available.')
   }
 })
 
@@ -63,7 +63,7 @@ test(`should return agent for a valid proxy`, async t => {
 
   const agent = await getAgent({ httpProxy: httpProxyUrl, log, exit })
 
-  t.is(true, agent instanceof HttpsProxyAgent)
+  t.is(agent instanceof HttpsProxyAgent, true)
 
   server.close()
 })

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -16,6 +16,11 @@ test.before(async t => {
   t.context.sitePath = builder.directory
 })
 
+test.after(async t => {
+  process.chdir(t.context.cwd)
+  await t.context.builder.cleanupAsync()
+})
+
 test('loadDetector: valid', t => {
   const d = loadDetector('create-react-app.js')
   t.is(typeof d, 'function')
@@ -171,9 +176,4 @@ test('chooseDefaultArgs', t => {
   const possibleArgsArrs = [['run', 'dev'], ['run develop']]
   const args = chooseDefaultArgs(possibleArgsArrs)
   t.deepEqual(args, possibleArgsArrs[0])
-})
-
-test.after(async t => {
-  process.chdir(t.context.cwd)
-  await t.context.builder.cleanupAsync()
 })

--- a/src/utils/headers.test.js
+++ b/src/utils/headers.test.js
@@ -31,6 +31,10 @@ test.before(async t => {
   t.context.builder = builder
 })
 
+test.after(async t => {
+  await t.context.builder.cleanupAsync()
+})
+
 test('_headers: validate correct parsing', t => {
   const rules = parseHeadersFile(path.resolve(t.context.builder.directory, '_headers'))
   t.deepEqual(rules, {
@@ -69,8 +73,4 @@ test('_headers: rulesForPath testing', t => {
     'X-Frame-Options': ['SAMEORIGIN'],
     'X-Frame-Thing': ['SAMEORIGIN'],
   })
-})
-
-test.after(async t => {
-  await t.context.builder.cleanupAsync()
 })


### PR DESCRIPTION
Related: https://github.com/netlify/build/pull/1935

This adds [`eslint-plugin-ava`](https://github.com/avajs/eslint-plugin-ava) to lint our Ava test files.