### PR TITLE
Use `Number.parseInt()` instead of `parseInt()`

### DIFF
--- a/src/lib/http-agent.js
+++ b/src/lib/http-agent.js
@@ -41,7 +41,7 @@ const getAgent = async ({ httpProxy, certificateFile, log, exit }) => {
   let open
   try {
     open = await waitPort({
-      port: parseInt(proxyUrl.port) || (scheme === 'http' ? 80 : 443),
+      port: Number.parseInt(proxyUrl.port) || (scheme === 'http' ? 80 : 443),
       host: proxyUrl.hostname,
       timeout: 50,
       output: 'silent',

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -81,7 +81,7 @@ if (process.env.IS_FORK !== 'true') {
   })
 
   // the edge handlers plugin only works on node >= 10
-  const version = parseInt(process.version.substring(1).split('.')[0])
+  const version = Number.parseInt(process.version.substring(1).split('.')[0])
   if (version >= 10) {
     test.serial('should deploy edge handlers when directory exists', async t => {
       await withSiteBuilder('site-with-public-folder', async builder => {


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`prefer-number-properties`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-number-properties.md).