### PR TITLE
fix(command:sites:delete): don't print duplicate netlify in help

### DIFF
--- a/docs/commands/sites.md
+++ b/docs/commands/sites.md
@@ -65,7 +65,7 @@ This command will permanently delete the site on Netlify. Use with caution.
 **Usage**
 
 ```bash
-netlify sites:delete {site-id}
+netlify sites:delete
 ```
 
 **Arguments**

--- a/site/scripts/docs.js
+++ b/site/scripts/docs.js
@@ -108,11 +108,6 @@ const commandListSubCommandDisplay = function (commands) {
 
 const formatUsage = function (commandName, info) {
   const defaultUsage = `netlify ${commandName}`
-
-  if (commandName === 'sites:delete') {
-    // console.log(info)
-  }
-
   const usageString = info.usage || defaultUsage
   return `**Usage**
 

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -94,8 +94,6 @@ class SitesDeleteCommand extends Command {
   }
 }
 
-SitesDeleteCommand.usage = `netlify sites:delete {site-id}`
-
 SitesDeleteCommand.description = `Delete a site
 
 This command will permanently delete the site on Netlify. Use with caution.


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1555

Looks like this was an attempt to improve the docs of the `delete` command.
Not sure why we need a different doc format for it.
We could improve single argument commands by appending the argument to the command in the docs, but that should be done for all commands (and in a separate PR).

**- Test plan**

Run `netlify sites:delete --help`

**- Description for the changelog**

Don't print a duplicate `netlify` when running `netlify sites:delete --help`

**- A picture of a cute animal (not mandatory but encouraged)**

🐱 