### PR TITLE
fix(docs): add jwtSecret doc to dev section

### DIFF
--- a/docs/netlify-dev.md
+++ b/docs/netlify-dev.md
@@ -115,6 +115,7 @@ Netlify Dev is meant to work with zero config for the majority of users, by usin
   targetPort = 3000 # The port for your application server, framework or site generator
   port = 8888 # The port that the netlify dev will be accessible on
   publish = "dist" # The path to your static content folder
+  jwtSecret = "secret" # The secret used to verify tokens for JWT based redirects
   jwtRolePath = "app_metadata.authorization.roles" # Object path we should look for role values for JWT based redirects
   autoLaunch = true # a Boolean value that determines if Netlify Dev launches the local server address in your browser
 ```


### PR DESCRIPTION
Fixes the docs to add a missing `jwtSecret` configuration to the `dev` block.
Follow up on https://github.com/netlify/cli/pull/1545