### PR TITLE
github tools: fix fossa workflow file

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -19,16 +19,12 @@ jobs:
         run: |-
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
           fossa init
-          echo ::set-env name=line_number::$(grep -n "project" .fossa.yml | cut -f1 -d:)
+      - name: Set env
+        run: echo "line_number=$(grep -n "project" .fossa.yml | cut -f1 -d:)" >> $GITHUB_ENV
       - name: Configuration
         run: |-
           sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
-      - name: Set env for unused_go/hello-world
-        run: |-
-          echo ::set-env name=unused_go_line_number::$(grep -m 1 -n "unused_go/hello-world" .fossa.yml | cut -f1 -d:)
-          echo ::set-env name=unused_go_last_line_number::$(grep -n "unused_go/hello-world" .fossa.yml | tail -1 | cut -f1 -d:)
-      - name: Remove unused_go/hello-world module
-        run: sed -i "${unused_go_line_number},${unused_go_last_line_number}d" .fossa.yml
+          cat .fossa.yml
       - name: Upload dependencies
         run: fossa analyze --debug
         env:


### PR DESCRIPTION
Updates github actions fossa workflow to use environment files instead of deprecated set-env command.