### PR TITLE
fix(docs): change port to targetPort when framework is #custom

### DIFF
--- a/docs/netlify-dev.md
+++ b/docs/netlify-dev.md
@@ -109,7 +109,7 @@ Netlify Dev is meant to work with zero config for the majority of users, by usin
   functions = "functions" # netlify dev uses this directory to scaffold and serve your functions
   publish = "dist"
 
-# note: each of these fields are OPTIONAL, with an exception that when you're specifying "command" and "port", you must specify framework = "#custom"
+# note: each of these fields are OPTIONAL, with an exception that when you're specifying "command" and "targetPort", you must specify framework = "#custom"
 [dev]
   command = "yarn start" # Command to start your dev server
   targetPort = 3000 # The port for your application server, framework or site generator


### PR DESCRIPTION
Fixes the docs to match https://github.com/netlify/cli/blame/master/docs/netlify-dev.md#L151, https://github.com/netlify/cli/blob/8efe94e5fb38976c49f0cf1ee7c062de2853ca43/src/utils/detect-server.js#L78, https://github.com/netlify/cli/blob/8efe94e5fb38976c49f0cf1ee7c062de2853ca43/src/utils/detect-server.js#L82 and https://github.com/netlify/cli/pull/843#issue-405552392