### PR TITLE
chore: remove netlify package rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,11 +5,6 @@
   masterIssue: true,
   packageRules: [
     {
-      packagePatterns: ['^@netlify', '^netlify'],
-      groupName: 'netlify packages',
-      schedule: null,
-    },
-    {
       // Those cannot be upgraded to a major version until we drop support for Node 8
       packageNames: [
         '@octokit/rest',


### PR DESCRIPTION
This is now part of the default config:
https://github.com/netlify/renovate-config/blob/9b7e2be6bd9bef2fc8546dd136891cf1ce8c6ed9/default.json#L19