### PR TITLE
Install traffic-mesh via npm package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,5 @@ jobs:
           # We set a flag so we can skip tests that access Netlify API
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-          NETLIFY_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Codecov test coverage
         run: bash scripts/coverage.sh "${{ matrix.os }}" "${{ matrix.node-version }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,9 @@
       }
     },
     "@netlify/traffic-mesh-agent": {
-      "version": "0.24.0-pre.10",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.10.tgz",
-      "integrity": "sha512-iEkS3V3BV3SIlJOPfUJ46IRRZDlIG1u1And2ncdwRosby6iHaMlvb4ZR4jtJC99p8n3et+UDrPLeQsET666KHg=="
+      "version": "0.24.0-pre.11",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.11.tgz",
+      "integrity": "sha512-BR5zogg/7M03jTgHsDt2R+diTQl9uiQwrKuux7yBwt36uMXuiD84xf2sqEf9QegUTAy+wukr1arxqXMR42Lk3g=="
     },
     "@netlify/zip-it-and-ship-it": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,9 @@
       }
     },
     "@netlify/traffic-mesh-agent": {
-      "version": "0.24.0-pre.8",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.8.tgz",
-      "integrity": "sha512-Buq4xp2j3Jg6PWFEcATmgsMvGP82easmCI3IUERidaPNjHOl/GqUkhBqG9WWo3hGx4fmQfD1C85mm/0cqXTDHw=="
+      "version": "0.24.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.9.tgz",
+      "integrity": "sha512-EM8ujv2IB0y78KeP389ju5kAh9XChbhAzmAiUt3Pb82aMNlHnRGmDEO0BfooKSsFNAMkTXW0qP4FiRJYq4ywiw=="
     },
     "@netlify/zip-it-and-ship-it": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,32 @@
       }
     },
     "@netlify/traffic-mesh-agent": {
-      "version": "0.24.0-pre.11",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.11.tgz",
-      "integrity": "sha512-BR5zogg/7M03jTgHsDt2R+diTQl9uiQwrKuux7yBwt36uMXuiD84xf2sqEf9QegUTAy+wukr1arxqXMR42Lk3g=="
+      "version": "0.24.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.23.tgz",
+      "integrity": "sha512-uv5F3grah5C0CPGm8raASIyVDi+lYBR4os+wG0GXkUVCU2r2Pcl8MStLeN3phe1G3AjVkco5WcAKC8XfBvvqEw==",
+      "requires": {
+        "@netlify/traffic-mesh-agent-darwin-x64": "^0.24.0-pre.23",
+        "@netlify/traffic-mesh-agent-linux-x64": "^0.24.0-pre.23",
+        "@netlify/traffic-mesh-agent-win32-x64": "^0.24.0-pre.23"
+      }
+    },
+    "@netlify/traffic-mesh-agent-darwin-x64": {
+      "version": "0.24.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-darwin-x64/-/traffic-mesh-agent-darwin-x64-0.24.0-pre.23.tgz",
+      "integrity": "sha512-XDn77F+tx+qQZ9sMwqmwRAOEm56syA7xO1rScDY4JV8oSyvwa6sfUWnFXefyxUt1uLNfIQhiKDnA4sOyCRJxDw==",
+      "optional": true
+    },
+    "@netlify/traffic-mesh-agent-linux-x64": {
+      "version": "0.24.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-linux-x64/-/traffic-mesh-agent-linux-x64-0.24.0-pre.23.tgz",
+      "integrity": "sha512-9D2sFOcO72IBsqiHgU1Z5tQ6+lvjRBUeOc0iFKgcUPG5eJ46pgrOAD8B8tNd2FscNz2lyrJxZc1kGAOjYikzUQ==",
+      "optional": true
+    },
+    "@netlify/traffic-mesh-agent-win32-x64": {
+      "version": "0.24.0-pre.23",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-win32-x64/-/traffic-mesh-agent-win32-x64-0.24.0-pre.23.tgz",
+      "integrity": "sha512-kFImydqG6Er+kgG5UFjIWBp7TxFcf/eOoXSOWr6a+3kJu2iwZP2IdflyNK9EsKdW/KA+W43PXleF4VQwLm830w==",
+      "optional": true
     },
     "@netlify/zip-it-and-ship-it": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,9 +1638,9 @@
       }
     },
     "@netlify/traffic-mesh-agent": {
-      "version": "0.24.0-pre.9",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.9.tgz",
-      "integrity": "sha512-EM8ujv2IB0y78KeP389ju5kAh9XChbhAzmAiUt3Pb82aMNlHnRGmDEO0BfooKSsFNAMkTXW0qP4FiRJYq4ywiw=="
+      "version": "0.24.0-pre.10",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.10.tgz",
+      "integrity": "sha512-iEkS3V3BV3SIlJOPfUJ46IRRZDlIG1u1And2ncdwRosby6iHaMlvb4ZR4jtJC99p8n3et+UDrPLeQsET666KHg=="
     },
     "@netlify/zip-it-and-ship-it": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1637,6 +1637,11 @@
         "execa": "^3.4.0"
       }
     },
+    "@netlify/traffic-mesh-agent": {
+      "version": "0.24.0-pre.8",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.24.0-pre.8.tgz",
+      "integrity": "sha512-Buq4xp2j3Jg6PWFEcATmgsMvGP82easmCI3IUERidaPNjHOl/GqUkhBqG9WWo3hGx4fmQfD1C85mm/0cqXTDHw=="
+    },
     "@netlify/zip-it-and-ship-it": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
     "@netlify/plugin-edge-handlers": "^1.9.0",
-    "@netlify/traffic-mesh-agent": "^0.24.0-pre.11",
+    "@netlify/traffic-mesh-agent": "^0.24.0-pre.23",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
     "@netlify/plugin-edge-handlers": "^1.9.0",
-    "@netlify/traffic-mesh-agent": "^0.24.0-pre.8",
+    "@netlify/traffic-mesh-agent": "^0.24.0-pre.9",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
     "@netlify/plugin-edge-handlers": "^1.9.0",
-    "@netlify/traffic-mesh-agent": "^0.24.0-pre.9",
+    "@netlify/traffic-mesh-agent": "^0.24.0-pre.10",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
     "@netlify/plugin-edge-handlers": "^1.9.0",
+    "@netlify/traffic-mesh-agent": "^0.24.0-pre.8",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@netlify/build": "^5.0.0",
     "@netlify/config": "^2.0.9",
     "@netlify/plugin-edge-handlers": "^1.9.0",
-    "@netlify/traffic-mesh-agent": "^0.24.0-pre.10",
+    "@netlify/traffic-mesh-agent": "^0.24.0-pre.11",
     "@netlify/zip-it-and-ship-it": "^1.3.9",
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",

--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -8,7 +8,7 @@ class TraceCommand extends Command {
     this.parse(TraceCommand)
 
     const args = ['trace'].concat(this.argv)
-    const { subprocess } = await runProcess({ log: this.log, args })
+    const { subprocess } = runProcess({ log: this.log, args })
     await subprocess
 
     await this.config.runHook('analytics', {

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const process = require('process')
 
+const { getTrafficMeshForLocalSystem } = require('@netlify/traffic-mesh-agent')
 const execa = require('execa')
 const waitPort = require('wait-port')
 
@@ -8,28 +9,7 @@ const { getPathInProject } = require('../lib/settings')
 
 const { NETLIFYDEVERR } = require('./logo')
 
-const EXEC_NAME = 'traffic-mesh'
-
 const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js')
-
-const getForwardProxyPath = () => {
-  let platform
-  switch (process.platform) {
-    case 'darwin':
-      platform = 'x86_64-apple-darwin'
-      break
-    case 'linux':
-      platform = 'x86_64-unknown-linux-gnu'
-      break
-    case 'win32':
-      platform = 'x86_64-pc-windows-msvc'
-      break
-    default:
-      throw new Error(`There is no traffic-mesh binary for ${process.platform}.`)
-  }
-
-  return path.resolve(EDGE_HANDLERS_BUNDLER_CLI_PATH, platform, EXEC_NAME)
-}
 
 const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDir, log, debug }) => {
   const args = [
@@ -41,8 +21,8 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
     `http://localhost:${frameworkPort}`,
     '--watch',
     publishDir,
-    // '--bundler',
-    // EDGE_HANDLERS_BUNDLER_CLI_PATH,
+    '--bundler',
+    EDGE_HANDLERS_BUNDLER_CLI_PATH,
     '--log-file',
     getPathInProject(['logs', 'traffic-mesh.log']),
   ]
@@ -86,7 +66,7 @@ const PROXY_READY_TIMEOUT = 3e4
 const PROXY_EXIT_TIMEOUT = 2e3
 
 const runProcess = ({ args }) => {
-  const subprocess = execa(getForwardProxyPath(), args, { stdio: 'inherit' })
+  const subprocess = execa(getTrafficMeshForLocalSystem(), args, { stdio: 'inherit' })
   return { subprocess }
 }
 

--- a/tests/command.dev.trace.test.js
+++ b/tests/command.dev.trace.test.js
@@ -1,14 +1,7 @@
 const test = require('ava')
 
-const { installTrafficMesh } = require('../src/utils/traffic-mesh')
-
 const callCli = require('./utils/call-cli')
 const { withSiteBuilder } = require('./utils/site-builder')
-
-test.before(async () => {
-  // pre-install the traffic mesh agent so we can run the tests in parallel
-  await installTrafficMesh({ log: console.log })
-})
 
 test('should not match redirect for empty site', async (t) => {
   await withSiteBuilder('empty-site', async (builder) => {


### PR DESCRIPTION
**- Summary**

This configures the CLI to load `traffic-mesh` via npm instead of via downloading it manually the first time `netlify dev` is run.

~~The package itself is quite heavy right now (40mb) because it contains the binaries for all operating systems, but we can always improve on that later by shipping a stripped package that downloads the right binaries on installation. For the MVP I wanted to avoid the additional moving parts this brings.~~

**- Test plan**

This should not change any behavior, so the existing tests should continue working.

**- Description for the changelog**

Install `traffic-mesh` component via npm package.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://picstatio.com/download/1920x1080/ak8xhf/Blue-cute-bird-flying-on-lake-water-wallpaper.jpg)