### PR TITLE
Prefer `[...array]` over `Array.from(array)`

### DIFF
--- a/src/utils/addons/compare.js
+++ b/src/utils/addons/compare.js
@@ -14,7 +14,7 @@ module.exports = function compare(oldValues, newValues) {
   const newKeys = Object.keys(newValues)
   const set = new Set(newKeys.concat(oldKeys))
 
-  return Array.from(set).reduce((acc, current) => {
+  return [...set].reduce((acc, current) => {
     // if values not deep equal. There are changes
     if (!isEqual(newValues[current], oldValues[current])) {
       return {

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -56,7 +56,7 @@ function parse(input, fn) {
         // Join sections under common name
         if (sec1.name === sec2.name) {
           sectionExists = true
-          sec1.patterns = Array.from(new Set(sec1.patterns.concat(sec2.patterns)))
+          sec1.patterns = [...new Set(sec1.patterns.concat(sec2.patterns))]
         }
       }
 

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -226,7 +226,7 @@ function initializeProxy(port, distDir, projectDir) {
     },
   })
 
-  const headersFiles = Array.from(new Set([path.resolve(projectDir, '_headers'), path.resolve(distDir, '_headers')]))
+  const headersFiles = [...new Set([path.resolve(projectDir, '_headers'), path.resolve(distDir, '_headers')])]
 
   let headerRules = headersFiles.reduce((prev, curr) => Object.assign(prev, parseHeadersFile(curr)), {})
   onChanges(headersFiles, () => {

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -63,13 +63,13 @@ function getCountry(req) {
 
 module.exports.createRewriter = async function createRewriter({ distDir, projectDir, jwtSecret, jwtRole, configPath }) {
   let matcher = null
-  const configFiles = Array.from(
-    new Set(
+  const configFiles = [
+    ...new Set(
       [path.resolve(distDir, '_redirects'), path.resolve(projectDir, '_redirects')].concat(
         configPath ? path.resolve(configPath) : []
       )
-    )
-  ).filter(f => f !== projectDir)
+    ),
+  ].filter(f => f !== projectDir)
   let rules = await parseRules(configFiles)
 
   onChanges(configFiles, async () => {


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`prefer-spread`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-spread.md).