### PR TITLE
Add Codecov test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,5 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           NETLIFY_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Codecov test coverage
+        run: bash scripts/coverage.sh "${{ matrix.os }}" "${{ matrix.node-version }}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Netlify CLI
 
+[![Coverage Status](https://codecov.io/gh/netlify/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/netlify/cli)
 [![npm version][npm-img]][npm] [![downloads][dl-img]][dl] [![netlify-status][netlify-img]][netlify] [![dependencies][david-img]][david] [![security][snyk-img]][snyk][![FOSSA Status](https://app.fossa.com/api/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2Fcli.git.svg?type=shield)](https://app.fossa.com/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2Fcli.git?ref=badge_shield)
 
 Interact with [Netlify](http://netlify.com/) from the comfort of your CLI.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  strict_yaml_branch: master
+coverage:
+  range: [80, 100]
+  parsers:
+    javascript:
+      enable_partials: true
+  status:
+    project: false
+    patch: false
+comment: false

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Upload test coverage to Codecov
+
+os="$1"
+os="${os/-latest/}"
+
+node="$2"
+node="node_${node//./_}"
+
+# We don't use the -Z flag (which makes CI build fail on upload error) because
+# Codecov fails wait too often.
+curl -s https://codecov.io/bash | \
+  bash -s -- -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
This adds Codecov for test coverage.

It's quite useful to see the test coverage of a PR by looking at the PR status. 
This disables PR comments because they can be noisy.