### PR TITLE
Speedup ESLint and Prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-node_modules
-site-cra
-site/dist

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ vendor
 coverage
 test-site
 site/dist
+site-cra
 
 site/src/**/*.md
 !site/src/register-addon.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-site/dist

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "scriptsArgs": {
-    "eslint": "--cache --format=codeframe --max-warnings=0 \"{src,scripts,site,tests,.github}/**/*.{js,md,html}\"",
-    "prettier": "--loglevel=warn \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\""
+    "eslint": "--ignore-path .gitignore --cache --format=codeframe --max-warnings=0 \"{src,scripts,site,tests,.github}/**/*.{js,md,html}\"",
+    "prettier": "--ignore-path .gitignore --loglevel=warn \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\""
   },
   "dependencies": {
     "@netlify/build": "^5.0.0",


### PR DESCRIPTION
This speeds up and simplifies ESLint and Prettier by using `.gitignore` (which skips more files) instead of `.prettierignore` and `.eslintignore`.