### PR TITLE
Add `node/global-require` linting rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,10 +30,6 @@ module.exports = {
     // 'node/callback-return': 2,
     // 'node/global-require': 2,
     'node/global-require': 2,
-    // 'node/prefer-global/url-search-params': 2,
-    // 'node/prefer-global/url': 2,
-    // 'node/prefer-global/buffer': [2, 'never'],
-    // 'node/prefer-global/process': [2, 'never'],
 
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase', ignore: ['.*.md'] }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,11 @@ module.exports = {
     // 'node/no-sync': 2,
     // 'node/callback-return': 2,
     // 'node/global-require': 2,
+    'node/global-require': 2,
+    // 'node/prefer-global/url-search-params': 2,
+    // 'node/prefer-global/url': 2,
+    // 'node/prefer-global/buffer': [2, 'never'],
+    // 'node/prefer-global/process': [2, 'never'],
 
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase', ignore: ['.*.md'] }],

--- a/site/scripts/generate-command-data.js
+++ b/site/scripts/generate-command-data.js
@@ -11,6 +11,7 @@ module.exports = function generateCommandData() {
   const commands = globby.sync([`${commandsPath}/**/**.js`, `${netlifyDevPath}/**/**.js`])
 
   const allCommands = commands.map((file) => {
+    // eslint-disable-next-line node/global-require
     const data = require(file)
     const command = commandFromPath(file)
     const [parentCommand] = command.split(':')

--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 const execa = require('execa')
 
 const Command = require('../../utils/command')
-const { getEnvSettings } = require('../../utils/env')
+const { addEnvVariables, getEnvSettings } = require('../../utils/env')
 const {
   // NETLIFYDEV,
   NETLIFYDEVLOG,
@@ -17,7 +17,6 @@ class ExecCommand extends Command {
     if (site.id) {
       // just to show some visual response first
       this.log(`${NETLIFYDEVLOG} Checking your site's environment variables...`)
-      const { addEnvVariables } = require('../../utils/dev')
       await addEnvVariables(api, site)
     } else {
       this.log(

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -5,13 +5,15 @@ const process = require('process')
 const { flags: flagsLib } = require('@oclif/command')
 const boxen = require('boxen')
 const chalk = require('chalk')
+const StaticServer = require('static-server')
 const stripAnsiCc = require('strip-ansi-control-characters')
 const waitPort = require('wait-port')
 const which = require('which')
+const wrapAnsi = require('wrap-ansi')
 
 const Command = require('../../utils/command')
 const { serverSettings } = require('../../utils/detect-server')
-const { getEnvSettings } = require('../../utils/env')
+const { addEnvVariables, getEnvSettings } = require('../../utils/env')
 const { startLiveTunnel } = require('../../utils/live-tunnel')
 const { NETLIFYDEV, NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require('../../utils/logo')
 const openBrowser = require('../../utils/open-browser')
@@ -21,8 +23,6 @@ const { startForwardProxy } = require('../../utils/traffic-mesh')
 
 const startFrameworkServer = async function ({ settings, log, exit }) {
   if (settings.noCmd) {
-    const StaticServer = require('static-server')
-
     const server = new StaticServer({
       rootPath: settings.dist,
       name: 'netlify-dev',
@@ -100,7 +100,6 @@ const FRAMEWORK_PORT_TIMEOUT = 6e5
 
 const getAddonsUrlsAndAddEnvVariablesToProcessEnv = async ({ api, site, flags }) => {
   if (site.id && !flags.offline) {
-    const { addEnvVariables } = require('../../utils/dev')
     const addonUrls = await addEnvVariables(api, site)
     return addonUrls
   }
@@ -174,7 +173,7 @@ const BANNER_LENGTH = 70
 
 const printBanner = ({ url, log }) => {
   // boxen doesnt support text wrapping yet https://github.com/sindresorhus/boxen/issues/16
-  const banner = require('wrap-ansi')(chalk.bold(`${NETLIFYDEVLOG} Server now ready on ${url}`), BANNER_LENGTH)
+  const banner = wrapAnsi(chalk.bold(`${NETLIFYDEVLOG} Server now ready on ${url}`), BANNER_LENGTH)
 
   log(
     boxen(banner, {

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -165,6 +165,7 @@ const processPayloadFromFlag = function (payloadString) {
     if (pathexists) {
       try {
         // there is code execution potential here
+        // eslint-disable-next-line node/global-require
         payload = require(payloadpath)
         return payload
       } catch (error) {

--- a/src/functions-templates/js/fauna-crud/fauna-crud.js
+++ b/src/functions-templates/js/fauna-crud/fauna-crud.js
@@ -1,3 +1,9 @@
+const createRoute = require('./create')
+const deleteRoute = require('./delete')
+const readRoute = require('./read')
+const readAllRoute = require('./read-all')
+const updateRoute = require('./update')
+
 const handler = async (event, context) => {
   const path = event.path.replace(/\.netlify\/functions\/[^/]+/, '')
   const segments = path.split('/').filter(Boolean)
@@ -6,13 +12,13 @@ const handler = async (event, context) => {
     case 'GET':
       // e.g. GET /.netlify/functions/fauna-crud
       if (segments.length === 0) {
-        return require('./read-all').handler(event, context)
+        return readAllRoute.handler(event, context)
       }
       // e.g. GET /.netlify/functions/fauna-crud/123456
       if (segments.length === 1) {
         const [id] = segments
         event.id = id
-        return require('./read').handler(event, context)
+        return readRoute.handler(event, context)
       }
       return {
         statusCode: 500,
@@ -22,13 +28,13 @@ const handler = async (event, context) => {
 
     case 'POST':
       // e.g. POST /.netlify/functions/fauna-crud with a body of key value pair objects, NOT strings
-      return require('./create').handler(event, context)
+      return createRoute.handler(event, context)
     case 'PUT':
       // e.g. PUT /.netlify/functions/fauna-crud/123456 with a body of key value pair objects, NOT strings
       if (segments.length === 1) {
         const [id] = segments
         event.id = id
-        return require('./update').handler(event, context)
+        return updateRoute.handler(event, context)
       }
       return {
         statusCode: 500,
@@ -40,7 +46,7 @@ const handler = async (event, context) => {
       if (segments.length === 1) {
         const [id] = segments
         event.id = id
-        return require('./delete').handler(event, context)
+        return deleteRoute.handler(event, context)
       }
       return {
         statusCode: 500,

--- a/src/functions-templates/js/fauna-graphql/sync-schema.js
+++ b/src/functions-templates/js/fauna-graphql/sync-schema.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 const { Buffer } = require('buffer')
+const fs = require('fs')
+const path = require('path')
 const process = require('process')
+
+const fetch = require('node-fetch')
 
 /* sync GraphQL schema to your FaunaDB account - use with `netlify dev:exec <path-to-this-file>` */
 const createFaunaGraphQL = function () {
@@ -9,9 +13,6 @@ const createFaunaGraphQL = function () {
   }
   console.log('Upload GraphQL Schema!')
 
-  const fetch = require('node-fetch')
-  const fs = require('fs')
-  const path = require('path')
   // name of your schema file
   const dataString = fs.readFileSync(path.join(__dirname, 'schema.graphql')).toString()
 

--- a/src/functions-templates/js/url-shortener/url-shortener.js
+++ b/src/functions-templates/js/url-shortener/url-shortener.js
@@ -1,3 +1,6 @@
+const generateRoute = require('./generate-route')
+const getRoute = require('./get-route')
+
 const handler = (event, context, callback) => {
   const path = event.path.replace(/\.netlify\/functions\/[^/]+/, '')
   const segments = path.split('/').filter(Boolean)
@@ -6,10 +9,10 @@ const handler = (event, context, callback) => {
   switch (event.httpMethod) {
     case 'GET':
       // e.g. GET /.netlify/functions/url-shortener
-      return require('./get-route').handler(event, context, callback)
+      return getRoute(event, context, callback)
     case 'POST':
       // e.g. POST /.netlify/functions/url-shortener
-      return require('./generate-route').handler(event, context, callback)
+      return generateRoute(event, context, callback)
     case 'PUT':
       // your code here
       return

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -4,6 +4,7 @@ const { format, inspect } = require('util')
 
 const resolveConfig = require('@netlify/config')
 const { Command, flags: flagsLib } = require('@oclif/command')
+const oclifParser = require('@oclif/parser')
 const merge = require('lodash.merge')
 const argv = require('minimist')(process.argv.slice(2))
 const API = require('netlify')
@@ -177,7 +178,7 @@ class BaseCommand extends Command {
     // enrich with flags here
     opts.flags = { ...opts.flags, ...globalFlags }
 
-    return require('@oclif/parser').parse(args, {
+    return oclifParser.parse(args, {
       context: this,
       ...opts,
     })

--- a/src/utils/detect-functions-builder.js
+++ b/src/utils/detect-functions-builder.js
@@ -1,10 +1,12 @@
+const fs = require('fs')
 const path = require('path')
 
 const detectFunctionsBuilder = async function (projectDir) {
-  const detectors = require('fs')
+  const detectors = fs
     .readdirSync(path.join(__dirname, '..', 'function-builder-detectors'))
     // only accept .js detector files
     .filter((filename) => filename.endsWith('.js'))
+    // eslint-disable-next-line node/global-require
     .map((det) => require(path.join(__dirname, '..', `function-builder-detectors/${det}`)))
 
   for (const detector of detectors) {

--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -6,6 +6,7 @@ const chalk = require('chalk')
 const fuzzy = require('fuzzy')
 const getPort = require('get-port')
 const inquirer = require('inquirer')
+const inquirerAutocompletePrompt = require('inquirer-autocomplete-prompt')
 
 const { NETLIFYDEVLOG, NETLIFYDEVWARN } = require('./logo')
 
@@ -47,8 +48,7 @@ const serverSettings = async (devConfig, flags, projectDir, log) => {
       settings.args = chooseDefaultArgs(settings.possibleArgsArrs)
     } else if (settingsArr.length > 1) {
       /** multiple matching detectors, make the user choose */
-      // lazy loading on purpose
-      inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
+      inquirer.registerPrompt('autocomplete', inquirerAutocompletePrompt)
       const scriptInquirerOptions = formatSettingsArrForInquirer(settingsArr)
       const { chosenSetting } = await inquirer.prompt({
         name: 'chosenSetting',
@@ -210,6 +210,7 @@ const DEFAULT_STATIC_PORT = 3999
 
 const loadDetector = function (detectorName) {
   try {
+    // eslint-disable-next-line node/global-require
     return require(path.join(__dirname, '..', 'detectors', detectorName))
   } catch (error) {
     throw new Error(

--- a/src/utils/init/config-manual.js
+++ b/src/utils/init/config-manual.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 const inquirer = require('inquirer')
 
 const { makeNetlifyTOMLtemplate } = require('./netlify-toml-template')
@@ -40,8 +43,6 @@ module.exports = async function configManual(ctx, site, repo) {
     },
   ])
 
-  const fs = require('fs')
-  const path = require('path')
   const tomlpath = path.join(ctx.netlify.site.root, 'netlify.toml')
   const tomlDoesNotExist = !fs.existsSync(tomlpath)
   if (tomlDoesNotExist && (!ctx.netlify.config || Object.keys(ctx.netlify.config).length === 0)) {

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1,5 +1,6 @@
 // Handlers are meant to be async outside tests
 /* eslint-disable require-await */
+const http = require('http')
 const path = require('path')
 const process = require('process')
 
@@ -848,8 +849,6 @@ testMatrix.forEach(({ args }) => {
       await builder.buildAsync()
 
       await withDevServer({ cwd: builder.directory, args }, async (server) => {
-        // we use http.request since fetch automatically sends a content-type header
-        const http = require('http')
         const options = {
           host: server.host,
           port: server.port,


### PR DESCRIPTION
This adds the [`node/global-require`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/global-require.md) ESLint rule.

We probably could remove more dynamic requires (currently marked as linting exceptions in this PR), but this would lead to too much refactoring for the moment.

A few dynamic requires had comments "lazily evaluated on purpose", but I don't see any actual good purpose for doing so since those libraries do not perform any logic on `require()` and are fairly small/fast to load.