### PR TITLE
Add logging for ignored env vars

### DIFF
--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -96,40 +96,71 @@ const getSiteInformation = async ({ flags = {}, api, site, warn, error: failAndE
   return { addonsUrls: {}, teamEnv: {}, addonsEnv: {}, siteEnv: {}, dotFilesEnv, siteUrl: '', capabilities: {} }
 }
 
-// if first arg is undefined, use default, but tell user about it in case it is unintentional
-const assignLoudly = function (optionalValue, defaultValue, tellUser) {
-  if (defaultValue === undefined) throw new Error('must have a defaultValue')
-  if (defaultValue !== optionalValue && optionalValue === undefined) {
-    tellUser(defaultValue)
-    return defaultValue
-  }
-  return optionalValue
-}
+// Convenience method for logging a message when an environment variable is overridden by another source (parent) with
+// a higher precedence.
+const logIgnoredEnvVar = ({ key, log, parentSource, source }) =>
+  log(
+    chalk.dim(
+      `${NETLIFYDEVLOG} Ignored ${chalk.bold(source)} env var: ${chalk.yellow(key)} (defined in ${parentSource})`,
+    ),
+  )
 
 const addEnvVariables = ({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv }) => {
+  const environment = new Map()
+
   for (const { file, env } of dotFilesEnv) {
     for (const key in env) {
-      const msg = () =>
-        log(`${NETLIFYDEVLOG} Injected ${chalk.green.bold(`${file} file`)} env var: ${chalk.yellow(key)}`)
-      process.env[key] = assignLoudly(process.env[key], env[key], msg)
+      const source = chalk.green.bold(`${file} file`)
+
+      if (environment.has(key)) {
+        logIgnoredEnvVar({ key, log, parentSource: environment.get(key).source, source })
+      } else {
+        environment.set(key, { source, value: env[key] })
+      }
     }
   }
 
   for (const key in siteEnv) {
-    const msg = () => log(`${NETLIFYDEVLOG} Injected ${chalk.blue.bold('build setting')} env var: ${chalk.yellow(key)}`)
-    process.env[key] = assignLoudly(process.env[key], siteEnv[key], msg)
+    const source = chalk.blue.bold('build setting')
+
+    if (environment.has(key)) {
+      logIgnoredEnvVar({ key, log, parentSource: environment.get(key).source, source })
+    } else {
+      environment.set(key, { source, value: siteEnv[key] })
+    }
   }
 
   for (const key in addonsEnv) {
-    const msg = () => log(`${NETLIFYDEVLOG} Injected ${chalk.yellow.bold('addon')} env var: ${chalk.yellow(key)}`)
-    process.env[key] = assignLoudly(process.env[key], addonsEnv[key], msg)
+    const source = chalk.yellow.bold('addon')
+
+    if (environment.has(key)) {
+      logIgnoredEnvVar({ key, log, parentSource: environment.get(key).source, source })
+    } else {
+      environment.set(key, { source, value: addonsEnv[key] })
+    }
   }
 
   for (const key in teamEnv) {
-    const msg = () =>
-      log(`${NETLIFYDEVLOG} Injected ${chalk.magenta.bold('shared build setting')} env var: ${chalk.yellow(key)}`)
-    process.env[key] = assignLoudly(process.env[key], teamEnv[key], msg)
+    const source = chalk.magenta.bold('shared build setting')
+
+    if (environment.has(key)) {
+      logIgnoredEnvVar({ key, log, parentSource: environment.get(key).source, source })
+    } else {
+      environment.set(key, { source, value: teamEnv[key] })
+    }
   }
+
+  environment.forEach(({ source, value }, key) => {
+    if (process.env[key] !== undefined) {
+      logIgnoredEnvVar({ key, log, parentSource: chalk.red('process'), source })
+
+      return
+    }
+
+    log(`${NETLIFYDEVLOG} Injected ${chalk.magenta.bold(source)} env var: ${chalk.yellow(key)}`)
+
+    process.env[key] = value
+  })
 
   process.env.NETLIFY_DEV = 'true'
 }

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -157,7 +157,7 @@ const addEnvVariables = ({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv }) => {
       return
     }
 
-    log(`${NETLIFYDEVLOG} Injected ${chalk.magenta.bold(source)} env var: ${chalk.yellow(key)}`)
+    log(`${NETLIFYDEVLOG} Injected ${chalk.bold(source)} env var: ${chalk.yellow(key)}`)
 
     process.env[key] = value
   })


### PR DESCRIPTION
**- Summary**

This PR adds logging messages that flag to the user whenever an environment variable they've defined is overridden by another variable with the same name defined somewhere with a higher precedence.

Closes #1598.

**- Test plan**

In this example, I've defined `NETLIFY_TEST_VAR` in four places (`.env` file, `.env.development` file, team-level environment, and site-level environment) and `TWITTER_SCREEN_NAME` in two (site-level environment and process level).

![Screenshot 2021-01-06 at 15 05 02](https://user-images.githubusercontent.com/4162329/103808109-5db95e80-504f-11eb-83b8-fefc20633d91.png)
<img width="654" alt="Screenshot 2021-01-06 at 16 04 29" src="https://user-images.githubusercontent.com/4162329/103808115-5eea8b80-504f-11eb-96ae-05900d5aad2d.png">


**- Description for the changelog**

Log overridden environment variables

**- A picture of a cute animal (not mandatory but encouraged)**

![acting-like-animals-dear-tumblr-im-bored](https://user-images.githubusercontent.com/4162329/103809810-ff41af80-5051-11eb-93e2-36c9c2210e7a.jpg)

