### PR TITLE
test(command-dev-trace): re-enable tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,4 @@ jobs:
           # We set a flag so we can skip tests that access Netlify API
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+          _NETLIFY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9833,9 +9833,9 @@
       }
     },
     "gh-release-fetch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gh-release-fetch/-/gh-release-fetch-1.0.4.tgz",
-      "integrity": "sha512-uL2T1vCOr5HAuY1Cbtj+h1AOTWZ0Qvubi1s7KCRqKOiytVlTDHLYoPJ9TIJLEmNYbmuCtZVOtYsojf3REAAgbQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gh-release-fetch/-/gh-release-fetch-1.1.0.tgz",
+      "integrity": "sha512-c8Vb2g6yzTItFGooCH2yppiwu8BwoWheMAWHl/qor95XcuDjFgqMYw8QUtvR/da+ZII5EYDPonZTypvI2anm4Q==",
       "requires": {
         "@types/download": "^6.2.4",
         "@types/mkdirp": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "find-up": "^4.1.0",
     "fuzzy": "^0.1.3",
     "get-port": "^5.1.0",
-    "gh-release-fetch": "^1.0.3",
+    "gh-release-fetch": "^1.1.0",
     "git-repo-info": "^2.1.0",
     "gitconfiglocal": "^2.1.0",
     "http-proxy": "^1.18.0",

--- a/src/lib/exec-fetcher.js
+++ b/src/lib/exec-fetcher.js
@@ -15,6 +15,16 @@ const getExecName = ({ execName }) => {
   return isWindows() ? `${execName}.exe` : execName
 }
 
+const getOptions = () => {
+  // this is used in out CI tests to avoid hitting GitHub API limit
+  // when calling gh-release-fetch
+  if (process.env._NETLIFY_GITHUB_TOKEN) {
+    return {
+      headers: { Authorization: `token ${process.env._NETLIFY_GITHUB_TOKEN}` },
+    }
+  }
+}
+
 const isExe = (mode, gid, uid) => {
   if (isWindows()) {
     return true
@@ -37,7 +47,8 @@ const execExist = async binPath => {
 }
 
 const isVersionOutdated = async ({ packageName, currentVersion }) => {
-  const outdated = await updateAvailable(getRepository({ packageName }), currentVersion)
+  const options = getOptions()
+  const outdated = await updateAvailable(getRepository({ packageName }), currentVersion, options)
   return outdated
 }
 
@@ -86,7 +97,8 @@ const fetchLatestVersion = async ({ packageName, execName, destination, extensio
     extract: true,
   }
 
-  await fetchLatest(release)
+  const options = getOptions()
+  await fetchLatest(release, options)
 }
 
 module.exports = { getExecName, shouldFetchLatestVersion, fetchLatestVersion }

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -88,4 +88,4 @@ const runProcess = async ({ log, args }) => {
   return { subprocess }
 }
 
-module.exports = { runProcess, startForwardProxy }
+module.exports = { runProcess, startForwardProxy, installTrafficMesh }

--- a/tests/command.dev.trace.test.js
+++ b/tests/command.dev.trace.test.js
@@ -1,8 +1,14 @@
 const test = require('ava')
 const { withSiteBuilder } = require('./utils/site-builder')
+const { installTrafficMesh } = require('../src/utils/traffic-mesh')
 const callCli = require('./utils/call-cli')
 
-test.serial.skip('should not match redirect for empty site', async t => {
+test.before(async () => {
+  // pre-install the traffic mesh agent so we can run the tests in parallel
+  await installTrafficMesh({ log: console.log })
+})
+
+test('should not match redirect for empty site', async t => {
   await withSiteBuilder('empty-site', async builder => {
     await builder.buildAsync()
 
@@ -14,7 +20,7 @@ test.serial.skip('should not match redirect for empty site', async t => {
   })
 })
 
-test.serial.skip('should match redirect when url matches', async t => {
+test('should match redirect when url matches', async t => {
   await withSiteBuilder('site-with-redirects', async builder => {
     builder.withRedirectsFile({
       redirects: [{ from: '/*', to: `/index.html`, status: 200 }],


### PR DESCRIPTION
This PR reintroduces `netlify dev:trace` command tests with some improvements:
1. Uses the latest version of `gh-release-fetch` that allows passing fetch options. We use it to pass an auth token that allows for much higher rate limits.
2. Pre-installs the traffic mesh agent so tests can run in parallel.