### PR TITLE
Document: 37 character limit on alias flag

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -87,7 +87,7 @@ netlify deploy
 - `dir` (*string*) - Specify a folder to deploy
 - `functions` (*string*) - Specify a functions folder to deploy
 - `prod` (*boolean*) - Deploy to production
-- `alias` (*string*) - Specifies the alias for deployment. Useful for creating predictable deployment URLs
+- `alias` (*string*) - Specifies the alias for deployment. Useful for creating predictable deployment URLs. Maximum 37 characters.
 - `branch` (*string*) - Serves the same functionality as --alias. Deprecated and will be removed in future versions
 - `open` (*boolean*) - Open site after deploy
 - `message` (*string*) - A short message to include in the deploy log

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -565,7 +565,7 @@ DeployCommand.flags = {
     exclusive: ['alias', 'branch'],
   }),
   alias: flagsLib.string({
-    description: 'Specifies the alias for deployment. Useful for creating predictable deployment URLs',
+    description: 'Specifies the alias for deployment. Useful for creating predictable deployment URLs. Maximum 37 characters.',
   }),
   branch: flagsLib.string({
     char: 'b',

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -565,7 +565,8 @@ DeployCommand.flags = {
     exclusive: ['alias', 'branch'],
   }),
   alias: flagsLib.string({
-    description: 'Specifies the alias for deployment. Useful for creating predictable deployment URLs. Maximum 37 characters.',
+    description:
+      'Specifies the alias for deployment. Useful for creating predictable deployment URLs. Maximum 37 characters.',
   }),
   branch: flagsLib.string({
     char: 'b',


### PR DESCRIPTION
**- Summary**

Adding an alias of 38 characters or more leads to the site not being deployed to the desired URL but instead does not resolve. This is a hard issue to debug. Furthermore, other documentation should be updated to state this limitation

**- Test plan**

Read the docs

**- Description for the changelog**

- Update deploy.md and deploy.js reflect the 37 character limit 

https://imgur.com/L6NPukj
