### PR TITLE
Add `func-name-matching` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     // Those ESLint rules are not enabled by Prettier, ESLint recommended rules
     // nor standard JavaScript. However, they are still useful
     'array-callback-return': [2, { allowImplicit: true, checkForEach: true }],
+    'func-name-matching': [2, { considerPropertyDescriptor: true }],
     'multiline-comment-style': [2, 'separate-lines'],
     'no-else-return': [2, { allowElseIf: false }],
 

--- a/src/utils/addons/validation.js
+++ b/src/utils/addons/validation.js
@@ -10,7 +10,7 @@ module.exports.missingConfigValues = function missingConfigValues(requiredConfig
   })
 }
 
-module.exports.updateConfigValues = function missingConfigValues(allowedConfig, currentConfig, newConfig) {
+module.exports.updateConfigValues = function updateConfigValues(allowedConfig, currentConfig, newConfig) {
   return Object.keys(allowedConfig).reduce((acc, key) => {
     if (newConfig[key]) {
       acc[key] = newConfig[key]


### PR DESCRIPTION
This adds the [`func-name-matching`](https://eslint.org/docs/rules/func-name-matching) ESLint rule.