### PR TITLE
Fix typo in the deploy `--alias` flag description

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -565,7 +565,7 @@ DeployCommand.flags = {
     exclusive: ['alias', 'branch'],
   }),
   alias: flagsLib.string({
-    description: "Specifies the alias for deployment. Useful for creating predictable deployment URL's",
+    description: 'Specifies the alias for deployment. Useful for creating predictable deployment URLs',
   }),
   branch: flagsLib.string({
     char: 'b',


### PR DESCRIPTION
**- Summary**
Small typo: "URL's" -> "URLs"
