### PR TITLE
Name `error` variable consistently

### DIFF
--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -188,8 +188,8 @@ async function update({ addonName, currentConfig, newConfig, settings, accessTok
   try {
     // TODO update updateAddon to https://open-api.netlify.com/#operation/updateServiceInstance
     updateAddonResponse = await updateAddon(settings, accessToken)
-  } catch (e) {
-    error(e.message)
+  } catch (error_) {
+    error(error_.message)
   }
   if (updateAddonResponse.code === 404) {
     logger(`No add-on "${addonName}" found. Please double check your add-on name and try again`)

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -157,8 +157,8 @@ async function createSiteAddon({ addonName, settings, accessToken, siteData, err
   try {
     // TODO update to https://open-api.netlify.com/#operation/createServiceInstance
     addonResponse = await createAddon(settings, accessToken)
-  } catch (e) {
-    error(e.message)
+  } catch (error_) {
+    error(error_.message)
   }
 
   if (addonResponse.code === 404) {

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -65,8 +65,8 @@ class AddonsDeleteCommand extends Command {
     try {
       // TODO update deleteAddon to https://open-api.netlify.com/#operation/deleteServiceInstance
       addonResponse = await deleteAddon(settings, accessToken)
-    } catch (e) {
-      this.error(e.message)
+    } catch (error) {
+      this.error(error.message)
     }
 
     if (addonResponse.status === 404) {

--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -50,8 +50,8 @@ class APICommand extends Command {
     try {
       const apiResponse = await api[apiMethod](payload)
       this.log(JSON.stringify(apiResponse, null, 2))
-    } catch (e) {
-      this.error(e)
+    } catch (error) {
+      this.error(error)
     }
   }
 }

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -27,11 +27,11 @@ const triggerDeploy = async ({ api, siteId, siteData, log, error }) => {
     log(
       `${NETLIFYDEV} A new deployment was triggered successfully. Visit https://app.netlify.com/sites/${siteData.name}/deploys/${siteBuild.deploy_id} to see the logs.`
     )
-  } catch (err) {
-    if (err.status === 404) {
+  } catch (error_) {
+    if (error_.status === 404) {
       error('Site not found. Please rerun "netlify link" and make sure that your site has CI configured.')
     } else {
-      error(err.message)
+      error(error_.message)
     }
   }
 }
@@ -68,16 +68,16 @@ const validateDeployFolder = async ({ deployFolder, error }) => {
   let stat
   try {
     stat = await statAsync(deployFolder)
-  } catch (e) {
-    if (e.code === 'ENOENT') {
+  } catch (error_) {
+    if (error_.code === 'ENOENT') {
       return error(`No such directory ${deployFolder}! Did you forget to run a build?`)
     }
 
     // Improve the message of permission errors
-    if (e.code === 'EACCES') {
+    if (error_.code === 'EACCES') {
       return error('Permission error when trying to access deploy folder')
     }
-    throw e
+    throw error_
   }
 
   if (!stat.isDirectory()) {
@@ -107,14 +107,14 @@ const validateFunctionsFolder = async ({ functionsFolder, log, error }) => {
     // but this was too strict for onboarding. we can just log a warning.
     try {
       stat = await statAsync(functionsFolder)
-    } catch (e) {
-      if (e.code === 'ENOENT') {
+    } catch (error_) {
+      if (error_.code === 'ENOENT') {
         log(
           `Functions folder "${functionsFolder}" specified but it doesn't exist! Will proceed without deploying functions`
         )
       }
       // Improve the message of permission errors
-      if (e.code === 'EACCES') {
+      if (error_.code === 'EACCES') {
         error('Permission error when trying to access functions folder')
       }
     }
@@ -221,31 +221,31 @@ const runDeploy = async ({
       deployId,
       filter: getDeployFilesFilter({ site, deployFolder }),
     })
-  } catch (e) {
+  } catch (error_) {
     if (deployId) {
       await cancelDeploy({ api, deployId, warn })
     }
     switch (true) {
-      case e.name === 'JSONHTTPError': {
-        warn(`JSONHTTPError: ${e.json.message} ${e.status}`)
-        warn(`\n${JSON.stringify(e, null, '  ')}\n`)
-        error(e)
+      case error_.name === 'JSONHTTPError': {
+        warn(`JSONHTTPError: ${error_.json.message} ${error_.status}`)
+        warn(`\n${JSON.stringify(error_, null, '  ')}\n`)
+        error(error_)
         return
       }
-      case e.name === 'TextHTTPError': {
-        warn(`TextHTTPError: ${e.status}`)
-        warn(`\n${e}\n`)
-        error(e)
+      case error_.name === 'TextHTTPError': {
+        warn(`TextHTTPError: ${error_.status}`)
+        warn(`\n${error_}\n`)
+        error(error_)
         return
       }
-      case e.message && e.message.includes('Invalid filename'): {
-        warn(e.message)
-        error(e)
+      case error_.message && error_.message.includes('Invalid filename'): {
+        warn(error_.message)
+        error(error_)
         return
       }
       default: {
-        warn(`\n${JSON.stringify(e, null, '  ')}\n`)
-        error(e)
+        warn(`\n${JSON.stringify(error_, null, '  ')}\n`)
+        error(error_)
         return
       }
     }
@@ -366,12 +366,12 @@ class DeployCommand extends Command {
     } else {
       try {
         siteData = await api.getSite({ siteId })
-      } catch (e) {
+      } catch (error_) {
         // TODO specifically handle known cases (e.g. no account access)
-        if (e.status === 404) {
+        if (error_.status === 404) {
           error('Site not found')
         } else {
-          error(e.message)
+          error(error_.message)
         }
       }
     }

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -39,13 +39,13 @@ async function startFrameworkServer({ settings, log, exit }) {
   }
 
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.framework || 'custom config'}`)
-  const commandBin = await which(settings.command).catch(err => {
-    if (err.code === 'ENOENT') {
+  const commandBin = await which(settings.command).catch(error => {
+    if (error.code === 'ENOENT') {
       throw new Error(
         `"${settings.command}" could not be found in your PATH. Please make sure that "${settings.command}" is installed and available in your PATH`
       )
     }
-    throw err
+    throw error
   })
   const ps = childProcess.spawn(commandBin, settings.args, {
     env: { ...process.env, ...settings.env, FORCE_COLOR: 'true' },
@@ -71,7 +71,7 @@ async function startFrameworkServer({ settings, log, exit }) {
     process.on(signal, () => {
       try {
         process.kill(-ps.pid)
-      } catch (err) {
+      } catch (error) {
         // Ignore
       }
       process.exit()
@@ -83,7 +83,7 @@ async function startFrameworkServer({ settings, log, exit }) {
     if (!open) {
       throw new Error(`Timed out waiting for port '${settings.frameworkPort}' to be open`)
     }
-  } catch (err) {
+  } catch (error) {
     log(NETLIFYDEVERR, `Netlify Dev could not connect to localhost:${settings.frameworkPort}.`)
     log(NETLIFYDEVERR, `Please make sure your framework server is running on port ${settings.frameworkPort}`)
     exit(1)
@@ -200,8 +200,8 @@ class DevCommand extends Command {
     let settings = {}
     try {
       settings = await serverSettings(devConfig, flags, site.root, log)
-    } catch (err) {
-      log(NETLIFYDEVERR, err.message)
+    } catch (error) {
+      log(NETLIFYDEVERR, error.message)
       exit(1)
     }
 

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -36,8 +36,8 @@ class EnvImportCommand extends Command {
     try {
       const envFileContents = fs.readFileSync(fileName)
       importedEnv = dotenv.parse(envFileContents)
-    } catch (e) {
-      this.log(e.message)
+    } catch (error) {
+      this.log(error.message)
       this.exit(1)
     }
 

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -130,13 +130,13 @@ class FunctionsInvokeCommand extends Command {
           // data = response.json();
           data = JSON.parse(data)
           // eslint-disable-next-line no-empty
-        } catch (err) {}
+        } catch (error) {}
         return data
       })
       .then(console.log)
-      .catch(err => {
+      .catch(error => {
         console.error('ran into an error invoking your function')
-        console.error(err)
+        console.error(error)
       })
   }
 }
@@ -162,8 +162,8 @@ function processPayloadFromFlag(payloadString) {
       try {
         payload = require(payloadpath) // there is code execution potential here
         return payload
-      } catch (err) {
-        console.error(err)
+      } catch (error) {
+        console.error(error)
       }
     }
     // case 3: invalid string, invalid path
@@ -270,7 +270,7 @@ function tryParseJSON(jsonString) {
       return o
     }
     // eslint-disable-next-line no-empty
-  } catch (e) {}
+  } catch (error) {}
 
   return false
 }

--- a/src/commands/functions/list.js
+++ b/src/commands/functions/list.js
@@ -17,15 +17,15 @@ class FunctionsListCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (e) {
-      if (e.status === 401 /* unauthorized */) {
+    } catch (error) {
+      if (error.status === 401 /* unauthorized */) {
         this.warn(`Log in with a different account or re-link to a site you have permission for`)
         this.error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      if (e.status === 404 /* missing */) {
+      if (error.status === 404 /* missing */) {
         this.error(`The site this folder is linked to can't be found`)
       }
-      this.error(e)
+      this.error(error)
     }
     const deploy = siteData.published_deploy || {}
     const deployedFunctions = deploy.available_functions || []

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -34,7 +34,7 @@ class InitCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (e) {
+    } catch (error) {
       // silent api error
       // TODO handle expected errors
       // Throw unexpected ones
@@ -204,14 +204,14 @@ git remote add origin https://github.com/YourUserName/RepoName.git
         case 'github': {
           try {
             await configGithub(this, siteData, repo)
-          } catch (e) {
-            this.warn(`GitHub error: ${e.status}`)
-            if (e.status === 404) {
+          } catch (error) {
+            this.warn(`GitHub error: ${error.status}`)
+            if (error.status === 404) {
               this.error(
                 `Does the repository ${repo.repo_path} exist and do you have the correct permissions to set up deploy keys?`
               )
             } else {
-              throw e
+              throw error
             }
           }
           break

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -24,7 +24,7 @@ class LinkCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (e) {
+    } catch (error) {
       // silent api error
     }
 
@@ -50,11 +50,11 @@ class LinkCommand extends Command {
     if (flags.id) {
       try {
         siteData = await api.getSite({ site_id: flags.id })
-      } catch (e) {
-        if (e.status === 404) {
+      } catch (error) {
+        if (error.status === 404) {
           this.error(new Error(`Site id ${flags.id} not found`))
         } else {
-          this.error(e)
+          this.error(error)
         }
       }
 
@@ -78,11 +78,11 @@ class LinkCommand extends Command {
           name: flags.name,
           filter: 'all',
         })
-      } catch (e) {
-        if (e.status === 404) {
+      } catch (error) {
+        if (error.status === 404) {
           this.error(new Error(`${flags.name} not found`))
         } else {
-          this.error(e)
+          this.error(error)
         }
       }
 

--- a/src/commands/open/admin.js
+++ b/src/commands/open/admin.js
@@ -26,12 +26,12 @@ Run \`netlify link\` to connect to this folder to a site`)
       siteData = await api.getSite({ siteId })
       this.log(`Opening "${siteData.name}" site admin UI:`)
       this.log(`> ${siteData.admin_url}`)
-    } catch (e) {
-      if (e.status === 401 /* unauthorized */) {
+    } catch (error) {
+      if (error.status === 401 /* unauthorized */) {
         this.warn(`Log in with a different account or re-link to a site you have permission for`)
         this.error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      if (e.status === 404 /* site not found */) {
+      if (error.status === 404 /* site not found */) {
         this.log()
         this.log('Please double check this ID and verify you are logged in with the correct account')
         this.log()
@@ -39,7 +39,7 @@ Run \`netlify link\` to connect to this folder to a site`)
         this.log()
         this.error(`Site "${siteId}" not found in account`)
       }
-      this.error(e)
+      this.error(error)
     }
 
     await openBrowser({ url: siteData.admin_url, log: this.log })

--- a/src/commands/open/site.js
+++ b/src/commands/open/site.js
@@ -28,12 +28,12 @@ Run \`netlify link\` to connect to this folder to a site`)
       url = siteData.ssl_url || siteData.url
       this.log(`Opening "${siteData.name}" site url:`)
       this.log(`> ${url}`)
-    } catch (e) {
-      if (e.status === 401 /* unauthorized */) {
+    } catch (error) {
+      if (error.status === 401 /* unauthorized */) {
         this.warn(`Log in with a different account or re-link to a site you have permission for`)
         this.error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      this.error(e)
+      this.error(error)
     }
 
     await openBrowser({ url, log: this.log })

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -140,14 +140,14 @@ class SitesCreateCommand extends Command {
         case repoData.host === 'github.com': {
           try {
             await configGithub(this, site, repo)
-          } catch (e) {
-            this.warn(`Github error: ${e.status}`)
-            if (e.status === 404) {
+          } catch (error) {
+            this.warn(`Github error: ${error.status}`)
+            if (error.status === 404) {
               this.error(
                 `Does the repository ${repo.repo_path} exist and do you have the correct permissions to set up deploy keys?`
               )
             } else {
-              throw e
+              throw error
             }
           }
           break

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -17,8 +17,8 @@ class SitesDeleteCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (err) {
-      if (err.status === 404) {
+    } catch (error) {
+      if (error.status === 404) {
         this.error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
       }
     }

--- a/src/commands/status/hooks.js
+++ b/src/commands/status/hooks.js
@@ -23,15 +23,15 @@ class StatusHooksCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (e) {
-      if (e.status === 401 /* unauthorized */) {
+    } catch (error) {
+      if (error.status === 401 /* unauthorized */) {
         this.warn(`Log in with a different account or re-link to a site you have permission for`)
         this.error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      if (e.status === 404 /* missing */) {
+      if (error.status === 404 /* missing */) {
         this.error(`The site this folder is linked to can't be found`)
       }
-      this.error(e)
+      this.error(error)
     }
 
     const ntlHooks = await api.listHooksBySiteId({ siteId: siteData.id })

--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -63,15 +63,15 @@ class StatusCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (e) {
-      if (e.status === 401 /* unauthorized */) {
+    } catch (error) {
+      if (error.status === 401 /* unauthorized */) {
         this.warn(`Log in with a different account or re-link to a site you have permission for`)
         this.error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      if (e.status === 404 /* missing */) {
+      if (error.status === 404 /* missing */) {
         this.error(`The site this folder is linked to can't be found`)
       }
-      this.error(e)
+      this.error(error)
     }
 
     // Json only logs out if --json flag is passed

--- a/src/commands/unlink.js
+++ b/src/commands/unlink.js
@@ -21,7 +21,7 @@ class UnlinkCommand extends Command {
     let siteData = {}
     try {
       siteData = await this.netlify.api.getSite({ siteId })
-    } catch (e) {
+    } catch (error) {
       // ignore errors if we can't get the site
     }
 

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -68,8 +68,8 @@ class SitesWatchCommand extends Command {
         })
       )
       console.timeEnd('Deploy time')
-    } catch (err) {
-      throw new CLIError(err)
+    } catch (error) {
+      throw new CLIError(error)
     }
 
     this.exit()

--- a/src/functions-templates/js/auth-fetch/auth-fetch.js
+++ b/src/functions-templates/js/auth-fetch/auth-fetch.js
@@ -23,11 +23,11 @@ exports.handler = async function(event, context) {
       statusCode: 200,
       body: JSON.stringify({ identity, user, msg: data.value }),
     }
-  } catch (err) {
-    console.log(err) // output to netlify function log
+  } catch (error) {
+    console.log(error) // output to netlify function log
     return {
       statusCode: 500,
-      body: JSON.stringify({ msg: err.message }), // Could be a custom message or object i.e. JSON.stringify(err)
+      body: JSON.stringify({ msg: error.message }), // Could be a custom message or object i.e. JSON.stringify(err)
     }
   }
 }

--- a/src/functions-templates/js/fauna-crud/create-schema.js
+++ b/src/functions-templates/js/fauna-crud/create-schema.js
@@ -28,11 +28,11 @@ function createFaunaDB() {
       )
     })
 
-    .catch(e => {
-      if (e.requestResult.statusCode === 400 && e.message === 'instance not unique') {
+    .catch(error => {
+      if (error.requestResult.statusCode === 400 && error.message === 'instance not unique') {
         console.log('DB already exists')
       }
-      throw e
+      throw error
     })
 }
 

--- a/src/functions-templates/js/fauna-graphql/sync-schema.js
+++ b/src/functions-templates/js/fauna-graphql/sync-schema.js
@@ -28,7 +28,7 @@ function createFaunaGraphQL() {
       console.log('Netlify Functions:Create - `fauna-graphql/sync-schema.js` success!')
       console.log(body)
     })
-    .catch(err => console.error('something wrong happened: ', { err }))
+    .catch(error => console.error('something wrong happened:', { err: error }))
 }
 
 createFaunaGraphQL()

--- a/src/functions-templates/js/hasura-event-triggered/hasura-event-triggered.js
+++ b/src/functions-templates/js/hasura-event-triggered/hasura-event-triggered.js
@@ -19,7 +19,7 @@ exports.handler = async (event, context) => {
   let request
   try {
     request = JSON.parse(event.body)
-  } catch (e) {
+  } catch (error) {
     return { statusCode: 400, body: 'c annot parse hasura event' }
   }
 
@@ -31,7 +31,7 @@ exports.handler = async (event, context) => {
   try {
     await axios.post(hgeEndpoint + '/v1alpha1/graphql', { query, variables })
     return { statusCode: 200, body: 'success' }
-  } catch (err) {
-    return { statusCode: 500, body: err.toString() }
+  } catch (error) {
+    return { statusCode: 500, body: error.toString() }
   }
 }

--- a/src/functions-templates/js/hello-world/hello-world.js
+++ b/src/functions-templates/js/hello-world/hello-world.js
@@ -9,7 +9,7 @@ exports.handler = async (event, context) => {
       // headers: { "headerName": "headerValue", ... },
       // isBase64Encoded: true,
     }
-  } catch (err) {
-    return { statusCode: 500, body: err.toString() }
+  } catch (error) {
+    return { statusCode: 500, body: error.toString() }
   }
 }

--- a/src/functions-templates/js/node-fetch/node-fetch.js
+++ b/src/functions-templates/js/node-fetch/node-fetch.js
@@ -14,11 +14,11 @@ exports.handler = async function(event, context) {
       statusCode: 200,
       body: JSON.stringify({ msg: data.joke }),
     }
-  } catch (err) {
-    console.log(err) // output to netlify function log
+  } catch (error) {
+    console.log(error) // output to netlify function log
     return {
       statusCode: 500,
-      body: JSON.stringify({ msg: err.message }), // Could be a custom message or object i.e. JSON.stringify(err)
+      body: JSON.stringify({ msg: error.message }), // Could be a custom message or object i.e. JSON.stringify(err)
     }
   }
 }

--- a/src/functions-templates/js/send-email/send-email.js
+++ b/src/functions-templates/js/send-email/send-email.js
@@ -14,28 +14,28 @@ exports.handler = (event, context, callback) => {
 
   try {
     validateLength('body.name', body.name, 3, 50)
-  } catch (e) {
+  } catch (error) {
     return callback(null, {
       statusCode: 403,
-      body: e.message,
+      body: error.message,
     })
   }
 
   try {
     validateEmail('body.email', body.email)
-  } catch (e) {
+  } catch (error) {
     return callback(null, {
       statusCode: 403,
-      body: e.message,
+      body: error.message,
     })
   }
 
   try {
     validateLength('body.details', body.details, 10, 1000)
-  } catch (e) {
+  } catch (error) {
     return callback(null, {
       statusCode: 403,
-      body: e.message,
+      body: error.message,
     })
   }
 

--- a/src/functions-templates/js/slack-rate-limit/slack-rate-limit.js
+++ b/src/functions-templates/js/slack-rate-limit/slack-rate-limit.js
@@ -113,14 +113,14 @@ module.exports = function handler(event, context, callback) {
         .then(() => {
           callback(null, { statusCode: 204 })
         })
-        .catch(err => {
+        .catch(error => {
           callback(null, {
             statusCode: 500,
-            body: 'Internal Server Error: ' + err,
+            body: 'Internal Server Error: ' + error,
           })
         })
-    } catch (e) {
-      callback(null, { statusCode: 500, body: 'Internal Server Error: ' + e })
+    } catch (error) {
+      callback(null, { statusCode: 500, body: 'Internal Server Error: ' + error })
     }
   })
 }

--- a/src/functions-templates/js/stripe-subscription/stripe-subscription.js
+++ b/src/functions-templates/js/stripe-subscription/stripe-subscription.js
@@ -18,19 +18,19 @@ exports.handler = async function(event, context) {
   let incoming
   try {
     incoming = JSON.parse(event.body)
-  } catch (err) {
-    console.error(`error with parsing function parameters: `, err)
+  } catch (error) {
+    console.error(`error with parsing function parameters:`, error)
     return {
       statusCode: 400,
-      body: JSON.stringify(err),
+      body: JSON.stringify(error),
     }
   }
   try {
     const { stripeToken, email, productPlan } = incoming
     const data = await createCustomerAndSubscribeToPlan(stripeToken, email, productPlan)
     return respond(data)
-  } catch (err) {
-    return respond(err)
+  } catch (error) {
+    return respond(error)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ try {
     pkg,
     updateCheckInterval: 1000 * 60 * 60 * 12, // check every 1/2 day
   }).notify()
-} catch (e) {
+} catch (error) {
   console.log('Error checking for updates:')
-  console.log(e)
+  console.log(error)
 }
 
 module.exports = require('@oclif/command')

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -77,8 +77,8 @@ const uploadEdgeHandlers = async ({ api, deployId, bundleBuffer, manifest }) => 
 const cancelDeploy = async ({ api, deployId, warn }) => {
   try {
     await api.cancelSiteDeploy({ deploy_id: deployId })
-  } catch (e) {
-    warn(`Failed canceling deploy with id ${deployId}: ${e.message}`)
+  } catch (error) {
+    warn(`Failed canceling deploy with id ${deployId}: ${error.message}`)
   }
 }
 

--- a/src/lib/exec-fetcher.js
+++ b/src/lib/exec-fetcher.js
@@ -64,12 +64,12 @@ const shouldFetchLatestVersion = async ({ binPath, packageName, execName, execAr
       currentVersion: match[1],
     })
     return outdated
-  } catch (e) {
+  } catch (error) {
     if (exists) {
       log(NETLIFYDEVWARN, `failed checking for new version of '${packageName}'. Using existing version`)
       return false
     } else {
-      throw e
+      throw error
     }
   }
 }

--- a/src/lib/http-agent.js
+++ b/src/lib/http-agent.js
@@ -27,7 +27,7 @@ const getAgent = async ({ httpProxy, certificateFile, log, exit }) => {
   let proxyUrl
   try {
     proxyUrl = new URL(httpProxy)
-  } catch (e) {
+  } catch (error) {
     log(NETLIFYDEVERR, `${httpProxy} is not a valid URL`)
     exit(1)
   }

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -26,8 +26,8 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
     const detectors = detectorsFiles.map(det => {
       try {
         return loadDetector(det)
-      } catch (err) {
-        console.error(err)
+      } catch (error) {
+        console.error(error)
         return null
       }
     })
@@ -199,11 +199,11 @@ async function getStaticServerSettings(settings, flags, projectDir, log) {
 function loadDetector(detectorName) {
   try {
     return require(path.join(__dirname, '..', 'detectors', detectorName))
-  } catch (err) {
+  } catch (error) {
     throw new Error(
       `Failed to load detector: ${chalk.yellow(
         detectorName
-      )}, this is likely a bug in the detector, please file an issue in netlify-cli\n ${err}`
+      )}, this is likely a bug in the detector, please file an issue in netlify-cli\n ${error}`
     )
   }
 }

--- a/src/utils/edge-handlers.js
+++ b/src/utils/edge-handlers.js
@@ -14,7 +14,7 @@ const validateEdgeHandlerFolder = async ({ site, error }) => {
       error(`Edge Handlers folder ${EDGE_HANDLERS_FOLDER} must be a path to a directory`)
     }
     return resolvedFolder
-  } catch (e) {
+  } catch (error_) {
     // ignore errors at the moment
     // TODO: report error if 'edge_handlers' config exists after
     // https://github.com/netlify/build/pull/1829 is published
@@ -31,8 +31,8 @@ const readBundleAndManifest = async ({ edgeHandlersResolvedFolder, error }) => {
   let manifestJson
   try {
     manifestJson = JSON.parse(manifest)
-  } catch (e) {
-    error(`Edge Handlers manifest file is not a valid JSON file: ${e.message}`)
+  } catch (error_) {
+    error(`Edge Handlers manifest file is not a valid JSON file: ${error_.message}`)
   }
 
   if (!manifestJson.sha) {
@@ -71,8 +71,8 @@ const deployEdgeHandlers = async ({ site, deployId, api, silent, error, warn }) 
         ? `Finished deploying Edge Handlers from directory: ${edgeHandlersResolvedFolder}`
         : `Skipped deploying Edge Handlers since the bundle already exists`
       stopSpinner({ spinner, text, error: false })
-    } catch (e) {
-      const text = `Failed deploying Edge Handlers: ${e.message}`
+    } catch (error_) {
+      const text = `Failed deploying Edge Handlers: ${error_.message}`
       stopSpinner({ spinner, text, error: true })
       await cancelDeploy({ api, deployId, warn })
       // no need to report the error again

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -87,7 +87,7 @@ async function ensureNetlifyIgnore(dir) {
   try {
     gitIgnoreContents = await readFileAsync(gitIgnorePath, 'utf8')
     ignorePatterns = parseIgnore.parse(gitIgnoreContents)
-  } catch (e) {
+  } catch (error) {
     // ignore
   }
   /* Not ignoring .netlify folder. Add to .gitignore */

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -136,9 +136,9 @@ async function configGithub(ctx, site, repo) {
         events: ['push', 'pull_request', 'delete'],
         active: true,
       })
-    } catch (e) {
+    } catch (error) {
       // Ignore exists error if the list doesn't return all installed hooks
-      if (!e.message.includes('Hook already exists on this repository')) ctx.error(e)
+      if (!error.message.includes('Hook already exists on this repository')) ctx.error(error)
     }
   }
 

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -125,11 +125,11 @@ Run ${chalk.cyanBright('git remote -v')} to see a list of your git remotes.`)
           name: searchTerm,
           filter: 'all',
         })
-      } catch (e) {
-        if (e.status === 404) {
+      } catch (error) {
+        if (error.status === 404) {
           context.error(`'${searchTerm}' not found`)
         } else {
-          context.error(e)
+          context.error(error)
         }
       }
 
@@ -168,8 +168,8 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
       let sites
       try {
         sites = await api.listSites({ filter: 'all' })
-      } catch (e) {
-        context.error(e)
+      } catch (error) {
+        context.error(error)
       }
 
       if (isEmpty(sites)) {
@@ -203,11 +203,11 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
 
       try {
         site = await api.getSite({ siteId })
-      } catch (e) {
-        if (e.status === 404) {
+      } catch (error) {
+        if (error.status === 404) {
           context.error(new Error(`Site ID '${siteId}' not found`))
         } else {
-          context.error(e)
+          context.error(error)
         }
       }
       break

--- a/src/utils/parse-raw-flags.js
+++ b/src/utils/parse-raw-flags.js
@@ -40,10 +40,10 @@ function aggressiveJSONParse(value) {
   let parsed
   try {
     parsed = JSON.parse(value)
-  } catch (e) {
+  } catch (error) {
     try {
       parsed = JSON.parse(`"${value}"`)
-    } catch (e) {
+    } catch (error) {
       parsed = value
     }
   }

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -37,7 +37,7 @@ async function getStatic(pathname, publicFolder) {
     try {
       const pathStats = await fs.stat(p)
       if (pathStats.isFile()) return '/' + path.relative(publicFolder, p)
-    } catch (err) {
+    } catch (error) {
       // Ignore
     }
   }
@@ -114,8 +114,8 @@ async function serveRedirect(req, res, proxy, match, options) {
       let jwtValue = {}
       try {
         jwtValue = jwtDecode(token) || {}
-      } catch (err) {
-        console.warn(NETLIFYDEVWARN, 'Error while decoding JWT provided in request', err.message)
+      } catch (error) {
+        console.warn(NETLIFYDEVWARN, 'Error while decoding JWT provided in request', error.message)
         res.writeHead(400)
         res.end('Invalid JWT provided. Please see logs for more info.')
         return

--- a/src/utils/read-repo-url.js
+++ b/src/utils/read-repo-url.js
@@ -29,7 +29,7 @@ function getRepoURLContents(repoHost, ownerAndRepo, contentsPath) {
     const APIURL = safeJoin('https://api.github.com/repos', ownerAndRepo, 'contents', contentsPath)
     return fetch(APIURL)
       .then(x => x.json())
-      .catch(error => console.error('Error occurred while fetching ', APIURL, error))
+      .catch(error => console.error(`Error occurred while fetching ${APIURL}`, error))
   }
   throw new Error('unsupported host ', repoHost)
 }

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -230,8 +230,8 @@ function createFormSubmissionHandler(siteInfo) {
             ])
           })
         })
-      } catch (err) {
-        return console.error(err)
+      } catch (error) {
+        return console.error(error)
       }
     } else {
       return console.error('Invalid Content-Type for Netlify Dev forms request')

--- a/src/utils/state-config.js
+++ b/src/utils/state-config.js
@@ -27,24 +27,24 @@ class StateConfig {
   get all() {
     try {
       return JSON.parse(fs.readFileSync(this.path, 'utf8'))
-    } catch (err) {
+    } catch (error) {
       // Don't create if it doesn't exist
-      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+      if (error.code === 'ENOENT' || error.code === 'ENOTDIR') {
         return {}
       }
 
       // Improve the message of permission errors
-      if (err.code === 'EACCES') {
-        err.message = `${err.message}\n${permissionError}\n`
+      if (error.code === 'EACCES') {
+        error.message = `${error.message}\n${permissionError}\n`
       }
 
       // Empty the file if it encounters invalid JSON
-      if (err.name === 'SyntaxError') {
+      if (error.name === 'SyntaxError') {
         writeFileAtomic.sync(this.path, '')
         return {}
       }
 
-      throw err
+      throw error
     }
   }
 
@@ -53,13 +53,13 @@ class StateConfig {
       // Make sure the folder exists as it could have been deleted in the meantime
       makeDir.sync(path.dirname(this.path))
       writeFileAtomic.sync(this.path, JSON.stringify(val, null, '\t'))
-    } catch (err) {
+    } catch (error) {
       // Improve the message of permission errors
-      if (err.code === 'EACCES') {
-        err.message = `${err.message}\n${permissionError}\n`
+      if (error.code === 'EACCES') {
+        error.message = `${error.message}\n${permissionError}\n`
       }
 
-      throw err
+      throw error
     }
   }
 

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -75,8 +75,8 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
       throw new Error(`Timed out waiting for forward proxy to be ready on port '${port}'`)
     }
     return `http://localhost:${port}`
-  } catch (e) {
-    log(`${NETLIFYDEVERR}`, e)
+  } catch (error) {
+    log(`${NETLIFYDEVERR}`, error)
   }
 }
 

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -14,7 +14,7 @@ const validateContent = async ({ siteUrl, path, content, t }) => {
     if (response.ok) {
       actualContent = await response.text()
     }
-  } catch (e) {
+  } catch (error) {
     // no op
   }
   t.is(actualContent, content)
@@ -330,8 +330,8 @@ if (process.env.IS_FORK !== 'true') {
           cwd: builder.directory,
           env: { NETLIFY_SITE_ID: t.context.siteId },
         })
-      } catch (e) {
-        t.is(e.stderr.includes('Error: No files or functions to deploy'), true)
+      } catch (error) {
+        t.is(error.stderr.includes('Error: No files or functions to deploy'), true)
       }
     })
   })

--- a/tests/utils/dev-server.js
+++ b/tests/utils/dev-server.js
@@ -38,7 +38,7 @@ const startServer = async ({ cwd, env = {}, args = [] }) => {
             pids.forEach(pid => () => {
               try {
                 process.kill(pid)
-              } catch (e) {
+              } catch (error) {
                 // no-op
               }
             })
@@ -58,11 +58,11 @@ const startDevServer = async options => {
     try {
       const server = await startServer(options)
       return server
-    } catch (e) {
+    } catch (error) {
       if (attempt === maxAttempts) {
-        throw e
+        throw error
       }
-      console.warn('Retrying startDevServer', e)
+      console.warn('Retrying startDevServer', error)
     }
   }
 }

--- a/tests/utils/site-builder.js
+++ b/tests/utils/site-builder.js
@@ -110,8 +110,8 @@ const createSiteBuilder = ({ siteName }) => {
       return builder
     },
     cleanupAsync: async () => {
-      await fs.remove(directory).catch(e => {
-        console.warn(e)
+      await fs.remove(directory).catch(error => {
+        console.warn(error)
       })
       return builder
     },


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`catch-error-name`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/catch-error-name.md).