### PR TITLE
feat: default to XDG spec for global config

### DIFF
--- a/src/utils/global-config.js
+++ b/src/utils/global-config.js
@@ -1,7 +1,11 @@
+const fs = require('fs')
+
 const Configstore = require('configstore')
 const { v4: uuidv4 } = require('uuid')
 
 const { getPathInHome } = require('../lib/settings')
+
+const CONFIG_NAME = 'netlify'
 
 const globalConfigDefaults = {
   /* disable stats from being sent to Netlify */
@@ -10,8 +14,16 @@ const globalConfigDefaults = {
   cliId: uuidv4(),
 }
 
+const legacyConfigPath = getPathInHome(['config.json'])
+const legacyConfigExists = fs.existsSync(legacyConfigPath)
+
+// Configuration location can be:
+// - ~/.netlify/config
+// - $XDG_CONFIG_HOME/netlify/config.json
+// - ~/.config/netlify/config.json
 const globalConfigOptions = {
-  configPath: getPathInHome(['config.json']),
+  configPath: legacyConfigExists ? legacyConfigPath : undefined,
+  globalConfigPath: true,
 }
 
-module.exports = new Configstore(null, globalConfigDefaults, globalConfigOptions)
+module.exports = new Configstore(CONFIG_NAME, globalConfigDefaults, globalConfigOptions)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Thank you for making tools with slick dx(love the branch previews)! I was looking into #526 as a first issue 🎉  , which requests the [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for the global netlify configuration. In other words use to `~/.config/netlify ...` instead of `~/.netlify/config.json`.

This PR suggests using `~/.netlify/config.json` if it exists. Otherwise configure `configstore` to place the config in `~/.config/netlify/config.json` or `$XDG_CONFIG_HOME/netlify/config.json`. I'm not fully happy with this plan, so I'm open to suggestions.

If `config.json` is retrieved in more places than the netlify cli([source](https://github.com/netlify/cli/blob/c704e22269a806b99adef9633fb1e473b5bbc8f4/src/utils/global-config.js#L13-L17)), then I'm happy to add that to this PR if possible! Also if the `~/.netlify` folder is used for more files, I recommend closing this PR and discussing the feasibility on #526 . I also worry about documentation, testing, and code style. Please let me know if there's something I missed.

Closes #526

<details><summary>My understanding of netlify configurations(not necessary to look at)</summary>
To frame the problem, there are three different configurations that I've come across: `netlify.toml`, `.netlify/config.json`, and `.netlify/state.json`. As I understand, their functions are:

* [`netlify.toml`](https://docs.netlify.com/configure-builds/file-based-configuration/): build settings(ex: use `npm run` vs `jekyll build`), deploy settings, and env variables
* `~/.netlify/config.json`: global netlify state, such as userId and auth tokens
* `.netlify/state.json`: local netlify state, such as siteId

Their path resolution: 

* `netlify.toml`: provided through flag or [source](https://github.com/netlify/build/blob/0b965ae2b1a1cc57f4724b1e18947f3aed6de891/packages/config/src/path.js#L16-L27)
* `~/.netlify/config.json`: set to `{os.homedir()}/.netlify/config.json` using configstore's [`configPath`](https://github.com/yeoman/configstore#configpath) [source](https://github.com/netlify/cli/blob/c704e22269a806b99adef9633fb1e473b5bbc8f4/src/utils/global-config.js#L13-L17)
* `.netlify/state.json`: searched for up from `cwd` like [node module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html#how-nodejs-resolves-modules)
([source](https://github.com/netlify/cli/blob/c704e22269a806b99adef9633fb1e473b5bbc8f4/src/utils/state-config.js#L22))
</details>

**- Test plan**

I can add a test that uses [`mock-fs`](https://www.npmjs.com/package/mock-fs), though we may run into issues with mock-fs not playing nice with tests using node's `fs` (https://github.com/tschaub/mock-fs/issues/103) and I vaguely remember having difficulty across os's.

https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/lib/exec-fetcher.test.js#L16-L18

I've run locally, though I don't consider that worth much for maintainability, so I'd love suggestions here!

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

feat: default to XDG spec for global config when `~/.netlify/config.json` doesn't exist.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
<details><summary>༼ つ ◕_◕ ༽つ</summary>
<img src="https://i.ytimg.com/vi/RQkWvoES_uQ/maxresdefault.jpg"/>
</details>