### PR TITLE
Add `prefer-destructuring` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'no-else-return': [2, { allowElseIf: false }],
     'no-implicit-coercion': 2,
     'no-var': 2,
+    'prefer-destructuring': 2,
     'prefer-object-spread': 2,
 
     // This version of eslint-plugin-unicorn requires Node 10

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -394,7 +394,7 @@ class DeployCommand extends Command {
 
     const deployFolder = await getDeployFolder({ flags, config, site, siteData, log })
     const functionsFolder = getFunctionsFolder({ flags, config, site, siteData })
-    const configPath = site.configPath
+    const { configPath } = site
 
     log(
       prettyjson.render({

--- a/src/commands/env/unset.js
+++ b/src/commands/env/unset.js
@@ -5,7 +5,7 @@ class EnvUnsetCommand extends Command {
     const { args, flags } = this.parse(EnvUnsetCommand)
     const { api, site } = this.netlify
     const siteId = site.id
-    const name = args.name
+    const { name } = args
 
     if (!siteId) {
       this.log('No site id found, please run inside a site folder or `netlify link`')

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -204,7 +204,7 @@ function ensureFunctionDirExists(flags, config) {
 // Download files from a given github URL
 async function downloadFromURL(flags, args, functionsDir) {
   const folderContents = await readRepoURL(flags.url)
-  const functionName = flags.url.split('/').slice(-1)[0]
+  const [functionName] = flags.url.split('/').slice(-1)
   const nameToUse = await getNameFromArgs(args, flags, functionName)
   const fnFolder = path.join(functionsDir, nameToUse)
   if (fs.existsSync(fnFolder + '.js') && fs.lstatSync(fnFolder + '.js').isFile()) {

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -58,10 +58,10 @@ class FunctionsInvokeCommand extends Command {
     if (eventTriggeredFunctions.has(functionToTrigger)) {
       /** handle event triggered fns  */
       // https://www.netlify.com/docs/functions/#event-triggered-functions
-      const parts = functionToTrigger.split('-')
-      if (parts[0] === 'identity') {
+      const [name, event] = functionToTrigger.split('-')
+      if (name === 'identity') {
         // https://www.netlify.com/docs/functions/#identity-event-functions
-        body.event = parts[1]
+        body.event = event
         body.user = {
           id: '1111a1a1-a11a-1111-aa11-aaa11111a11a',
           aud: '',

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -89,13 +89,13 @@ class LinkCommand extends Command {
       if (results.length === 0) {
         this.error(new Error(`No sites found named ${flags.name}`))
       }
-      siteData = results[0]
-      state.set('siteId', siteData.id)
+      const [firstSiteData] = results
+      state.set('siteId', firstSiteData.id)
 
-      this.log(`Linked to ${siteData.name} in ${path.relative(path.join(process.cwd(), '..'), state.path)}`)
+      this.log(`Linked to ${firstSiteData.name} in ${path.relative(path.join(process.cwd(), '..'), state.path)}`)
 
       await track('sites_linked', {
-        siteId: (siteData && siteData.id) || siteId,
+        siteId: (firstSiteData && firstSiteData.id) || siteId,
         linkType: 'manual',
         kind: 'byName',
       })

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -28,7 +28,7 @@ class SitesCreateCommand extends Command {
 
     let accountSlug = flags['account-slug']
     if (!accountSlug) {
-      const results = await inquirer.prompt([
+      const { accountSlug: accountSlugInput } = await inquirer.prompt([
         {
           type: 'list',
           name: 'accountSlug',
@@ -39,10 +39,10 @@ class SitesCreateCommand extends Command {
           })),
         },
       ])
-      accountSlug = results.accountSlug
+      accountSlug = accountSlugInput
     }
 
-    const name = flags.name
+    const { name } = flags
     let userName
     let site
 
@@ -64,7 +64,7 @@ class SitesCreateCommand extends Command {
         console.log(
           `Choose a unique site name (e.g. ${siteSuggestion}.netlify.app) or leave it blank for a random name. You can update the site name later.`
         )
-        const results = await inquirer.prompt([
+        const { name: nameInput } = await inquirer.prompt([
           {
             type: 'input',
             name: 'name',
@@ -73,7 +73,7 @@ class SitesCreateCommand extends Command {
             validate: (input) => /^[a-zA-Z\d-]+$/.test(input) || 'Only alphanumeric characters and hyphens are allowed',
           },
         ])
-        name = results.name
+        name = nameInput
       }
 
       const body = {}

--- a/src/function-builder-detectors/netlify-lambda.js
+++ b/src/function-builder-detectors/netlify-lambda.js
@@ -19,7 +19,8 @@ module.exports = function () {
     const script = scripts[key]
     const match = script.match(/netlify-lambda build (\S+)/)
     if (match) {
-      settings.src = match[1]
+      const [, src] = match
+      settings.src = src
       settings.npmScript = key
       break
     }

--- a/src/functions-templates/js/fauna-crud/delete.js
+++ b/src/functions-templates/js/fauna-crud/delete.js
@@ -7,7 +7,7 @@ const client = new faunadb.Client({
 })
 
 exports.handler = async (event) => {
-  const id = event.id
+  const { id } = event
   console.log(`Function 'delete' invoked. delete id: ${id}`)
   return client
     .query(q.Delete(q.Ref(`classes/items/${id}`)))

--- a/src/functions-templates/js/fauna-crud/fauna-crud.js
+++ b/src/functions-templates/js/fauna-crud/fauna-crud.js
@@ -10,7 +10,8 @@ exports.handler = async (event, context) => {
       }
       // e.g. GET /.netlify/functions/fauna-crud/123456
       if (segments.length === 1) {
-        event.id = segments[0]
+        const [id] = segments
+        event.id = id
         return require('./read').handler(event, context)
       }
       return {
@@ -25,7 +26,8 @@ exports.handler = async (event, context) => {
     case 'PUT':
       // e.g. PUT /.netlify/functions/fauna-crud/123456 with a body of key value pair objects, NOT strings
       if (segments.length === 1) {
-        event.id = segments[0]
+        const [id] = segments
+        event.id = id
         return require('./update').handler(event, context)
       }
       return {
@@ -36,7 +38,8 @@ exports.handler = async (event, context) => {
     case 'DELETE':
       // e.g. DELETE /.netlify/functions/fauna-crud/123456
       if (segments.length === 1) {
-        event.id = segments[0]
+        const [id] = segments
+        event.id = id
         return require('./delete').handler(event, context)
       }
       return {

--- a/src/functions-templates/js/fauna-crud/read.js
+++ b/src/functions-templates/js/fauna-crud/read.js
@@ -7,7 +7,7 @@ const client = new faunadb.Client({
 })
 
 exports.handler = async (event) => {
-  const id = event.id
+  const { id } = event
   console.log(`Function 'read' invoked. Read id: ${id}`)
   return client
     .query(q.Get(q.Ref(`classes/items/${id}`)))

--- a/src/functions-templates/js/fauna-crud/update.js
+++ b/src/functions-templates/js/fauna-crud/update.js
@@ -8,7 +8,7 @@ const client = new faunadb.Client({
 
 exports.handler = async (event) => {
   const data = JSON.parse(event.body)
-  const id = event.id
+  const { id } = event
   console.log(`Function 'update' invoked. update id: ${id}`)
   return client
     .query(q.Update(q.Ref(`classes/items/${id}`), { data }))

--- a/src/functions-templates/js/submission-created/submission-created.js
+++ b/src/functions-templates/js/submission-created/submission-created.js
@@ -5,7 +5,7 @@
 const fetch = require('node-fetch')
 const { EMAIL_TOKEN } = process.env
 exports.handler = async (event) => {
-  const email = JSON.parse(event.body).payload.email
+  const { email } = JSON.parse(event.body).payload
   console.log(`Recieved a submission: ${email}`)
   return fetch('https://api.buttondown.email/v1/subscribers', {
     method: 'POST',

--- a/src/functions-templates/js/url-shortener/get-route.js
+++ b/src/functions-templates/js/url-shortener/get-route.js
@@ -4,7 +4,7 @@ const request = require('request')
 
 module.exports = function handler(event, context, callback) {
   // which URL code are we trying to retrieve?
-  const code = event.queryStringParameters.code
+  const { code } = event.queryStringParameters
 
   // where is the data?
   const url =

--- a/src/lib/exec-fetcher.test.js
+++ b/src/lib/exec-fetcher.test.js
@@ -37,7 +37,7 @@ const packages = [
 ]
 
 packages.forEach(({ packageName, execName, execArgs, pattern, extension }) => {
-  const log = console.log
+  const { log } = console
 
   test(`${packageName} - should return true on empty directory`, async (t) => {
     const { binPath } = t.context

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -241,7 +241,7 @@ class BaseCommand extends Command {
     // Set user data
     this.netlify.globalConfig.set(`users.${userID}`, userData)
 
-    const email = user.email
+    const { email } = user
     await identify({
       name: user.full_name,
       email,

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -36,7 +36,8 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
       if (detectorResult) settingsArr.push(detectorResult)
     }
     if (settingsArr.length === 1) {
-      settings = settingsArr[0]
+      const [firstSettings] = settingsArr
+      settings = firstSettings
       settings.args = chooseDefaultArgs(settings.possibleArgsArrs)
     } else if (settingsArr.length > 1) {
       /** multiple matching detectors, make the user choose */
@@ -174,7 +175,7 @@ module.exports.serverSettings = async (devConfig, flags, projectDir, log) => {
 const DEFAULT_PORT = 8888
 
 async function getStaticServerSettings(settings, flags, projectDir, log) {
-  let dist = settings.dist
+  let { dist } = settings
   if (flags.dir) {
     log(`${NETLIFYDEVWARN} Using simple static server because --dir flag was specified`)
     dist = flags.dir
@@ -211,7 +212,7 @@ module.exports.loadDetector = loadDetector
 
 function chooseDefaultArgs(possibleArgsArrs) {
   // vast majority of projects will only have one matching detector
-  const args = possibleArgsArrs[0] // just pick the first one
+  const [args] = possibleArgsArrs // just pick the first one
   if (!args) {
     const { scripts } = JSON.parse(fs.readFileSync('package.json', { encoding: 'utf8' }))
     const err = new Error(

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -1,4 +1,4 @@
-const version = require('../../../package.json').version
+const { version } = require('../../../package.json')
 const os = require('os')
 const ghauth = require('../../utils/gh-auth')
 const { Octokit } = require('@octokit/rest')

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -83,7 +83,8 @@ Run ${chalk.cyanBright('git remote -v')} to see a list of your git remotes.`)
 
       // Matches a single site hooray!
       if (matchingSites.length === 1) {
-        site = matchingSites[0]
+        const [firstSite] = matchingSites
+        site = firstSite
       } else if (matchingSites.length > 1) {
         // Matches multiple sites. Users must choose which to link.
         console.log(`Found ${matchingSites.length} matching sites!`)
@@ -156,7 +157,8 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
         }
         site = selectedSite
       } else {
-        site = matchingSites[0]
+        const [firstSite] = matchingSites
+        site = firstSite
       }
       break
     }

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -209,10 +209,11 @@ async function serveRedirect(req, res, proxy, match, options) {
     }
 
     const destStaticFile = await getStatic(dest.pathname, options.publicFolder)
-    let status
+    let statusValue
     if (match.force || (!staticFile && ((!options.framework && destStaticFile) || isInternal(destURL)))) {
       req.url = destStaticFile ? destStaticFile + dest.search : destURL
-      status = match.status
+      const { status } = match
+      statusValue = status
       console.log(`${NETLIFYDEVLOG} Rewrote URL to`, req.url)
     }
 
@@ -225,7 +226,7 @@ async function serveRedirect(req, res, proxy, match, options) {
       return proxy.web(req, res, { target: urlForAddons })
     }
 
-    return proxy.web(req, res, { ...options, status })
+    return proxy.web(req, res, { ...options, status: statusValue })
   }
 
   return proxy.web(req, res, options)

--- a/src/utils/telemetry/index.js
+++ b/src/utils/telemetry/index.js
@@ -59,7 +59,7 @@ function track(eventName, payload) {
   }
 
   let userId = properties.userID
-  let cliId = properties.cliId
+  let { cliId } = properties
 
   if (!userId) {
     userId = globalConfig.get('userId')
@@ -117,7 +117,7 @@ function identify(payload) {
   }
 
   let userId = data.userID
-  let cliId = data.cliId
+  let { cliId } = data
 
   if (!userId) {
     userId = globalConfig.get('userId')

--- a/src/utils/telemetry/validation.js
+++ b/src/utils/telemetry/validation.js
@@ -9,9 +9,7 @@ module.exports = function isValidEventName(eventName, config) {
   if (!containsSeparators(eventName) || !matches) {
     return formattingWarning(eventName)
   }
-  const project = matches[1]
-  const object = matches[2]
-  const action = matches[3]
+  const [, project, object, action] = matches
   let error
   // if missing any parts of event, exit
   if (!project || !object || !action) {

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -805,7 +805,7 @@ testMatrix.forEach(({ args }) => {
   test(testName('should redirect requests to an external server', args), async (t) => {
     await withSiteBuilder('site-redirects-file-to-external', async (builder) => {
       const server = startExternalServer()
-      const port = server.address().port
+      const { port } = server.address()
       builder.withRedirectsFile({
         redirects: [{ from: '/api/*', to: `http://localhost:${port}/:splat`, status: 200 }],
       })

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -85,7 +85,7 @@ if (process.env.IS_FORK !== 'true') {
   })
 
   test.serial('env:get --json should return empty object if var not set', async (t) => {
-    const key = getArgsFromState(ENV_VAR_STATES.get)[0]
+    const [key] = getArgsFromState(ENV_VAR_STATES.get)
 
     const cliResponse = await callCli(['env:get', '--json', key], t.context.execOptions)
     const json = JSON.parse(cliResponse)
@@ -166,7 +166,7 @@ if (process.env.IS_FORK !== 'true') {
 
   test.serial('env:set --json should be able to set var with empty value', async (t) => {
     const args = getArgsFromState(ENV_VAR_STATES.setEmpty)
-    const key = args[0]
+    const [key] = args
 
     const cliResponse = await callCli(['env:set', '--json', ...args], t.context.execOptions)
     const json = JSON.parse(cliResponse)
@@ -177,7 +177,7 @@ if (process.env.IS_FORK !== 'true') {
   })
 
   test.serial('env:unset --json should remove existing variable', async (t) => {
-    const key = getArgsFromState(ENV_VAR_STATES.unset)[0]
+    const [key] = getArgsFromState(ENV_VAR_STATES.unset)
 
     const cliResponse = await callCli(['env:unset', '--json', key], t.context.execOptions)
     const json = JSON.parse(cliResponse)

--- a/tests/utils/create-live-test-site.js
+++ b/tests/utils/create-live-test-site.js
@@ -30,7 +30,7 @@ async function createLiveTestSite(siteName) {
 
   const matches = /Site ID:\s+([a-zA-Z\d-]+)/m.exec(stripAnsi(cliResponse))
   if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
-    const siteId = matches[1]
+    const [, siteId] = matches
     console.log(`Done creating site ${siteName} for account '${accountSlug}'. Site Id: ${siteId}`)
     return siteId
   }


### PR DESCRIPTION
This adds the [`prefer-destructuring`](https://eslint.org/docs/rules/prefer-destructuring) ESLint rule.

Two functions required more refactoring, so those changes have been done in separate PRs #1414 and #1415, and `// eslint-disable-next-line` was used instead in this PR.