### PR TITLE
fix(command-deploy): print relevant log error when background functions are not supported

### DIFF
--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -1,0 +1,23 @@
+const chalk = require('chalk')
+const dotProp = require('dot-prop')
+
+const RED_BACKGROUND = chalk.red('-background')
+const [PRO, BUSINESS, ENTERPRISE] = ['Pro', 'Business', 'Enterprise'].map((plan) => chalk.magenta(plan))
+const BACKGROUND_FUNCTIONS_WARNING = `A serverless function ending in \`${RED_BACKGROUND}\` was detected.
+Your team’s current plan doesn’t support Background Functions, which have names ending in \`${RED_BACKGROUND}\`.
+To be able to deploy this function successfully either:
+  - change the function name to remove \`${RED_BACKGROUND}\` and execute it synchronously
+  - upgrade your team plan to a level that supports Background Functions (${PRO}, ${BUSINESS}, or ${ENTERPRISE})
+`
+
+const messages = {
+  functions: {
+    backgroundNotSupported: BACKGROUND_FUNCTIONS_WARNING,
+  },
+}
+
+const getLogMessage = (key) => dotProp.get(messages, key, 'Missing Log Message Key')
+
+module.exports = {
+  getLogMessage,
+}

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -16,6 +16,8 @@ const multiparty = require('multiparty')
 const getRawBody = require('raw-body')
 const winston = require('winston')
 
+const { getLogMessage } = require('../lib/log')
+
 const { detectFunctionsBuilder } = require('./detect-functions-builder')
 const { getFunctions } = require('./get-functions')
 const { NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require('./logo')
@@ -168,18 +170,9 @@ const shouldBase64Encode = function (contentType) {
 
 const BASE_64_MIME_REGEXP = /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/i
 
-const RED_BACKGROUND = chalk.red('-background')
-const [PRO, BUSINESS, ENTERPRISE] = ['Pro', 'Business', 'Enterprise'].map((plan) => chalk.magenta(plan))
-const BACKGROUND_FUNCTIONS_WARNING = `A serverless function ending in \`${RED_BACKGROUND}\` was detected.
-Your team’s current plan doesn’t support Background Functions, which have names ending in \`${RED_BACKGROUND}\`.
-To be able to deploy this function successfully either:
-  - change the function name to remove \`${RED_BACKGROUND}\` and execute it synchronously
-  - upgrade your team plan to a level that supports Background Functions (${PRO}, ${BUSINESS}, or ${ENTERPRISE})
-`
-
 const validateFunctions = function ({ functions, capabilities, warn }) {
   if (!capabilities.backgroundFunctions && functions.some(({ isBackground }) => isBackground)) {
-    warn(BACKGROUND_FUNCTIONS_WARNING)
+    warn(getLogMessage('functions.backgroundNotSupported'))
   }
 }
 


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1569

**- Test plan**

See error message:
![image](https://user-images.githubusercontent.com/26760571/99538653-ee5fb080-29b5-11eb-88c0-2ae19ef59a6f.png)


**- Description for the changelog**

Print relevant error message when failing to deploy a background function to an account that doesn't support it

**- A picture of a cute animal (not mandatory but encouraged)**

🐼 
