### PR TITLE
Display more informative error information in TimeoutError response body

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -20,11 +20,15 @@ const { detectFunctionsBuilder } = require('./detect-functions-builder')
 const { getFunctions } = require('./get-functions')
 const { NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require('./logo')
 
+const formatJsError = (err) => `${err.name}: ${err.message}\n\t${err.stack.join('\n\t')}`
+const formatLambdaLocalError = (err) => `${err.errorType}: ${err.errorMessage}\n\t${err.stackTrace.join('\n\t')}`
+
 const handleErr = function (err, response) {
   response.statusCode = 500
-  response.write(`${NETLIFYDEVERR} Function invocation failed: ${err.toString()}`)
+  const errorString = err instanceof Error ? formatJsError(err) : formatLambdaLocalError(err)
+  response.write(`Function invocation failed: ${errorString}`)
   response.end()
-  console.log(`${NETLIFYDEVERR} Error during invocation:`, err)
+  console.log(`${NETLIFYDEVERR} Function invocation failed:`, errorString)
 }
 
 const formatLambdaError = (err) => chalk.red(`${err.errorType}: ${err.errorMessage}`)


### PR DESCRIPTION
**- Summary**

Closes #1459, problem described with detail in relative issue.
There are more elegant ways to solve this, but I would delay them to later times. This is kind of a quick but solid workaround.

I also removed the colored `◈` from the response body (ANSI chars), and changed the console log message to include the same exact failure message of the response: "Function invocation failed" (was slightly different, creating confusion).

**- Test plan**

Tested as described in #1459 with a TimeoutError, and by manually causing a `new Error` in the code.
Knowing what else can cause an error would help in triggering other possible error types.

**- Description for the changelog**

- Error 500 "Function invocation failed" message is more informative in both response body and console log (for example a TimeoutError)

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="258" alt="cute cat" src="https://user-images.githubusercontent.com/1799710/96758400-05bb7600-13d7-11eb-86b6-04ce4a1e6943.png">

Thanks! ;)
