### PR TITLE
fix(command-dev): warn when background functions are not supported

### DIFF
--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -6,12 +6,13 @@ const { getSiteInformation, addEnvVariables } = require('../../utils/dev')
 class ExecCommand extends Command {
   async run() {
     const { log, warn, error, netlify } = this
-    const { site, api } = netlify
+    const { site, api, siteInfo } = netlify
     const { teamEnv, addonsEnv, siteEnv, dotFilesEnv } = await getSiteInformation({
       api,
       site,
       warn,
       error,
+      siteInfo,
     })
     await addEnvVariables({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv })
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -169,7 +169,7 @@ class DevCommand extends Command {
     this.log(`${NETLIFYDEV}`)
     const { error: errorExit, log, warn, exit } = this
     const { flags } = this.parse(DevCommand)
-    const { api, site, config } = this.netlify
+    const { api, site, config, siteInfo } = this.netlify
     config.dev = { ...config.dev }
     config.build = { ...config.build }
     const devConfig = {
@@ -180,12 +180,13 @@ class DevCommand extends Command {
       ...flags,
     }
 
-    const { addonsUrls, teamEnv, addonsEnv, siteEnv, dotFilesEnv } = await getSiteInformation({
+    const { addonsUrls, teamEnv, addonsEnv, siteEnv, dotFilesEnv, siteUrl, capabilities } = await getSiteInformation({
       flags,
       api,
       site,
       warn,
       error: errorExit,
+      siteInfo,
     })
 
     await addEnvVariables({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv })
@@ -198,7 +199,15 @@ class DevCommand extends Command {
       exit(1)
     }
 
-    await startFunctionsServer({ settings, site, log, warn, errorExit, siteInfo: this.netlify.cachedConfig.siteInfo })
+    await startFunctionsServer({
+      settings,
+      site,
+      log,
+      warn,
+      errorExit,
+      siteUrl,
+      capabilities,
+    })
     await startFrameworkServer({ settings, log, exit })
 
     let url = await startProxyServer({ flags, settings, site, log, exit, addonsUrls })

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -369,12 +369,13 @@ const createFunctionAddon = async function ({ api, addons, siteId, addonName, si
 
 const injectEnvVariables = async ({ context }) => {
   const { log, warn, error, netlify } = context
-  const { api, site } = netlify
+  const { api, site, siteInfo } = netlify
   const { teamEnv, addonsEnv, siteEnv, dotFilesEnv } = await getSiteInformation({
     api,
     site,
     warn,
     error,
+    siteInfo,
   })
   await addEnvVariables({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv })
 }

--- a/src/lib/account.js
+++ b/src/lib/account.js
@@ -1,0 +1,18 @@
+const dotProp = require('dot-prop')
+
+const supportsBooleanCapability = (account, capability) => {
+  return dotProp.get(account, `capabilities.${capability}.included`)
+}
+
+const supportsEdgeHandlers = (account) => {
+  return supportsBooleanCapability(account, 'edge_handlers')
+}
+
+const supportsBackgroundFunctions = (account) => {
+  return supportsBooleanCapability(account, 'background_functions')
+}
+
+module.exports = {
+  supportsBackgroundFunctions,
+  supportsEdgeHandlers,
+}

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -4,12 +4,13 @@ const { getSiteInformation } = require('../utils/dev')
 
 const getBuildEnv = async ({ context }) => {
   const { warn, error, netlify } = context
-  const { site, api } = netlify
+  const { site, api, siteInfo } = netlify
   const { teamEnv, addonsEnv, siteEnv } = await getSiteInformation({
     api,
     site,
     warn,
     error,
+    siteInfo,
   })
   const env = { ...teamEnv, ...addonsEnv, ...siteEnv }
   return env

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -54,7 +54,7 @@ class BaseCommand extends Command {
     const state = new StateConfig(cwd)
 
     const cachedConfig = await this.getConfig(cwd, state, token)
-    const { configPath, config, buildDir } = cachedConfig
+    const { configPath, config, buildDir, siteInfo } = cachedConfig
 
     const { flags } = this.parse(BaseCommand)
     const agent = await getAgent({
@@ -85,6 +85,8 @@ class BaseCommand extends Command {
           state.set('siteId', id)
         },
       },
+      // Site information retrieved using the API
+      siteInfo,
       // Configuration from netlify.[toml/yml]
       config,
       // Used to avoid calling @neltify/config again

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -2,6 +2,9 @@ const process = require('process')
 
 const fromEntries = require('@ungap/from-entries')
 const chalk = require('chalk')
+const isEmpty = require('lodash.isempty')
+
+const { supportsBackgroundFunctions } = require('../lib/account')
 
 const { loadDotEnvFiles } = require('./dot-env')
 const { NETLIFYDEVLOG } = require('./logo')
@@ -9,21 +12,16 @@ const { NETLIFYDEVLOG } = require('./logo')
 const ERROR_CALL_TO_ACTION =
   "Double-check your login status with 'netlify status' or contact support with details of your error."
 
-const getSiteData = async ({ api, site, failAndExit }) => {
-  try {
-    const siteData = await api.getSite({ siteId: site.id })
-    return siteData
-  } catch (error) {
-    failAndExit(
-      `Failed retrieving site data for site ${chalk.yellow(site.id)}: ${error.message}. ${ERROR_CALL_TO_ACTION}`,
-    )
+const validateSiteInfo = ({ site, siteInfo, failAndExit }) => {
+  if (isEmpty(siteInfo)) {
+    failAndExit(`Failed retrieving site information for site ${chalk.yellow(site.id)}. ${ERROR_CALL_TO_ACTION}`)
   }
 }
 
 const getAccounts = async ({ api, failAndExit }) => {
   try {
-    const account = await api.listAccountsForUser()
-    return account
+    const accounts = await api.listAccountsForUser()
+    return accounts
   } catch (error) {
     failAndExit(`Failed retrieving user account: ${error.message}. ${ERROR_CALL_TO_ACTION}`)
   }
@@ -38,50 +36,64 @@ const getAddons = async ({ api, site, failAndExit }) => {
   }
 }
 
-const getAddonsInformation = ({ siteData, addons }) => {
-  const urls = fromEntries(addons.map((addon) => [addon.service_slug, `${siteData.ssl_url}${addon.service_path}`]))
+const getAddonsInformation = ({ siteInfo, addons }) => {
+  const urls = fromEntries(addons.map((addon) => [addon.service_slug, `${siteInfo.ssl_url}${addon.service_path}`]))
   const env = Object.assign({}, ...addons.map((addon) => addon.env))
   return { urls, env }
 }
 
-const getTeamEnv = ({ siteData, accounts }) => {
-  const siteAccount = accounts.find((account) => account.slug === siteData.account_slug)
-  if (siteAccount && siteAccount.site_env) {
-    return siteAccount.site_env
+const getSiteAccount = ({ siteInfo, accounts, warn }) => {
+  const siteAccount = accounts.find((account) => account.slug === siteInfo.account_slug)
+  if (!siteAccount) {
+    warn(`Could not find account for site '${siteInfo.name}' with account slug '${siteInfo.account_slug}'`)
+    return {}
+  }
+  return siteAccount
+}
+
+const getTeamEnv = ({ account }) => {
+  if (account.site_env) {
+    return account.site_env
   }
   return {}
 }
 
-const getSiteEnv = ({ siteData }) => {
-  if (siteData.build_settings && siteData.build_settings.env) {
-    return siteData.build_settings.env
+const getSiteEnv = ({ siteInfo }) => {
+  if (siteInfo.build_settings && siteInfo.build_settings.env) {
+    return siteInfo.build_settings.env
   }
   return {}
 }
 
-const getSiteInformation = async ({ flags = {}, api, site, warn, error: failAndExit }) => {
+const getSiteInformation = async ({ flags = {}, api, site, warn, error: failAndExit, siteInfo }) => {
   if (site.id && !flags.offline) {
-    const [siteData, accounts, addons, dotFilesEnv] = await Promise.all([
-      getSiteData({ api, site, failAndExit }),
+    validateSiteInfo({ site, siteInfo, failAndExit })
+    const [accounts, addons, dotFilesEnv] = await Promise.all([
       getAccounts({ api, failAndExit }),
       getAddons({ api, site, failAndExit }),
       loadDotEnvFiles({ projectDir: site.root, warn }),
     ])
 
-    const { urls: addonsUrls, env: addonsEnv } = getAddonsInformation({ siteData, addons })
-    const teamEnv = getTeamEnv({ siteData, accounts })
-    const siteEnv = getSiteEnv({ siteData })
+    const { urls: addonsUrls, env: addonsEnv } = getAddonsInformation({ siteInfo, addons })
+    const account = getSiteAccount({ siteInfo, accounts, warn })
+    const teamEnv = getTeamEnv({ account })
+    const siteEnv = getSiteEnv({ siteInfo })
+
     return {
       addonsUrls,
       teamEnv,
       addonsEnv,
       siteEnv,
       dotFilesEnv,
+      siteUrl: siteInfo.ssl_url,
+      capabilities: {
+        backgroundFunctions: supportsBackgroundFunctions(account),
+      },
     }
   }
 
   const dotFilesEnv = await loadDotEnvFiles({ projectDir: site.root, warn })
-  return { addonsUrls: {}, teamEnv: {}, addonsEnv: {}, siteEnv: {}, dotFilesEnv }
+  return { addonsUrls: {}, teamEnv: {}, addonsEnv: {}, siteEnv: {}, dotFilesEnv, siteUrl: '', capabilities: {} }
 }
 
 // if first arg is undefined, use default, but tell user about it in case it is unintentional

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -1,10 +1,10 @@
 const process = require('process')
 
 const test = require('ava')
-const dotProp = require('dot-prop')
 const fetch = require('node-fetch')
 const omit = require('omit.js').default
 
+const { supportsEdgeHandlers } = require('../src/lib/account')
 const { getToken } = require('../src/utils/command')
 
 const callCli = require('./utils/call-cli')
@@ -93,12 +93,8 @@ if (process.env.IS_FORK !== 'true') {
   const EDGE_HANDLER_MIN_LENGTH = 50
   if (version >= EDGE_HANDLER_MIN_VERSION) {
     test.serial('should deploy edge handlers when directory exists', async (t) => {
-      const {
-        context: { account },
-      } = t
-      const supportsEdgeHandlers = dotProp.get(account, 'capabilities.edge_handlers.included')
-      if (!supportsEdgeHandlers) {
-        console.warn(`Skipping edge handlers deploy test for account ${account.slug}`)
+      if (!supportsEdgeHandlers(t.context.account)) {
+        console.warn(`Skipping edge handlers deploy test for account ${t.context.account.slug}`)
         return
       }
       await withSiteBuilder('site-with-public-folder', async (builder) => {

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -507,7 +507,7 @@ testMatrix.forEach(({ args }) => {
           'client-ip': '127.0.0.1',
           connection: 'close',
           host: `${server.host}:${server.port}`,
-          'content-length': '285',
+          'content-length': '289',
           'content-type': 'application/json',
           'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
           'x-forwarded-for': '::ffff:127.0.0.1',
@@ -534,8 +534,8 @@ testMatrix.forEach(({ args }) => {
                 value: 'thing',
               },
             ],
+            site_url: '',
           },
-          site: {},
         })
       })
     })


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1553
Also related to https://github.com/netlify/cli/issues/958

**- Test plan**

Tested locally with an account that supports background functions, and another one that doesn't

See example warning:
![image](https://user-images.githubusercontent.com/26760571/98954652-adbfed00-2506-11eb-8391-98f26c390628.png)

**- Description for the changelog**

Warn when background functions are not supported when `netlify dev` is invoked

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/26760571/98953754-bfed5b80-2505-11eb-83a3-5bcc8e43dc41.png)
