### PR TITLE
Prefer `String.slice()`

### DIFF
--- a/src/lib/http-agent.js
+++ b/src/lib/http-agent.js
@@ -32,7 +32,7 @@ const getAgent = async ({ httpProxy, certificateFile, log, exit }) => {
     exit(1)
   }
 
-  const scheme = proxyUrl.protocol.substr(0, proxyUrl.protocol.length - 1)
+  const scheme = proxyUrl.protocol.slice(0, -1)
   if (!['http', 'https'].includes(scheme)) {
     log(NETLIFYDEVERR, `${httpProxy} must have a scheme of http or https`)
     exit(1)

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -60,7 +60,7 @@ class BaseCommand extends Command {
     const apiOpts = { agent }
     if (NETLIFY_API_URL) {
       const apiUrl = new URL(NETLIFY_API_URL)
-      apiOpts.scheme = apiUrl.protocol.substring(0, apiUrl.protocol.length - 1)
+      apiOpts.scheme = apiUrl.protocol.slice(0, -1)
       apiOpts.host = apiUrl.host
       apiOpts.pathPrefix = NETLIFY_API_URL === `${apiUrl.protocol}//${apiUrl.host}` ? '/api/v1' : apiUrl.pathname
     }

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -73,8 +73,8 @@ function parseHeadersFile(filePath) {
       const sepIndex = line.indexOf(':')
       if (sepIndex < 1) throw new Error(`invalid header at line: ${i}\n${lines[i]}\n`)
 
-      const key = line.substr(0, sepIndex).trim()
-      const value = line.substr(sepIndex + 1).trim()
+      const key = line.slice(0, sepIndex).trim()
+      const value = line.slice(sepIndex + 1).trim()
 
       if (Object.prototype.hasOwnProperty.call(rules, path)) {
         if (Object.prototype.hasOwnProperty.call(rules[path], key)) {

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -30,7 +30,7 @@ function addonUrl(addonUrls, req) {
 }
 
 async function getStatic(pathname, publicFolder) {
-  const alternatives = [pathname, ...alternativePathsFor(pathname)].map(p => path.resolve(publicFolder, p.substr(1)))
+  const alternatives = [pathname, ...alternativePathsFor(pathname)].map(p => path.resolve(publicFolder, p.slice(1)))
 
   for (const i in alternatives) {
     const p = alternatives[i]

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -81,7 +81,7 @@ if (process.env.IS_FORK !== 'true') {
   })
 
   // the edge handlers plugin only works on node >= 10
-  const version = Number.parseInt(process.version.substring(1).split('.')[0])
+  const version = Number.parseInt(process.version.slice(1).split('.')[0])
   if (version >= 10) {
     test.serial('should deploy edge handlers when directory exists', async t => {
       await withSiteBuilder('site-with-public-folder', async builder => {

--- a/tests/utils/create-live-test-site.js
+++ b/tests/utils/create-live-test-site.js
@@ -5,7 +5,7 @@ function generateSiteName(prefix) {
   const randomString = Math.random()
     .toString(36)
     .replace(/[^a-z]+/g, '')
-    .substr(0, 8)
+    .slice(0, 8)
   return `${prefix}${randomString}`
 }
 


### PR DESCRIPTION
Related to #1343

This fixes the linting errors from the `eslint-plugin-unicorn` rule [`prefer-string-slice`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-string-slice.md).