### PR TITLE
Use template strings

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -102,8 +102,9 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
 
   if (!settings.noCmd && devConfig.command) {
     console.log(
-      `${NETLIFYDEVLOG} Overriding ${chalk.yellow('command')} with setting derived from netlify.toml [dev] block: `,
-      devConfig.command
+      `${NETLIFYDEVLOG} Overriding ${chalk.yellow('command')} with setting derived from netlify.toml [dev] block: ${
+        devConfig.command
+      }`
     )
     const [devConfigCommand, ...devConfigArgs] = devConfig.command.split(/\s+/)
     settings.command = devConfigCommand

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -42,7 +42,7 @@ async function addEnvVariables(api, site) {
       addonUrls[addon.slug] = `${addon.config.site_url}/.netlify/${addon.slug}`
       for (const key in addon.env) {
         const msg = () =>
-          console.log(`${NETLIFYDEVLOG} Injected ${chalk.yellow.bold('addon')} env var: `, chalk.yellow(key))
+          console.log(`${NETLIFYDEVLOG} Injected ${chalk.yellow.bold('addon')} env var: ${chalk.yellow(key)}`)
         process.env[key] = assignLoudly(process.env[key], addon.env[key], msg)
       }
     })
@@ -108,7 +108,7 @@ module.exports = {
 function assignLoudly(
   optionalValue,
   defaultValue,
-  tellUser = dV => console.log(`No value specified, using fallback of `, dV)
+  tellUser = dV => console.log(`No value specified, using fallback of ${dV}`)
 ) {
   if (defaultValue === undefined) throw new Error('must have a defaultValue')
   if (defaultValue !== optionalValue && optionalValue === undefined) {

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -174,7 +174,7 @@ async function serveRedirect(req, res, proxy, match, options) {
     }
 
     if (isExternal(match)) {
-      console.log(`${NETLIFYDEVLOG} Proxying to `, dest.toString())
+      console.log(`${NETLIFYDEVLOG} Proxying to ${dest}`)
       const handler = createProxyMiddleware({
         target: `${dest.protocol}//${dest.host}`,
         changeOrigin: true,

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -21,7 +21,7 @@ function handleErr(err, response) {
   response.statusCode = 500
   response.write(`${NETLIFYDEVERR} Function invocation failed: ` + err.toString())
   response.end()
-  console.log(`${NETLIFYDEVERR} Error during invocation: `, err)
+  console.log(`${NETLIFYDEVERR} Error during invocation:`, err)
 }
 
 function capitalize(t) {


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from `eslint-plugin-unicorn` related to template strings.