### PR TITLE
test: add CLI timeout

### DIFF
--- a/tests/utils/call-cli.js
+++ b/tests/utils/call-cli.js
@@ -2,8 +2,15 @@ const execa = require('execa')
 
 const cliPath = require('./cli-path')
 
+const CLI_TIMEOUT = 3e5
+
 const callCli = async function (args, execOptions) {
-  const { stdout } = await execa(cliPath, args, { windowsHide: true, windowsVerbatimArguments: true, ...execOptions })
+  const { stdout } = await execa(cliPath, args, {
+    windowsHide: true,
+    windowsVerbatimArguments: true,
+    timeout: CLI_TIMEOUT,
+    ...execOptions,
+  })
   return stdout
 }
 

--- a/tests/utils/call-cli.js
+++ b/tests/utils/call-cli.js
@@ -6,8 +6,6 @@ const CLI_TIMEOUT = 3e5
 
 const callCli = async function (args, execOptions) {
   const { stdout } = await execa(cliPath, args, {
-    windowsHide: true,
-    windowsVerbatimArguments: true,
     timeout: CLI_TIMEOUT,
     ...execOptions,
   })


### PR DESCRIPTION
This PR adds a timeout of 30 seconds for CLI invocations in our tests.