### PR TITLE
chore(deps): ignore major updates for `del` and `dot-prop`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,8 @@
         'concordance',
         'cosmiconfig',
         'eslint',
+        'del',
+        'dot-prop',
         'execa',
         'find-up',
         'globby',


### PR DESCRIPTION
Ignores major updates to `del` and `dot-prop` due to Node 8 compatibility. 