### PR TITLE
Lint RegExps

### DIFF
--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -86,7 +86,7 @@ async function getNameFromArgs(args, flags, defaultName) {
         message: 'name your function: ',
         default: defaultName,
         type: 'input',
-        validate: val => Boolean(val) && /^[\w\-.]+$/i.test(val),
+        validate: val => Boolean(val) && /^[\w.-]+$/i.test(val),
         // make sure it is not undefined and is a valid filename.
         // this has some nuance i have ignored, eg crossenv and i18n concerns
       },

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -70,7 +70,7 @@ class SitesCreateCommand extends Command {
             name: 'name',
             message: 'Site name (optional):',
             filter: val => (val === '' ? undefined : val),
-            validate: input => /^[a-zA-Z0-9-]+$/.test(input) || 'Only alphanumeric characters and hyphens are allowed',
+            validate: input => /^[a-zA-Z\d-]+$/.test(input) || 'Only alphanumeric characters and hyphens are allowed',
           },
         ])
         name = results.name

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -24,7 +24,7 @@ function isFunction(functionsPort, url) {
 }
 
 function addonUrl(addonUrls, req) {
-  const m = req.url.match(/^\/.netlify\/([^\/]+)(\/.*)/) // eslint-disable-line no-useless-escape
+  const m = req.url.match(/^\/.netlify\/([^/]+)(\/.*)/)
   const addonUrl = m && addonUrls[m[1]]
   return addonUrl ? `${addonUrl}${m[2]}` : null
 }

--- a/tests/utils/create-live-test-site.js
+++ b/tests/utils/create-live-test-site.js
@@ -28,7 +28,7 @@ async function createLiveTestSite(siteName) {
     throw new Error(`Failed creating site: ${cliResponse}`)
   }
 
-  const matches = /Site ID:\s+([a-zA-Z0-9-]+)/m.exec(stripAnsi(cliResponse))
+  const matches = /Site ID:\s+([a-zA-Z\d-]+)/m.exec(stripAnsi(cliResponse))
   if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
     const siteId = matches[1]
     console.log(`Done creating site ${siteName} for account '${accountSlug}'. Site Id: ${siteId}`)


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`better-regex`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/better-regex.md).