### PR TITLE
Wrap Markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,4 +26,5 @@ Add any other context or screenshots about the feature request here.
 
 Yes/No.
 
-> Pull requests are welcome! If you would like to help us add this feature, please check our [contributions guidelines](../../CONTRIBUTING.md).
+> Pull requests are welcome! If you would like to help us add this feature, please check our
+> [contributions guidelines](../../CONTRIBUTING.md).

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,6 +2,7 @@
   "semi": false,
   "singleQuote": true,
   "printWidth": 120,
+  "proseWrap": "always",
   "quoteProps": "consistent",
   "trailingComma": "es5"
 }

--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -17,9 +17,11 @@
 
 ## things to note
 
-- Dev block overrides will supercede anything you write in your detector: https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection
+- Dev block overrides will supercede anything you write in your detector:
+  https://github.com/netlify/cli/blob/master/docs/netlify-dev.md#project-detection
 - detectors are language agnostic. don't assume npm or yarn.
-- if default args (like 'develop') are missing, that means the user has configured it, best to tell them to use the -c flag.
+- if default args (like 'develop') are missing, that means the user has configured it, best to tell them to use the -c
+  flag.
 
 ## detector notes
 

--- a/src/function-builder-detectors/README.md
+++ b/src/function-builder-detectors/README.md
@@ -1,6 +1,7 @@
 ## function builder detectors
 
-similar to project detectors, each file here detects function builders. this is so that netlify dev never manages the webpack or other config. the expected output is very simple:
+similar to project detectors, each file here detects function builders. this is so that netlify dev never manages the
+webpack or other config. the expected output is very simple:
 
 ```js
 module.exports = {

--- a/src/functions-templates/js/README.md
+++ b/src/functions-templates/js/README.md
@@ -4,7 +4,8 @@ place new templates here and our CLI will pick it up. each template must be in i
 
 ## not a long term solution
 
-we dont want people to update their CLI every time we add a template. see https://github.com/netlify/netlify-dev-plugin/issues/42 for how we may solve in future
+we dont want people to update their CLI every time we add a template. see
+https://github.com/netlify/netlify-dev-plugin/issues/42 for how we may solve in future
 
 ## template lifecycles
 

--- a/tests/site-cra/README.md
+++ b/tests/site-cra/README.md
@@ -6,24 +6,22 @@ In the project directory, you can run:
 
 ### `yarn start`
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Runs the app in the development mode.<br /> Open [http://localhost:3000](http://localhost:3000) to view it in the
+browser.
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+The page will reload if you make edits.<br /> You will also see any lint errors in the console.
 
 ### `yarn test`
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Launches the test runner in the interactive watch mode.<br /> See the section about
+[running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
 ### `yarn build`
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Builds the app for production to the `build` folder.<br /> It correctly bundles React in production mode and optimizes
+the build for the best performance.
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+The build is minified and the filenames include the hashes.<br /> Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
@@ -31,15 +29,21 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will
+remove the single build dependency from your project.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right
+into your project so you have full control over them. All of the commands except `eject` will still work, but they will
+point to the copied scripts so you can tweak them. At this point you’re on your own.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you
+shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t
+customize it when you are ready for it.
 
 ## Learn More
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+You can learn more in the
+[Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
 
@@ -65,4 +69,5 @@ This section has moved here: https://facebook.github.io/create-react-app/docs/de
 
 ### `yarn build` fails to minify
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+This section has moved here:
+https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify


### PR DESCRIPTION
This uses Prettier to enforce the maximum line length inside Markdown files too, by using wrapping, without changing how the Markdown is rendered.

Note that Prettier is not run on `README.md` and other Markdown files that are automatically generated in this repository.