### PR TITLE
Configure `ava/no-only-test` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,9 @@ module.exports = {
     'require-await': 2,
     'no-unused-vars': [2, {}],
     'no-undef': [2, { typeof: true }],
+
+    // The autofix makes it impossible to use those in debugging
+    'ava/no-only-test': 0,
     'ava/no-skip-test': 0,
 
     // Those ESLint rules are not enabled by Prettier, ESLint recommended rules


### PR DESCRIPTION
`test.only()` and `test.skip()` are useful in debugging. Enabling those ESLint rules would prevent from using those due to the autofix on file save.