### PR TITLE
fix: support index.js function name

### DIFF
--- a/src/utils/finders.js
+++ b/src/utils/finders.js
@@ -18,17 +18,15 @@ const findHandler = function (functionPath) {
     return functionPath
   }
 
-  let handlerPath
-  const indexHandlerPath = path.join(functionPath, `index.js`)
   const namedHandlerPath = path.join(functionPath, `${path.basename(functionPath)}.js`)
-
   if (fs.existsSync(namedHandlerPath)) {
-    handlerPath = namedHandlerPath
+    return namedHandlerPath
   }
-  if (fs.existsSync(indexHandlerPath) && !fs.existsSync(namedHandlerPath)) {
-    handlerPath = indexHandlerPath
+
+  const indexHandlerPath = path.join(functionPath, `index.js`)
+  if (fs.existsSync(indexHandlerPath)) {
+    return indexHandlerPath
   }
-  return handlerPath
 }
 
 module.exports = { findModuleDir, findHandler }

--- a/src/utils/finders.js
+++ b/src/utils/finders.js
@@ -18,9 +18,15 @@ const findHandler = function (functionPath) {
     return functionPath
   }
 
-  const handlerPath = path.join(functionPath, `${path.basename(functionPath)}.js`)
-  if (!fs.existsSync(handlerPath)) {
-    return
+  let handlerPath
+  const indexHandlerPath = path.join(functionPath, `index.js`)
+  const namedHandlerPath = path.join(functionPath, `${path.basename(functionPath)}.js`)
+
+  if (fs.existsSync(namedHandlerPath)) {
+    handlerPath = namedHandlerPath
+  }
+  if (fs.existsSync(indexHandlerPath) && !fs.existsSync(namedHandlerPath)) {
+    handlerPath = indexHandlerPath
   }
   return handlerPath
 }


### PR DESCRIPTION
**- Summary**

Per the [Build with Javascript documentation](https://docs.netlify.com/functions/build-with-javascript/), functions ought to support the following naming formats:

- my_functions/functionname.js
- my_functions/functionname/functionname.js
- my_functions/functionname/index.js

Currently, this works perfectly fine on Netlify hosted production environments, but fails when running `netlify dev` via the CLI.

For more details on how to replicate this problem, including a minimal reproduction, please see this [support thread](https://community.netlify.com/t/netlify-dev-function-returns-404-when-using-functions-functionname-index-js-syntax-instead-of-functions-functionname-js/24124/2) I created on the Community Forums.

**- Test plan**

1. I first tested some basic scenarios in a production environment hosted on Netlify to understand the expected behaviour when different naming conventions (and different combinations) are used, for example:

   ```
   .
   |-- my_functions
   |    |    |-- bob
   |    |    |    |-- bob.js
   |    |    |    |-- index.js
   |    |    |-- test
   |    |    |    |-- test.js
   |    |    |-- test2
   |    |    |    |-- index.js
   |    |    |-- test3
   |    |    |    |-- index.js
   |    |    |    |-- test3.js
   |    |    |-- hello-world.js
   ```

   This can be verified here: https://gatsby-cloud-netlify-functions.netlify.app/
   e.g. https://gatsby-cloud-netlify-functions.netlify.app/.netlify/functions/hello-world.js etc...

2. In the above scenarios, everything works as expected with the ambiguous cases being `bob` and `test3` where both `functionname/index.js` and `functionname/functionname.js` files exist. In these cases, the production environment takes the the named function file, if it exists, then the index file, if it exists AND the named function file doesn't exist.

   This behaviour can be confirmed here:
   Uses bob.js: https://gatsby-cloud-netlify-functions.netlify.app/.netlify/functions/bob
   Uses test3.js: https://gatsby-cloud-netlify-functions.netlify.app/.netlify/functions/test3


3. This PR reflects this behaviour in the local `netlify dev` environment.

4. Per [this conversation](https://github.com/netlify/cli/issues/694#issuecomment-716717020), there is a failing test for `should deploy edge handlers when directory exists` but all other tests appear to be passing fine (as far as I can see).

**- Description for the changelog**

Adds missing support for naming functions using the `my_functions/functionname/index.js` convention per official documentation.

**- A picture of a cute animal (not mandatory but encouraged)**

dog tax:
![IMG_0786](https://user-images.githubusercontent.com/39966887/97306832-5d257000-1835-11eb-9246-13dea136c0bb.JPG)
