### PR TITLE
Fix dependency error in docs site

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1989,6 +1989,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4148,6 +4157,12 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.5.11",
@@ -6382,6 +6397,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoassert": {
       "version": "1.1.0",
@@ -9948,7 +9968,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/site/package.json
+++ b/site/package.json
@@ -47,6 +47,7 @@
     "filter-obj": "^2.0.1",
     "map-obj": "^4.1.0",
     "markdown-magic": "^1.0.0",
+    "nan": "^2.14.2",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.0",
     "sane": "^4.1.0",


### PR DESCRIPTION
**- Summary**

When running the `site:build:install` command, I'm getting an error for a missing dependency: `nan`. This seems to be a problem with a transitive dependency, as reported in https://github.com/fsevents/fsevents/issues/320.

This PR removes that error by adding `nan` to the `devDependencies` list of the docs site.

**- Test plan**

Issue observed and solution verified in Node v12.20.0. Test suite running smoothly.

**- Description for the changelog**

Add nan to devDependencies of docs site

**- A picture of a cute animal (not mandatory but encouraged)**

![animals-cute-koala-bear-love-nature-Favim com-341180](https://user-images.githubusercontent.com/4162329/103757446-b0235c80-5008-11eb-80c6-ce18999925a0.jpg)

