### PR TITLE
feat(command-dev-local): pass path to bundler plugin CLI to mesh forward

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5613,9 +5613,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001148",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-      "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw=="
+      "version": "1.0.30001150",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz",
+      "integrity": "sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ=="
     },
     "cardinal": {
       "version": "2.1.1",
@@ -13460,9 +13460,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.63",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
-      "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg=="
+      "version": "1.1.64",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.64.tgz",
+      "integrity": "sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg=="
     },
     "node-source-walk": {
       "version": "4.2.0",
@@ -15475,9 +15475,9 @@
       }
     },
     "rollup": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.32.0.tgz",
-      "integrity": "sha512-0FIG1jY88uhCP2yP4CfvtKEqPDRmsUwfY1kEOOM+DH/KOGATgaIFd/is1+fQOxsvh62ELzcFfKonwKWnHhrqmw==",
+      "version": "2.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.32.1.tgz",
+      "integrity": "sha512-Op2vWTpvK7t6/Qnm1TTh7VjEZZkN8RWgf0DHbkKzQBwNf748YhXbozHVefqpPp/Fuyk/PQPAnYsBxAEtlMvpUw==",
       "requires": {
         "fsevents": "~2.1.2"
       }
@@ -16639,9 +16639,9 @@
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
     },
     "terser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.6.tgz",
-      "integrity": "sha512-145ap5v1HYx69HfLuwWaxTIlXyiSr+nSTb7ZWlJCgJn2JptuJRKziNa/zwFx9B1IU99Q055jHni74nLuuEC78w==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.7.tgz",
+      "integrity": "sha512-lJbKdfxWvjpV330U4PBZStCT9h3N9A4zZVA5Y4k9sCWXknrpdyxi1oMsRKLmQ/YDMDxSBKIh88v0SkdhdqX06w==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2294,9 +2294,9 @@
       "integrity": "sha512-kkRCzA71HugJxmPOcWv2B4ArHhSMKjs2ArGBr10ndocVLdAHwCYoJm0X4Xt8IYaOcGD9Lm4fbLjpXDLDRGDzPw=="
     },
     "@netlify/plugin-edge-handlers": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@netlify/plugin-edge-handlers/-/plugin-edge-handlers-1.8.0.tgz",
-      "integrity": "sha512-eOU3P8GgRSMKXZWBxMeLZYX3UUwq/w5Hn6BiUyroJ57UkxHFzMsIcsIryt/KW5vKEiLo/pvYZyU0S4WVcbHbWA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-edge-handlers/-/plugin-edge-handlers-1.9.0.tgz",
+      "integrity": "sha512-5JRVj9lVxG3VKI3vUk95AkS2ZatDHEcOBPZ5En4j+vKlfwQpn0oCbTbHQ5V45Zf0dKZv3rULAYZ//vHmVIH/Nw==",
       "requires": {
         "@babel/core": "^7.11.4",
         "@babel/preset-env": "^7.11.5",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
+    "@netlify/plugin-edge-handlers": "^1.8.0",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
-    "@netlify/plugin-edge-handlers": "^1.8.0",
+    "@netlify/plugin-edge-handlers": "^1.9.0",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -10,6 +10,11 @@ const EXEC_NAME = 'traffic-mesh'
 
 const LATEST_VERSION = 'v0.22.1'
 
+const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.join(
+  path.dirname(require.resolve('@netlify/plugin-edge-handlers')),
+  'cli.js'
+)
+
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])
 
 const installTrafficMesh = async ({ log }) => {
@@ -48,6 +53,8 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
     `http://localhost:${frameworkPort}`,
     '--watch',
     publishDir,
+    '--bundler',
+    EDGE_HANDLERS_BUNDLER_CLI_PATH,
     '--log-file',
     getPathInProject(['logs', 'traffic-mesh.log']),
   ]

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -11,7 +11,7 @@ const EXEC_NAME = 'traffic-mesh'
 const LATEST_VERSION = 'v0.22.1'
 
 const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(
-  path.join(path.dirname(require.resolve('@netlify/plugin-edge-handlers')), 'cli.js')
+  path.join(path.dirname(require.resolve('@netlify/plugin-edge-handlers')), 'cli.js'),
 )
 
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -10,9 +10,7 @@ const EXEC_NAME = 'traffic-mesh'
 
 const LATEST_VERSION = 'v0.22.1'
 
-const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(
-  require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js',
-)
+const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js')
 
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])
 

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -10,9 +10,8 @@ const EXEC_NAME = 'traffic-mesh'
 
 const LATEST_VERSION = 'v0.22.1'
 
-const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.join(
-  path.dirname(require.resolve('@netlify/plugin-edge-handlers')),
-  'cli.js'
+const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(
+  path.join(path.dirname(require.resolve('@netlify/plugin-edge-handlers')), 'cli.js')
 )
 
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -11,7 +11,7 @@ const EXEC_NAME = 'traffic-mesh'
 const LATEST_VERSION = 'v0.22.1'
 
 const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(
-  path.join(path.dirname(require.resolve('@netlify/plugin-edge-handlers')), 'cli.js'),
+  require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js',
 )
 
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])


### PR DESCRIPTION
**- Summary**

To make resolution more rigid and to avoid bloating the user's PATH with internal tools, mesh-forward now wants the path to the CLI of the edge handler build plugin passed in via its CLI. In this PR we resolve the path to the CLI via `require.resolve` and then pass it on to mesh-forward.

~~Please note the version of the build plugin specified in the dependencies here **does not yet** ship with the CLI, that's why this is a draft (it would be super nice to get this released, but I don't have the permissions to do that).~~

**- Test plan**

I wonder what's the best way forward here.

Ideally both repos (mesh-forward & cli) had separate integration tests against one another, but I'm afraid right now only `cli` as a consumer of mesh-forward actually has them.

I made changes to mesh-forward that will allow unpinning the mesh-forward version again, but eventually we do want to consume it via npm anyway, such that the version again is fixed.

**- A picture of a cute animal (not mandatory but encouraged)**

🐞
