### PR TITLE
Add `no-promise-executor-return` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     'no-negated-condition': 2,
     'no-nested-ternary': 2,
     'no-plusplus': [2, { allowForLoopAfterthoughts: true }],
+    'no-promise-executor-return': 2,
     'no-underscore-dangle': [2, { enforceInMethodNames: true }],
     'no-unreachable-loop': 2,
     'no-useless-backreference': 2,

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -41,7 +41,9 @@ testMatrix.forEach(({ args }) => {
         handler: async () => {
           console.log('ding')
           // Wait for 4 seconds
-          await new Promise((resolve) => setTimeout(resolve, 4000))
+          await new Promise((resolve) => {
+            setTimeout(resolve, 4000)
+          })
           return {
             statusCode: 200,
             body: 'ping',

--- a/tests/utils/dev-server.js
+++ b/tests/utils/dev-server.js
@@ -44,7 +44,12 @@ const startServer = async ({ cwd, env = {}, args = [] }) => {
               }
             })
             ps.kill()
-            await Promise.race([ps.catch(() => {}), new Promise((resolve) => setTimeout(resolve, 1000))])
+            await Promise.race([
+              ps.catch(() => {}),
+              new Promise((resolve) => {
+                setTimeout(resolve, 1000)
+              }),
+            ])
           },
         })
       }


### PR DESCRIPTION
This adds the [`no-promise-executor-return`](https://eslint.org/docs/rules/no-promise-executor-return) ESLint rule.