### PR TITLE
Use environment variables from @netlify/config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,13 +1432,13 @@
       }
     },
     "@netlify/build": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-8.0.3.tgz",
-      "integrity": "sha512-ULtguXXvONPVD7P+Susz2ADP6BM+Mk4i3Ur7MfxdNpUYfgb66DBYH09lkrN2zvc8F1thx067HZ06xQ55g9UfvA==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-8.0.5.tgz",
+      "integrity": "sha512-rWBsKpxztjOjMpWHDTcVgDRFhSoDuczih8+U78U06XeCShtLIOb3JV+iDto+AXKNEzva4LXUczA50X+kwX5vZQ==",
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/cache-utils": "^1.0.6",
-        "@netlify/config": "^2.4.3",
+        "@netlify/config": "^3.0.1",
         "@netlify/functions-utils": "^1.3.4",
         "@netlify/git-utils": "^1.0.6",
         "@netlify/plugin-edge-handlers": "^1.8.0",
@@ -1488,6 +1488,34 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "@netlify/config": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-3.0.1.tgz",
+          "integrity": "sha512-lW+HGiDOfkcAUO3MhXcoLA7n1XnHtupO03gjZlcankksTrBOlkIMw2RFanptg6LAPqlW47cS0DHvU1sSkKyJCg==",
+          "requires": {
+            "@ungap/from-entries": "^0.2.1",
+            "array-flat-polyfill": "^1.0.1",
+            "chalk": "^3.0.0",
+            "deepmerge": "^4.2.2",
+            "execa": "^3.4.0",
+            "fast-safe-stringify": "^2.0.7",
+            "figures": "^3.2.0",
+            "filter-obj": "^2.0.1",
+            "find-up": "^4.1.0",
+            "indent-string": "^4.0.0",
+            "is-plain-obj": "^2.1.0",
+            "js-yaml": "^4.0.0",
+            "netlify": "^6.0.0",
+            "omit.js": "^2.0.2",
+            "p-locate": "^4.1.0",
+            "path-exists": "^4.0.0",
+            "path-type": "^4.0.0",
+            "toml": "^3.0.0",
+            "tomlify-j0.4": "^3.0.0",
+            "validate-npm-package-name": "^3.0.0",
+            "yargs": "^15.3.0"
+          }
+        },
         "@sindresorhus/is": {
           "version": "0.14.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1660,10 +1688,11 @@
       }
     },
     "@netlify/config": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-2.4.3.tgz",
-      "integrity": "sha512-Uz7Oo3tJP2VTgNgsJtRlwAhO5jTozkpNMCKALb814ssJKx7nE/4QvNxJPCQNBDXY9BSeXVIPfy0vMfshxatL+g==",
+      "version": "2.4.4-0",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-2.4.4-0.tgz",
+      "integrity": "sha512-qNZQo20z7Puoni99yA2KYZvcHBRBfWPoslJLBvueH+GMzS6C1k4cvRyxWdoNArB2xvLK9HnSnXOHHuW14ODlRQ==",
       "requires": {
+        "@ungap/from-entries": "^0.2.1",
         "array-flat-polyfill": "^1.0.1",
         "chalk": "^3.0.0",
         "deepmerge": "^4.2.2",
@@ -12956,6 +12985,74 @@
       "requires": {
         "@netlify/config": "^2.0.0",
         "lodash.isplainobject": "^4.0.6"
+      },
+      "dependencies": {
+        "@netlify/config": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/@netlify/config/-/config-2.4.3.tgz",
+          "integrity": "sha512-Uz7Oo3tJP2VTgNgsJtRlwAhO5jTozkpNMCKALb814ssJKx7nE/4QvNxJPCQNBDXY9BSeXVIPfy0vMfshxatL+g==",
+          "requires": {
+            "array-flat-polyfill": "^1.0.1",
+            "chalk": "^3.0.0",
+            "deepmerge": "^4.2.2",
+            "execa": "^3.4.0",
+            "fast-safe-stringify": "^2.0.7",
+            "figures": "^3.2.0",
+            "filter-obj": "^2.0.1",
+            "find-up": "^4.1.0",
+            "indent-string": "^4.0.0",
+            "is-plain-obj": "^2.1.0",
+            "js-yaml": "^4.0.0",
+            "netlify": "^6.0.0",
+            "omit.js": "^2.0.2",
+            "p-locate": "^4.1.0",
+            "path-exists": "^4.0.0",
+            "path-type": "^4.0.0",
+            "toml": "^3.0.0",
+            "tomlify-j0.4": "^3.0.0",
+            "validate-npm-package-name": "^3.0.0",
+            "yargs": "^15.3.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+        }
       }
     },
     "netlify-redirector": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "@netlify/config": {
-      "version": "2.4.4-0",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-2.4.4-0.tgz",
-      "integrity": "sha512-qNZQo20z7Puoni99yA2KYZvcHBRBfWPoslJLBvueH+GMzS6C1k4cvRyxWdoNArB2xvLK9HnSnXOHHuW14ODlRQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-3.0.1.tgz",
+      "integrity": "sha512-lW+HGiDOfkcAUO3MhXcoLA7n1XnHtupO03gjZlcankksTrBOlkIMw2RFanptg6LAPqlW47cS0DHvU1sSkKyJCg==",
       "requires": {
         "@ungap/from-entries": "^0.2.1",
         "array-flat-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "prettier": "--ignore-path .gitignore --loglevel=warn \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\" \".*.{js,yml,json,html}\" \"!package-lock.json\""
   },
   "dependencies": {
-    "@netlify/build": "^8.0.4-0",
-    "@netlify/config": "^2.4.4-0",
+    "@netlify/build": "^8.0.5",
+    "@netlify/config": "^3.0.1",
     "@netlify/plugin-edge-handlers": "^1.10.0",
     "@netlify/traffic-mesh-agent": "^0.27.0",
     "@netlify/zip-it-and-ship-it": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "prettier": "--ignore-path .gitignore --loglevel=warn \"{src,scripts,site,tests,.github}/**/*.{js,md,yml,json,html}\" \"*.{js,yml,json,html}\" \".*.{js,yml,json,html}\" \"!package-lock.json\""
   },
   "dependencies": {
-    "@netlify/build": "^8.0.0",
-    "@netlify/config": "^2.0.9",
+    "@netlify/build": "^8.0.4-0",
+    "@netlify/config": "^2.4.4-0",
     "@netlify/plugin-edge-handlers": "^1.10.0",
     "@netlify/traffic-mesh-agent": "^0.27.0",
     "@netlify/zip-it-and-ship-it": "^2.0.0",

--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -1,20 +1,13 @@
 const execa = require('execa')
 
 const Command = require('../../utils/command')
-const { getSiteInformation, addEnvVariables } = require('../../utils/dev')
+const { injectEnvVariables } = require('../../utils/dev')
 
 class ExecCommand extends Command {
   async run() {
-    const { log, warn, error, netlify } = this
-    const { site, api, siteInfo } = netlify
-    const { teamEnv, addonsEnv, siteEnv, dotFilesEnv } = await getSiteInformation({
-      api,
-      site,
-      warn,
-      error,
-      siteInfo,
-    })
-    await addEnvVariables({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv })
+    const { log, warn, netlify } = this
+    const { site } = netlify
+    await injectEnvVariables({ env: this.netlify.cachedConfig.env, log, site, warn })
 
     execa(this.argv[0], this.argv.slice(1), {
       stdio: 'inherit',

--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -6,8 +6,8 @@ const { injectEnvVariables } = require('../../utils/dev')
 class ExecCommand extends Command {
   async run() {
     const { log, warn, netlify } = this
-    const { site } = netlify
-    await injectEnvVariables({ env: this.netlify.cachedConfig.env, log, site, warn })
+    const { cachedConfig, site } = netlify
+    await injectEnvVariables({ env: cachedConfig.env, log, site, warn })
 
     execa(this.argv[0], this.argv.slice(1), {
       stdio: 'inherit',

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -13,7 +13,7 @@ const wrapAnsi = require('wrap-ansi')
 
 const Command = require('../../utils/command')
 const { serverSettings } = require('../../utils/detect-server')
-const { getSiteInformation, addEnvVariables } = require('../../utils/dev')
+const { getSiteInformation, injectEnvVariables } = require('../../utils/dev')
 const { startLiveTunnel } = require('../../utils/live-tunnel')
 const { NETLIFYDEV, NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require('../../utils/logo')
 const openBrowser = require('../../utils/open-browser')
@@ -180,7 +180,9 @@ class DevCommand extends Command {
       ...flags,
     }
 
-    const { addonsUrls, teamEnv, addonsEnv, siteEnv, dotFilesEnv, siteUrl, capabilities } = await getSiteInformation({
+    await injectEnvVariables({ env: this.netlify.cachedConfig.env, log, site, warn })
+
+    const { addonsUrls, siteUrl, capabilities } = await getSiteInformation({
       flags,
       api,
       site,
@@ -188,8 +190,6 @@ class DevCommand extends Command {
       error: errorExit,
       siteInfo,
     })
-
-    await addEnvVariables({ log, teamEnv, addonsEnv, siteEnv, dotFilesEnv })
 
     let settings = {}
     try {

--- a/src/commands/env/get.js
+++ b/src/commands/env/get.js
@@ -3,7 +3,7 @@ const Command = require('../../utils/command')
 class EnvGetCommand extends Command {
   async run() {
     const { args, flags } = this.parse(EnvGetCommand)
-    const { api, site, config } = this.netlify
+    const { api, cachedConfig, site } = this.netlify
     const siteId = site.id
 
     if (!siteId) {
@@ -19,12 +19,9 @@ class EnvGetCommand extends Command {
     })
 
     const siteData = await api.getSite({ siteId })
-    const {
-      build: { environment = {} },
-    } = config
 
     const { name } = args
-    const value = environment[name]
+    const { value } = cachedConfig.env[name] || {}
 
     // Return json response for piping commands
     if (flags.json) {

--- a/src/commands/env/list.js
+++ b/src/commands/env/list.js
@@ -1,3 +1,4 @@
+const fromEntries = require('@ungap/from-entries')
 const AsciiTable = require('ascii-table')
 const isEmpty = require('lodash/isEmpty')
 
@@ -22,17 +23,12 @@ class EnvListCommand extends Command {
     })
 
     const siteData = await api.getSite({ siteId })
-    const environment = Object.entries(cachedConfig.env).reduce((env, [key, variable]) => {
-      // Omitting general variables to reduce noise.
-      if (variable.sources[0] === 'general') {
-        return env
-      }
-
-      return {
-        ...env,
-        [key]: variable.value,
-      }
-    }, {})
+    const environment = fromEntries(
+      Object.entries(cachedConfig.env)
+        // Omitting general variables to reduce noise.
+        .filter(([, variable]) => variable.sources[0] !== 'general')
+        .map(([key, variable]) => [key, variable.value]),
+    )
 
     // Return json response for piping commands
     if (flags.json) {

--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -9,15 +9,8 @@ const getBuildOptions = ({ context, token, flags }) => {
   const { dry, debug } = flags
   // buffer = true will not stream output
   const buffer = flags.json || flags.silent
-  const env = Object.entries(cachedConfig.env).reduce(
-    (obj, [key, variable]) => ({
-      ...obj,
-      [key]: variable.value,
-    }),
-    {},
-  )
 
-  return { cachedConfig: serializedConfig, token, dry, debug, mode: 'cli', telemetry: false, buffer, env }
+  return { cachedConfig: serializedConfig, token, dry, debug, mode: 'cli', telemetry: false, buffer }
 }
 
 const runBuild = async (options) => {

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -127,6 +127,7 @@ class BaseCommand extends Command {
         siteId: argv.siteId || (typeof argv.site === 'string' && argv.site) || state.get('siteId'),
         token,
         mode: 'cli',
+        offline: argv.offline,
       })
     } catch (error) {
       const message = error.type === 'userError' ? error.message : error.stack

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -105,7 +105,7 @@ class BaseCommand extends Command {
       siteInfo,
       // Configuration from netlify.[toml/yml]
       config,
-      // Used to avoid calling @neltify/config again
+      // Used to avoid calling @netlify/config again
       cachedConfig,
       // global cli config
       globalConfig,

--- a/src/utils/dot-env.js
+++ b/src/utils/dot-env.js
@@ -1,13 +1,11 @@
 const path = require('path')
-const process = require('process')
 
 const dotenv = require('dotenv')
-const filterObject = require('filter-obj')
 
 const { isFileAsync, readFileAsync } = require('../lib/fs')
 
 const loadDotEnvFiles = async function ({ projectDir, warn }) {
-  const dotenvFiles = ['.env.development', '.env']
+  const dotenvFiles = ['.env', '.env.development']
   const results = await Promise.all(
     dotenvFiles.map(async (file) => {
       const filepath = path.resolve(projectDir, file)
@@ -21,9 +19,7 @@ const loadDotEnvFiles = async function ({ projectDir, warn }) {
         return
       }
       const content = await readFileAsync(filepath)
-      const parsed = dotenv.parse(content)
-      // only keep envs not configured in process.env
-      const env = filterObject(parsed, (key) => !Object.prototype.hasOwnProperty.call(process.env, key))
+      const env = dotenv.parse(content)
       return { file, env }
     }),
   )

--- a/src/utils/dot-env.test.js
+++ b/src/utils/dot-env.test.js
@@ -62,8 +62,8 @@ test('should read from both .env.development and .env', async (t) => {
 
     const results = await loadDotEnvFiles({ projectDir: builder.directory, warn })
     t.deepEqual(results, [
-      { file: '.env.development', env: { ONE: 'FROM_DEVELOPMENT_ENV', THREE: 'FROM_DEVELOPMENT_ENV' } },
       { file: '.env', env: { ONE: 'FROM_ENV', TWO: 'FROM_ENV' } },
+      { file: '.env.development', env: { ONE: 'FROM_DEVELOPMENT_ENV', THREE: 'FROM_DEVELOPMENT_ENV' } },
     ])
   })
 })
@@ -78,20 +78,5 @@ test('should handle empty .env file', async (t) => {
 
     const results = await loadDotEnvFiles({ projectDir: builder.directory, warn })
     t.deepEqual(results, [{ file: '.env', env: {} }])
-  })
-})
-
-test('should filter process.env vars', async (t) => {
-  await withSiteBuilder('site-with-empty-env-file', async (builder) => {
-    builder.withEnvFile({
-      path: '.env',
-      env: { SHOULD_FILTER: 'FROM_ENV', OTHER: 'FROM_ENV' },
-    })
-
-    await builder.buildAsync()
-
-    process.env.SHOULD_FILTER = 'FROM_PROCESS_ENV'
-    const results = await loadDotEnvFiles({ projectDir: builder.directory, warn })
-    t.deepEqual(results, [{ file: '.env', env: { OTHER: 'FROM_ENV' } }])
   })
 })

--- a/tests/command.build.test.js
+++ b/tests/command.build.test.js
@@ -14,7 +14,7 @@ const runBuildCommand = async function (t, cwd, { exitCode: expectedExitCode = 0
   const { all, exitCode } = await execa(cliPath, ['build', ...flags], {
     reject: false,
     cwd,
-    env: { FORCE_COLOR: '1', NETLIFY_AUTH_TOKEN: 'test', ...env },
+    env: { FORCE_COLOR: '1', ...env },
     all: true,
   })
 

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -248,7 +248,7 @@ testMatrix.forEach(({ args }) => {
       await builder.buildAsync()
 
       await withDevServer({ cwd: builder.directory, args }, async (server) => {
-        const response = await fetch(`${server.url}/.netlify/functions/env`).then((res) => res.text())
+        const response = await got(`${server.url}/.netlify/functions/env`).text()
         t.is(response, 'FROM_CONFIG_FILE')
       })
     })
@@ -291,7 +291,7 @@ testMatrix.forEach(({ args }) => {
       await builder.buildAsync()
 
       await withDevServer({ cwd: builder.directory, env: { TEST: 'FROM_PROCESS_ENV' }, args }, async (server) => {
-        const response = await fetch(`${server.url}/.netlify/functions/env`).then((res) => res.text())
+        const response = await got(`${server.url}/.netlify/functions/env`).text()
         t.is(response, 'FROM_PROCESS_ENV')
       })
     })

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -234,7 +234,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should pass [build.environment] env vars to function', args), async (t) => {
-    await withSiteBuilder('site-with-process-env', async (builder) => {
+    await withSiteBuilder('site-with-build-environment', async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { environment: { TEST: 'FROM_CONFIG_FILE' }, functions: 'functions' } } })
         .withFunction({
@@ -277,7 +277,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should override [build.environment] with process env', args), async (t) => {
-    await withSiteBuilder('site-with-override', async (builder) => {
+    await withSiteBuilder('site-with-build-environment-override', async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { environment: { TEST: 'FROM_CONFIG_FILE' }, functions: 'functions' } } })
         .withFunction({

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -233,6 +233,27 @@ testMatrix.forEach(({ args }) => {
     })
   })
 
+  test(testName('should pass [build.environment] env vars to function', args), async (t) => {
+    await withSiteBuilder('site-with-process-env', async (builder) => {
+      builder
+        .withNetlifyToml({ config: { build: { environment: { TEST: 'FROM_CONFIG_FILE' }, functions: 'functions' } } })
+        .withFunction({
+          path: 'env.js',
+          handler: async () => ({
+            statusCode: 200,
+            body: `${process.env.TEST}`,
+          }),
+        })
+
+      await builder.buildAsync()
+
+      await withDevServer({ cwd: builder.directory, args }, async (server) => {
+        const response = await fetch(`${server.url}/.netlify/functions/env`).then((res) => res.text())
+        t.is(response, 'FROM_CONFIG_FILE')
+      })
+    })
+  })
+
   test(testName('should override .env.development with process env', args), async (t) => {
     await withSiteBuilder('site-with-override', async (builder) => {
       builder
@@ -250,6 +271,27 @@ testMatrix.forEach(({ args }) => {
 
       await withDevServer({ cwd: builder.directory, env: { TEST: 'FROM_PROCESS_ENV' }, args }, async (server) => {
         const response = await got(`${server.url}/.netlify/functions/env`).text()
+        t.is(response, 'FROM_PROCESS_ENV')
+      })
+    })
+  })
+
+  test(testName('should override [build.environment] with process env', args), async (t) => {
+    await withSiteBuilder('site-with-override', async (builder) => {
+      builder
+        .withNetlifyToml({ config: { build: { environment: { TEST: 'FROM_CONFIG_FILE' }, functions: 'functions' } } })
+        .withFunction({
+          path: 'env.js',
+          handler: async () => ({
+            statusCode: 200,
+            body: `${process.env.TEST}`,
+          }),
+        })
+
+      await builder.buildAsync()
+
+      await withDevServer({ cwd: builder.directory, env: { TEST: 'FROM_PROCESS_ENV' }, args }, async (server) => {
+        const response = await fetch(`${server.url}/.netlify/functions/env`).then((res) => res.text())
         t.is(response, 'FROM_PROCESS_ENV')
       })
     })


### PR DESCRIPTION
**- Summary**

This PR is the CLI counterpart of https://github.com/netlify/build/pull/2040. It introduces the updated environment variables object coming from `@netlify/build` to various commands.

Copying across this list created by @ehmicky in the build PR. I'll use it to track the progress on the various commands.

  - `netlify build`:
     - [x] Do not pass [the `env` option](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/lib/build.js#L31) to `@netlify/build` anymore
     - [x] This means [`getBuildEnv()`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/lib/build.js#L5) can be removed.
  - [`netlify env:list`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/commands/env/list.js#L26) and [`netlify env:get`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/commands/env/get.js#L23):
     - [x] Use the `env` return value from `@netlify/config` instead of `config.build.environment`.
       We might want to select only specific environment variables categories, and merge them.
  - `netlify dev`, `netlify dev:exec`, `netlify functions:create`:
     - [x] Use the `env` return value from `@netlify/config`. Note: this will also add support to `build.environment`.
     - [x] The `dev.environment` property in `netlify.toml` should be merged to them: `{ ...env.all, ...dev.environment }`.
     - [x] Do not use [`getSiteInformation()`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/utils/dev.js#L62) anymore, except for the [`addonsUrl`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/utils/dev.js#L42) and [`dotenv`](https://github.com/netlify/cli/blob/master/src/utils/dot-env.js) logic
     - [x] Adjust logs in [`addEnvVariables()`](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/utils/dev.js#L97) to dissociate between netlify.toml and UI site environment variables
     - Pass [`--offline` CLI flag](https://github.com/netlify/cli/blob/e031d8eb3bc2b56e85fc19e5fc395440acd30158/src/commands/dev/index.js#L254) to `@netlify/config`. `netlify dev:exec` and `netlify functions:create` might not have this flag yet, but `netlify dev` does.

**- Test plan**

Added new tests that assert the capture of environment variables from `[build.environment]`. Rest of the test suite unchanged.

**- Description for the changelog**

Mimic the environment variables used in production

**- A picture of a cute animal (not mandatory but encouraged)**

![5f510bbc10345b91b189bf45dde83ddb](https://user-images.githubusercontent.com/4162329/104331682-4105a680-54e7-11eb-83dd-ebc57c758874.jpg)
