### PR TITLE
Move a function to the top-level scope

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -91,16 +91,17 @@ function buildClientContext(headers) {
   }
 }
 
+const clearCache = action => path => {
+  console.log(`${NETLIFYDEVLOG} ${path} ${action}, reloading...`)
+  Object.keys(require.cache).forEach(k => {
+    delete require.cache[k]
+  })
+  console.log(`${NETLIFYDEVLOG} ${path} ${action}, successfully reloaded!`)
+}
+
 function createHandler(dir) {
   const functions = getFunctions(dir)
 
-  const clearCache = action => path => {
-    console.log(`${NETLIFYDEVLOG} ${path} ${action}, reloading...`)
-    Object.keys(require.cache).forEach(k => {
-      delete require.cache[k]
-    })
-    console.log(`${NETLIFYDEVLOG} ${path} ${action}, successfully reloaded!`)
-  }
   const watcher = chokidar.watch(dir, { ignored: /node_modules/ })
   watcher.on('change', clearCache('modified')).on('unlink', clearCache('deleted'))
 


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`consistent-function-scoping`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/consistent-function-scoping.md).

This function can be safely moved to the top-level scope.