### PR TITLE
Upgrade `@netlify/eslint-config-node`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,35 +1,23 @@
 const { overrides } = require('@netlify/eslint-config-node')
 
 module.exports = {
-  extends: ['@netlify/eslint-config-node', 'plugin:node/recommended'],
+  extends: '@netlify/eslint-config-node',
   rules: {
-    'node/handle-callback-err': 2,
-    'node/no-new-require': 2,
-    'node/exports-style': 2,
-    'node/file-extension-in-import': 2,
-    'node/no-mixed-requires': 2,
-    // Browser globals should not use `require()`. Non-browser globals should
-    'node/prefer-global/console': 2,
-    'node/prefer-global/buffer': [2, 'never'],
-    'node/prefer-global/process': [2, 'never'],
-    // TODO: enable after dropping support for Node <10.0.0
-    'node/prefer-global/url-search-params': 0,
-    'node/prefer-global/url': 0,
-    // TODO: enable after dropping support for Node <11.0.0
-    'node/prefer-global/text-decoder': 0,
-    'node/prefer-global/text-encoder': 0,
-    // TODO: enable after dropping support for Node <11.4.0
-    'node/prefer-promises/fs': 0,
-    'node/prefer-promises/dns': 0,
-    // This does not work well in a monorepo
-    'node/shebang': 0,
-
-    // TODO: enable this
+    // Those rules from @netlify/eslint-config-node are currently disabled
+    // TODO: remove
+    'class-methods-use-this': 0,
+    complexity: 0,
+    'max-depth': 0,
+    'max-lines': 0,
+    'max-lines-per-function': 0,
+    'max-nested-callbacks': 0,
+    'max-statements': 0,
+    'no-param-reassign': 0,
     'no-process-exit': 0,
-    // 'node/no-sync': 2,
-    'node/callback-return': 2,
-    // 'node/global-require': 2,
-    'node/global-require': 2,
+    'fp/no-mutating-methods': 0,
+    'fp/no-mutation': 0,
+    'import/max-dependencies': 0,
+    'node/no-sync': 0,
 
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase', ignore: ['.*.md'] }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,9 +1487,9 @@
       }
     },
     "@netlify/eslint-config-node": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@netlify/eslint-config-node/-/eslint-config-node-0.2.7.tgz",
-      "integrity": "sha512-xU98jNwhla2DmBtupMWuQJDcjklRfNafCbvKFSCGExjV5QkuvVEKtm+bLuTjD3a/CXHNQx4Y/unzDaxmPdgLAg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/eslint-config-node/-/eslint-config-node-0.3.0.tgz",
+      "integrity": "sha512-rGS28SewtuwWHME28nqJKQSOkt6s68C0G3z8unKM99P2UBDHJQC9e8fBotx8cWE5FHMGQf9OZ6cF2bwOXYvnzQ==",
       "dev": true,
       "requires": {
         "babel-eslint": "^10.1.0",
@@ -16149,9 +16149,9 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
+      "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
       "dev": true
     },
     "triple-beam": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@netlify/eslint-config-node": "^0.2.6",
+    "@netlify/eslint-config-node": "^0.3.0",
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "auto-changelog": "^2.0.0",

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -134,7 +134,6 @@ class FunctionsInvokeCommand extends Command {
         try {
           // data = response.json();
           data = JSON.parse(data)
-          // eslint-disable-next-line no-empty
         } catch (error) {}
         return data
       })
@@ -275,7 +274,6 @@ const tryParseJSON = function (jsonString) {
     if (parsedValue && typeof parsedValue === 'object') {
       return parsedValue
     }
-    // eslint-disable-next-line no-empty
   } catch (error) {}
 
   return false


### PR DESCRIPTION
This upgrades `@netlify/eslint-config-node`.
This takes an approach slightly different from the one commented in https://github.com/netlify/cli/pull/1472#discussion_r512653424, to decrease the amount of PRs and back-and-forth.

Instead, `@netlify/eslint-config-node` [now contains](https://github.com/netlify/eslint-config-node/commit/dd7f829536d99d2e6305f6b80e6a1156b1f00c41) all the rules we might want to enable. In Netlify Build, all those rules currently work. In the CLI, there are a few rules that require additional refactoring, so they are explicitly disabled. We can fix those one at a time. If it turns out a specific rule is to much of a problem, or we want to change rule options, we can do it directly on `@netlify/eslint-config-node`, then make a new release.