### PR TITLE
fix: don't pass bundler path to mesh forward

### DIFF
--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -13,7 +13,8 @@ const EXEC_NAME = 'traffic-mesh'
 
 const LATEST_VERSION = 'v0.22.1'
 
-const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js')
+// TODO: uncomment once we increment LATEST_VERSION
+// const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js')
 
 const getBinPath = () => getPathInHome([PACKAGE_NAME, 'bin'])
 
@@ -53,8 +54,8 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
     `http://localhost:${frameworkPort}`,
     '--watch',
     publishDir,
-    '--bundler',
-    EDGE_HANDLERS_BUNDLER_CLI_PATH,
+    // '--bundler',
+    // EDGE_HANDLERS_BUNDLER_CLI_PATH,
     '--log-file',
     getPathInProject(['logs', 'traffic-mesh.log']),
   ]


### PR DESCRIPTION
This PR reverts https://github.com/netlify/cli/pull/1458 until we have a new mesh forward version ready. See
https://github.com/netlify/cli/pull/1458#discussion_r510114277
and https://github.com/netlify/cli/pull/1469

since it's blocking CLI releases as passing the bundler arg fails on version `v0.22.1`:
```
error: Found argument '--bundler' which wasn't expected, or isn't valid in this context
```