### PR TITLE
Release Tarball to Github Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish Release Asset
+
+on:
+  push:
+#    tags:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: npm ci
+      - name: Build tarball
+        # does not bundle node
+        run: npx oclif-dev pack --targets=
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(cat package.json | jq --raw .version)
+          echo "::set-output name=tag::${VERSION}"
+      - name: Create release if not exists
+        # ignore failures if the release already exists
+        run: gh release create v${{ steps.version.tag }}.ci-test || true
+      - name: Upload release asset
+        run: |
+          gh release upload --clobber v${{ steps.version.tag }}.ci-test \
+          dist/netlify-v${{ steps.version.tag }}/netlify-v${{ steps.version.tag }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Publish Release Asset
 on:
   push:
     tags:
+      - '*'
 
 env:
   GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish Release Asset
 
 on:
   push:
-#    tags:
+    tags:
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -26,8 +26,8 @@ jobs:
           echo "::set-output name=tag::${VERSION}"
       - name: Create release if not exists
         # ignore failures if the release already exists
-        run: gh release create v${{ steps.version.outputs.tag }}.ci-test || true
+        run: gh release create v${{ steps.version.outputs.tag }} || true
       - name: Upload release asset
         run: |
-          gh release upload --clobber v${{ steps.version.outputs.tag }}.ci-test \
+          gh release upload v${{ steps.version.outputs.tag }} \
           'dist/netlify-v${{ steps.version.outputs.tag }}/netlify-v${{ steps.version.outputs.tag }}.tar.gz#netlify-cli.tar.gz'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION=$(cat package.json | jq --raw .version)
+          VERSION=$(cat package.json | jq --raw-output .version)
           echo "::set-output name=tag::${VERSION}"
       - name: Create release if not exists
         # ignore failures if the release already exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
           echo "::set-output name=tag::${VERSION}"
       - name: Create release if not exists
         # ignore failures if the release already exists
-        run: gh release create v${{ steps.version.tag }}.ci-test || true
+        run: gh release create v${{ steps.version.outputs.tag }}.ci-test || true
       - name: Upload release asset
         run: |
-          gh release upload --clobber v${{ steps.version.tag }}.ci-test \
-          dist/netlify-v${{ steps.version.tag }}/netlify-v${{ steps.version.tag }}.tar.gz
+          gh release upload --clobber v${{ steps.version.outputs.tag }}.ci-test \
+          dist/netlify-v${{ steps.version.outputs.tag }}/netlify-v${{ steps.version.outputs.tag }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
 #    tags:
 
+env:
+  GITHUB_TOKEN: ${{ github.token }}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Upload release asset
         run: |
           gh release upload --clobber v${{ steps.version.outputs.tag }}.ci-test \
-          dist/netlify-v${{ steps.version.outputs.tag }}/netlify-v${{ steps.version.outputs.tag }}.tar.gz
+          'dist/netlify-v${{ steps.version.outputs.tag }}/netlify-v${{ steps.version.outputs.tag }}.tar.gz#netlify-cli.tar.gz'


### PR DESCRIPTION
**- Summary**

In order to have a single asset that can be downloaded i decided to make a workflow that uses `oclif-dev pack` which is recommended by oclif and actively used by Heroku for their CLI.

Downside: This will include the traffic-mesh agent for linux, because it's built on linux. For anyone who wants to use `netlify dev` i'd recommend to not use those tarballs.

It will try to create a release for the version in the package json, but is fine if there already is one.

**- Test plan**

Testing in CI

Run where the release did not exist: https://github.com/netlify/cli/runs/1349748657
Run where the release already existed: https://github.com/netlify/cli/runs/1349776403
Test release: https://github.com/netlify/cli/releases/tag/v2.67.2.ci-test

**- Description for the changelog**

Release as tarball to Github

**- A picture of a cute animal (not mandatory but encouraged)**

[![](https://source.unsplash.com/3Xd5j9-drDA/600x400)](https://unsplash.com/photos/3Xd5j9-drDA)