### PR TITLE
test: don't run edge handlers deploy if the account doesn't support it

### DIFF
--- a/tests/command.addons.test.js
+++ b/tests/command.addons.test.js
@@ -10,7 +10,7 @@ const siteName = generateSiteName('netlify-test-addons-')
 
 if (process.env.IS_FORK !== 'true') {
   test.before(async (t) => {
-    const siteId = await createLiveTestSite(siteName)
+    const { siteId } = await createLiveTestSite(siteName)
     const builder = createSiteBuilder({ siteName: 'site-with-addons' })
     await builder.buildAsync()
 

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -67,7 +67,7 @@ const getArgsFromState = function (state) {
 
 if (process.env.IS_FORK !== 'true') {
   test.before(async (t) => {
-    const siteId = await createLiveTestSite(siteName)
+    const { siteId } = await createLiveTestSite(siteName)
     const builder = createSiteBuilder({ siteName: 'site-with-env-vars' })
       .withEnvFile({
         path: ENV_FILE_NAME,

--- a/tests/utils/create-live-test-site.js
+++ b/tests/utils/create-live-test-site.js
@@ -23,7 +23,8 @@ const createLiveTestSite = async function (siteName) {
   if (!Array.isArray(accounts) || accounts.length <= 0) {
     throw new Error(`Can't find suitable account to create a site`)
   }
-  const accountSlug = accounts[0].slug
+  const [account] = accounts
+  const accountSlug = account.slug
   console.log(`Using account ${accountSlug} to create site: ${siteName}`)
   const cliResponse = await callCli(['sites:create', '--name', siteName, '--account-slug', accountSlug])
 
@@ -36,7 +37,7 @@ const createLiveTestSite = async function (siteName) {
   if (matches && Object.prototype.hasOwnProperty.call(matches, 1) && matches[1]) {
     const [, siteId] = matches
     console.log(`Done creating site ${siteName} for account '${accountSlug}'. Site Id: ${siteId}`)
-    return siteId
+    return { siteId, account }
   }
 
   throw new Error(`Failed creating site: ${cliResponse}`)


### PR DESCRIPTION
This test is failing for most contributors since the Edge Handlers are in preview and not enabled for most accounts.
Added a small check to only run it if the account supports it