### PR TITLE
Set CONTEXT when running Netlify Dev

### DIFF
--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -163,6 +163,7 @@ const addEnvVariables = ({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv }) => {
   })
 
   process.env.NETLIFY_DEV = 'true'
+  process.env.CONTEXT = 'dev'
 }
 
 module.exports = {


### PR DESCRIPTION
**- Summary**

In the last few months the addition of Build Plugins (particularly https://github.com/bencao/netlify-plugin-inline-functions-env) combined with the [deploy context env var](https://docs.netlify.com/configure-builds/environment-variables/#build-metadata) have made it possible for Functions to feel environment-agnostic a la:

```js
const contextualEnvVar = (v) => {
  const currentContext = process.env.CONTEXT
  const formattedContext = currentContext.replace('-', '_').toUpperCase()
  return process.env[`${formattedContext}_${v}`]
}

exports.handler = async _ => {
  return {
    statusCode: 200,
    body: JSON.stringify({
      status: contextualEnvVar('API_KEY')
    })
  }
}

```

I'll be writing up a post on this soon, but the premise is that I can set `PRODUCTION_API_KEY`, `DEPLOY_PREVIEW_API_KEY`, and `DEV_API_KEY` all in the Netlify Admin UI then my function will correctly get the key value for each environment using `contextualEnvVar('API_KEY')` as shown above.

The ultimate result is that my Function will run with the correct ENV vars for each environment it's in, I can (securely) set ENV var _values_ via the Netlify Admin UI for all four environments (dev, deploy-preview, branch-preview, and production), and I can _easily_ override the dev key locally by just adding the key to my local `.env` file (adding `DEV_API_KEY` in this case).

This is really neat. Using Stripe as the canonical example, this structure would let me have my Stripe Prod and Testing keys configured safely in the Netlify Admin UI and feel good knowing that my local dev, deploy-previews, and production environments would be using the correct keys all the time.

This PR just adds `CONTEXT` = `dev` to the process thread when running netlify dev locally. Currently no `CONTEXT` is set and I think this just adds parity to Netlify's other environments where `CONTEXT` _is_ set.

**- Description for the changelog**

Add CONTEXT=dev to environment variables when running netlify dev

**- What else**

I currently have this working great on a micro testing site, Tenv (test env)! Here are a couple of `cURL`s to show:

`$ curl https://deploy-preview-2--tenv.netlify.app/.netlify/functions/output-env-var`

`$ curl https://tenv.netlify.app/.netlify/functions/output-env-var`

The site can be inspected as needed too. [tenv.netlify.app](https://tenv.netlify.app)

I believe this addition / workflow would also satisfy a [few](https://community.netlify.com/t/environment-variable-per-branch-for-lambda-functions/5009/14) different [community](https://community.netlify.com/t/netlify-functions-and-env-variables-from-netlify-toml/4404/12) requests.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/8585984/103278045-85962b80-4998-11eb-91a8-1239882355f3.png)

