### PR TITLE
refactor(command-init): remove duplicate call to getSite

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -135,8 +135,7 @@ git remote add origin https://github.com/YourUserName/RepoName.git
       this.error(repo.error)
     }
 
-    // TODO: remove siteInfo.id === undefined once https://github.com/netlify/build/pull/2081 is published
-    if (isEmpty(siteInfo) || siteInfo.id === undefined) {
+    if (isEmpty(siteInfo)) {
       const NEW_SITE = '+  Create & configure a new site'
       const EXISTING_SITE = '⇄  Connect this directory to an existing Netlify site'
 


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/958

**- Test plan**

Tested manually

**- Description for the changelog**

Use `siteInfo` from `@netlify/config` instead of calling `api.getSite`

**- A picture of a cute animal (not mandatory but encouraged)**

🐱 