### PR TITLE
Add `no-invalid-this` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'multiline-comment-style': [2, 'separate-lines'],
     'no-else-return': [2, { allowElseIf: false }],
     'no-implicit-coercion': 2,
+    'no-invalid-this': 2,
     'no-var': 2,
     'prefer-object-spread': 2,
 


### PR DESCRIPTION
This adds the [`no-invalid-this`](https://eslint.org/docs/rules/no-invalid-this) ESLint rule.

A file is passing `this` around instead of using class methods, which is odd. We should either use class methods there, or pass the `context` object around. This PR chooses the second pattern for the time being, because this generates the smallest diff.