### PR TITLE
Add `prefer-object-spread` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'multiline-comment-style': [2, 'separate-lines'],
     'no-else-return': [2, { allowElseIf: false }],
     'no-var': 2,
+    'prefer-object-spread': 2,
 
     // This version of eslint-plugin-unicorn requires Node 10
     // TODO: remove after dropping Node 8 support

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -115,7 +115,7 @@ class FunctionsInvokeCommand extends Command {
       }
     }
     const payload = processPayloadFromFlag(flags.payload)
-    body = Object.assign({}, body, payload)
+    body = { ...body, ...payload }
 
     // fetch
     fetch(`http://localhost:${port}/.netlify/functions/${functionToTrigger}` + formatQstring(flags.querystring), {

--- a/src/functions-templates/js/sanity-groq/sanity-groq.js
+++ b/src/functions-templates/js/sanity-groq/sanity-groq.js
@@ -32,9 +32,7 @@ const client = sanityClient({
 exports.handler = async (event) => {
   const { query = '' } = event.queryStringParameters
   // The rest of the query params are handled as parameters to the query
-  const params = Object.assign({}, event.queryStringParameters, {
-    query: null,
-  })
+  const params = { ...event.queryStringParameters, query: null }
 
   return client
     .fetch(query, params)

--- a/src/utils/addons/compare.js
+++ b/src/utils/addons/compare.js
@@ -20,12 +20,13 @@ module.exports = function compare(oldValues, newValues) {
       return {
         isEqual: false,
         keys: acc.keys.concat(current),
-        diffs: Object.assign({}, acc.diffs, {
+        diffs: {
+          ...acc.diffs,
           [`${current}`]: {
             newValue: newValues[current],
             oldValue: oldValues[current],
           },
-        }),
+        },
       }
     }
     return acc

--- a/src/utils/addons/diffs/index.js
+++ b/src/utils/addons/diffs/index.js
@@ -2,7 +2,7 @@ const concordance = require('concordance')
 const { concordanceOptions, concordanceDiffOptions } = require('./options')
 
 function formatDescriptorDiff(actualDescriptor, expectedDescriptor, options) {
-  const diffOptions = Object.assign({}, options, concordanceDiffOptions)
+  const diffOptions = { ...options, ...concordanceDiffOptions }
   return concordance.diffDescriptors(actualDescriptor, expectedDescriptor, diffOptions)
 }
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -170,18 +170,12 @@ class BaseCommand extends Command {
     }
 
     // enrich with flags here
-    opts.flags = Object.assign({}, opts.flags, globalFlags)
+    opts.flags = { ...opts.flags, ...globalFlags }
 
-    return require('@oclif/parser').parse(
-      argv,
-      Object.assign(
-        {},
-        {
-          context: this,
-        },
-        opts
-      )
-    )
+    return require('@oclif/parser').parse(argv, {
+      context: this,
+      ...opts,
+    })
   }
 
   get chalk() {

--- a/src/utils/gh-auth.js
+++ b/src/utils/gh-auth.js
@@ -12,14 +12,12 @@ module.exports = getGitHubToken
 async function getGitHubToken({ opts, log }) {
   log('')
 
-  opts = Object.assign(
-    {
-      userAgent: 'Netlify-cli-octokit',
-      note: 'Netlify-cli-gh-auth',
-      scopes: [],
-    },
-    opts
-  )
+  opts = {
+    userAgent: 'Netlify-cli-octokit',
+    note: 'Netlify-cli-gh-auth',
+    scopes: [],
+    ...opts,
+  }
 
   async function promptForOTP() {
     const { otp } = await inquirer.prompt([

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -36,7 +36,7 @@ function matchPaths(rulePath, targetPath) {
 
 function objectForPath(rules, pathname) {
   return Object.entries(rules).reduce(
-    (prev, [rulePath, pathHeaders]) => Object.assign({}, prev, matchPaths(rulePath, pathname) && pathHeaders),
+    (prev, [rulePath, pathHeaders]) => ({ ...prev, ...(matchPaths(rulePath, pathname) && pathHeaders) }),
     {}
   )
 }

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -106,14 +106,11 @@ module.exports.createRewriter = async function createRewriter({ distDir, project
         }`
       )
       const cookieValues = cookie.parse(req.headers.cookie || '')
-      const headers = Object.assign(
-        {},
-        {
-          'x-language': cookieValues.nf_lang || getLanguage(req.headers),
-          'x-country': cookieValues.nf_country || getCountry(req),
-        },
-        req.headers
-      )
+      const headers = {
+        'x-language': cookieValues.nf_lang || getLanguage(req.headers),
+        'x-country': cookieValues.nf_country || getCountry(req),
+        ...req.headers,
+      }
 
       // Definition: https://github.com/netlify/libredirect/blob/e81bbeeff9f7c260a5fb74cad296ccc67a92325b/node/src/redirects.cpp#L28-L60
       const matchReq = {

--- a/src/utils/telemetry/index.js
+++ b/src/utils/telemetry/index.js
@@ -91,7 +91,7 @@ function track(eventName, payload) {
     event: eventName,
     userId,
     anonymousId: cliId,
-    properties: Object.assign({}, defaultProperties, properties),
+    properties: { ...defaultProperties, ...properties },
   }
 
   return send('track', defaultData)
@@ -143,7 +143,7 @@ function identify(payload) {
   const identifyData = {
     anonymousId: cliId,
     userId,
-    traits: Object.assign({}, defaultTraits, data),
+    traits: { ...defaultTraits, ...data },
   }
 
   return send('identify', identifyData)


### PR DESCRIPTION
This adds the [`prefer-object-spread`](https://eslint.org/docs/rules/prefer-object-spread) ESLint rule.

This PR's diff was generated by `eslint --fix` + `prettier`.