### PR TITLE
Improve npm scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,19 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Git checkout
+        uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Linting
+        run: npm run format:ci
+        if: "${{ matrix.node-version == '14.x' }}"
+      - name: Tests
+        run: npm run test:ci
         env:
           # GitHub secrets are not available when running on PR from forks
           # We set a flag so we can skip tests that access Netlify API

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ oclif.manifest.json
 
 # Local Netlify folder
 .netlify
+
+.eslintcache

--- a/package-lock.json
+++ b/package-lock.json
@@ -6609,6 +6609,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -40,15 +40,22 @@
   "scripts": {
     "build:site": "cd site && npm ci && npm run build",
     "start": "node ./bin/run",
-    "test": "run-s test:*",
-    "ava": "ava --verbose",
-    "format": "prettier --write \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\"",
-    "test:lint": "eslint --fix \"{src,scripts,site,tests,.github}/**/*.{js,md,html}\"",
-    "test:format": "prettier --check \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\"",
-    "test:cli-version": "npm run start -- --version",
-    "test:cli-help": "npm run start -- --help",
-    "test:install-deps": "npm ci --prefix tests/site-cra",
-    "test:ava": "nyc --reporter=lcov ava --verbose && nyc report",
+    "test": "run-s format test:dev",
+    "format": "run-s format:check-fix:*",
+    "format:ci": "run-s format:check:*",
+    "format:check-fix:lint": "./scripts/run-on-error.js format:check:lint format:fix:lint",
+    "format:check:lint": "cross-env-shell eslint $npm_package_scriptsArgs_eslint",
+    "format:fix:lint": "cross-env-shell eslint --fix $npm_package_scriptsArgs_eslint",
+    "format:check-fix:prettier": "./scripts/run-on-error.js format:check:prettier format:fix:prettier",
+    "format:check:prettier": "cross-env-shell prettier --check $npm_package_scriptsArgs_prettier",
+    "format:fix:prettier": "cross-env-shell prettier --write $npm_package_scriptsArgs_prettier",
+    "test:dev": "run-s test:init:* test:dev:*",
+    "test:ci": "run-s test:init:* test:ci:*",
+    "test:init:cli-version": "npm run start -- --version",
+    "test:init:cli-help": "npm run start -- --help",
+    "test:init:install-deps": "npm ci --prefix tests/site-cra",
+    "test:dev:ava": "ava --verbose",
+    "test:ci:ava": "nyc -r lcovonly -r text -r json ava --verbose",
     "docs": "node ./site/scripts/docs.js",
     "watch": "nyc --reporter=lcov ava --watch",
     "prepack": "oclif-dev manifest && npm prune --prod",
@@ -59,6 +66,10 @@
     "release:version": "git push && git push --tags && gh-release",
     "release:publish": "npm publish",
     "postinstall": "node ./scripts/postinstall.js"
+  },
+  "scriptsArgs": {
+    "eslint": "--cache --format=codeframe --max-warnings=0 \"{src,scripts,site,tests,.github}/**/*.{js,md,html}\"",
+    "prettier": "--loglevel=warn \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\""
   },
   "dependencies": {
     "@netlify/build": "^5.0.0",
@@ -158,6 +169,7 @@
     "auto-changelog": "^2.0.0",
     "ava": "^2.4.0",
     "babel-eslint": "^10.1.0",
+    "cross-env": "^7.0.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^14.1.1",
@@ -222,7 +234,8 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-push": "npm run format"
     }
   },
   "standard-version": {

--- a/scripts/run-on-error.js
+++ b/scripts/run-on-error.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+const execa = require('execa')
+const { argv } = require('process')
+
+const [, , npmScript, npmScriptOnError] = argv
+
+// Run a npm script. If that script fails, another npm script is run.
+// We use this for example with ESLint and Prettier to be able to fail if
+// anything should be autofixed, while still autofixing it. Those tools do not
+// provide good CLI flags for this.
+const runOnError = async function() {
+  const { failed, exitCode = DEFAULT_ERROR_EXIT_CODE } = await runNpmScript(npmScript)
+  if (!failed) {
+    return
+  }
+
+  await runNpmScript(npmScriptOnError)
+  process.exitCode = exitCode
+}
+
+const runNpmScript = function(npmScript) {
+  return execa.command(`npm run ${npmScript}`, { stdio: 'inherit', reject: false })
+}
+
+const DEFAULT_ERROR_EXIT_CODE = 1
+
+runOnError()


### PR DESCRIPTION
This PR aims at improving the Netlify CLI npm scripts:
  - Only run ESLint and Prettier on Node 14 in CI, as described in https://github.com/netlify/build/issues/1962 and as implemented in Netlify Build in https://github.com/netlify/build/pull/1969
  - Minor updates (adding some titles) in the GitHub actions `workflow.yml` to make it more similar to [`@netlify/build`'s `workflow.yml`](https://github.com/netlify/build/blob/master/.github/workflows/workflow.yml)
  - Run formatting on `git push`, as described in https://github.com/netlify/build/issues/1950
  - Sort and rename npm scripts
  - Distinguish between `npm test` (local machine) vs `npm test:ci`.
  - Small optimization of the `nyc` arguments to avoid running it twice
  - Add caching to ESLint, and few smaller CLI flags (`--format=codeframe` and `--max-warnings=0`)
  - Make Prettier less verbose (`--loglevel warn`)

This PR includes many unrelated changes that could have been broken down, but because they all modified the npm scripts, it was simpler to group in a single PR.

Please share any thoughts, and we can update it both in this PR and in Netlify Build :)