### PR TITLE
chore(renovate): add npm constraint

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,7 @@
 {
+  constraints: {
+    npm: '6',
+  },
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,


### PR DESCRIPTION
@ehmicky I'm hoping this will force `npm@6`:
https://github.com/renovatebot/renovate/blob/75737805c804f69f427e0f8147c463836b1af448/lib/manager/npm/post-update/npm.ts#L31