### PR TITLE
Prefer `Array.find()` over `Array.filter()`

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -114,9 +114,9 @@ function createHandler(dir) {
     // handle proxies without path re-writes (http-servr)
     const cleanPath = request.path.replace(/^\/.netlify\/functions/, '')
 
-    const func = cleanPath.split('/').filter(function(e) {
+    const func = cleanPath.split('/').find(function(e) {
       return e
-    })[0]
+    })
     if (!functions[func]) {
       response.statusCode = 404
       response.end('Function not found...')


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`prefer-array-find`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-array-find.md).