### PR TITLE
chore: force renovate to use npm v6

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,8 @@
 {
-  constraints: {
-    npm: '6',
+  force: {
+    constraints: {
+      node: '< 15.0.0',
+    },
   },
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/1470

See https://github.com/renovatebot/renovate/issues/7474#issuecomment-717051216 and https://github.com/renovatebot/renovate/issues/7474#issuecomment-717009199