### PR TITLE
chore(dev): update TM agent and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1971,31 +1971,31 @@
       }
     },
     "@netlify/traffic-mesh-agent": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.27.7.tgz",
-      "integrity": "sha512-MrsO615+/54eh39PxAKDPyZ0kbgjnaVCMLcm2YgV7vjwre8QpYxfac8OZ4VkwjDJo77wJ3bEJE7D7hCxMJK1vw==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.27.8.tgz",
+      "integrity": "sha512-hO58FtU+DYlSf2r4BQlf4d0ZhjUHoKCUQdDbHRRfIUUxGNoT6gIdGcMNkvtj+AO35t+tyh/vBRlPn1z38BUfyw==",
       "requires": {
-        "@netlify/traffic-mesh-agent-darwin-x64": "^0.27.7",
-        "@netlify/traffic-mesh-agent-linux-x64": "^0.27.7",
-        "@netlify/traffic-mesh-agent-win32-x64": "^0.27.7"
+        "@netlify/traffic-mesh-agent-darwin-x64": "^0.27.8",
+        "@netlify/traffic-mesh-agent-linux-x64": "^0.27.8",
+        "@netlify/traffic-mesh-agent-win32-x64": "^0.27.8"
       }
     },
     "@netlify/traffic-mesh-agent-darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-darwin-x64/-/traffic-mesh-agent-darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-X6mevhyziuwGMQW6Ya9FTsRRLW4gqe8Mp51dtlk4RBS7rxZzA+S8zf7w3eKi18D45S7kBjvsPC3O7SpB4ZHP7g==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-darwin-x64/-/traffic-mesh-agent-darwin-x64-0.27.8.tgz",
+      "integrity": "sha512-y2AfFo/RDdnmSXFqsJD07iMjSiAkTyBSmUuailmVssPSO0Z6uiPvxvngFCz2e0qbiVarPu9japLkx630P/MmpQ==",
       "optional": true
     },
     "@netlify/traffic-mesh-agent-linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-linux-x64/-/traffic-mesh-agent-linux-x64-0.27.7.tgz",
-      "integrity": "sha512-8lSqgS1UfGCC7LexUjBqZ2PtttZa/guOf8iYv+mthA1DoBnp4ug9Pg2LGyrjOUdXHpLgKimBbaq5q6ggULjhOQ==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-linux-x64/-/traffic-mesh-agent-linux-x64-0.27.8.tgz",
+      "integrity": "sha512-tT+2Urh3dgePC1SbGZl0f2G51ss7yU+6E+fF9B1CYow/eGnQ8Z9PUc1QC1tNE3+js2ApO/eOm90iHCYIqLtF4w==",
       "optional": true
     },
     "@netlify/traffic-mesh-agent-win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-win32-x64/-/traffic-mesh-agent-win32-x64-0.27.7.tgz",
-      "integrity": "sha512-1Bye+9Hcn2RLJO6Dq3u/Xr6lamHB4fzg0akVO69EEPCtF3scKEqTfTu3+ZqmdeaLUOUKRshvFYVH4UO0wP2acg==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent-win32-x64/-/traffic-mesh-agent-win32-x64-0.27.8.tgz",
+      "integrity": "sha512-c6W/uh+MiNGQNmVFfz6vQCbJxkOrR5Q4X8zd35mH1/+twmcMs8aRHHPr1aRw/LXb6uQzT8GRB7sV4lD5yBLqmA==",
       "optional": true
     },
     "@netlify/zip-it-and-ship-it": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@netlify/build": "^8.0.5",
     "@netlify/config": "^3.0.1",
     "@netlify/plugin-edge-handlers": "^1.10.0",
-    "@netlify/traffic-mesh-agent": "^0.27.0",
+    "@netlify/traffic-mesh-agent": "^0.27.8",
     "@netlify/zip-it-and-ship-it": "^2.0.0",
     "@oclif/command": "^1.6.1",
     "@oclif/config": "^1.15.1",

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -109,6 +109,8 @@ const startProxyServer = async ({ flags, settings, site, log, exit, addonsUrls }
       log,
       debug: flags.debug,
       locationDb: flags.locationDb,
+      jwtRolesPath: settings.jwtRolePath,
+      jwtSecret: settings.jwtSecret,
     })
     if (!url) {
       log(NETLIFYDEVERR, `Unable to start forward proxy on port '${settings.port}'`)

--- a/src/utils/traffic-mesh.js
+++ b/src/utils/traffic-mesh.js
@@ -15,7 +15,17 @@ const { NETLIFYDEVLOG, NETLIFYDEVERR, NETLIFYDEVWARN } = require('./logo')
 
 const EDGE_HANDLERS_BUNDLER_CLI_PATH = path.resolve(require.resolve('@netlify/plugin-edge-handlers'), '..', 'cli.js')
 
-const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDir, log, debug, locationDb }) => {
+const startForwardProxy = async ({
+  port,
+  frameworkPort,
+  functionsPort,
+  publishDir,
+  log,
+  debug,
+  locationDb,
+  jwtRolesPath,
+  jwtSecret,
+}) => {
   const args = [
     'start',
     'local',
@@ -42,6 +52,14 @@ const startForwardProxy = async ({ port, frameworkPort, functionsPort, publishDi
 
   if (locationDb) {
     args.push('--geo', locationDb)
+  }
+
+  if (jwtRolesPath) {
+    args.push('--jwt-roles-path', jwtRolesPath)
+  }
+
+  if (jwtSecret) {
+    args.push('--signature-secret', jwtSecret)
   }
 
   const { subprocess } = runProcess({ log, args })

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -463,7 +463,7 @@ testMatrix.forEach(({ args }) => {
           .json()
 
         t.is(response.headers.host, `${server.host}:${server.port}`)
-        t.is(response.headers['content-type'], `multipart/form-data; boundary=${formBoundary}`)
+        t.is(response.headers['content-type'], `multipart/form-data; boundary=${expectedBoundary}`)
         t.is(response.headers['content-length'], 164)
         t.is(response.httpMethod, 'POST')
         t.is(response.isBase64Encoded, false)

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -464,7 +464,7 @@ testMatrix.forEach(({ args }) => {
 
         t.is(response.headers.host, `${server.host}:${server.port}`)
         t.is(response.headers['content-type'], `multipart/form-data; boundary=${expectedBoundary}`)
-        t.is(response.headers['content-length'], 164)
+        t.is(response.headers['content-length'], '164')
         t.is(response.httpMethod, 'POST')
         t.is(response.isBase64Encoded, false)
         t.is(response.path, '/api/echo')

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -66,6 +66,9 @@ const setupRoleBasedRedirectsSite = (builder) => {
 }
 
 const validateRoleBasedRedirectsSite = async ({ builder, args, t, jwtSecret, jwtRolePath }) => {
+  const adminToken = getToken({ jwtSecret, jwtRolePath, roles: ['admin'] })
+  const editorToken = getToken({ jwtSecret, jwtRolePath, roles: ['editor'] })
+
   await withDevServer({ cwd: builder.directory, args }, async (server) => {
     const unauthenticatedResponse = await gotCatch404(`${server.url}/admin`)
     t.is(unauthenticatedResponse.statusCode, 404)
@@ -73,7 +76,7 @@ const validateRoleBasedRedirectsSite = async ({ builder, args, t, jwtSecret, jwt
 
     const authenticatedResponse = await got(`${server.url}/admin/foo`, {
       headers: {
-        cookie: `nf_jwt=${getToken({ jwtSecret, jwtRolePath, roles: ['admin'] })}`,
+        cookie: `nf_jwt=${adminToken}`,
       },
     })
     t.is(authenticatedResponse.statusCode, 200)
@@ -81,7 +84,7 @@ const validateRoleBasedRedirectsSite = async ({ builder, args, t, jwtSecret, jwt
 
     const wrongRoleResponse = await gotCatch404(`${server.url}/admin/foo`, {
       headers: {
-        cookie: `nf_jwt=${getToken({ jwtSecret, jwtRolePath, roles: ['editor'] })}`,
+        cookie: `nf_jwt=${editorToken}`,
       },
     })
     t.is(wrongRoleResponse.statusCode, 404)
@@ -107,7 +110,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should return user defined headers when / is accessed', args), async (t) => {
-    await withSiteBuilder('site-with-index-file', async (builder) => {
+    await withSiteBuilder('site-with-headers-on-root', async (builder) => {
       builder.withContentFile({
         path: 'index.html',
         content: '<h1>⊂◉‿◉つ</h1>',
@@ -127,7 +130,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should return user defined headers when non-root path is accessed', args), async (t) => {
-    await withSiteBuilder('site-with-index-file', async (builder) => {
+    await withSiteBuilder('site-with-headers-on-non-root', async (builder) => {
       builder.withContentFile({
         path: 'foo/index.html',
         content: '<h1>⊂◉‿◉つ</h1>',
@@ -345,15 +348,7 @@ testMatrix.forEach(({ args }) => {
       await withDevServer({ cwd: builder.directory, args }, async (server) => {
         const response = await got(`${server.url}/api/echo?ding=dong`).json()
         t.is(response.body, undefined)
-        t.deepEqual(response.headers, {
-          accept: 'application/json',
-          'accept-encoding': 'gzip, deflate, br',
-          'client-ip': '127.0.0.1',
-          connection: 'close',
-          host: `${server.host}:${server.port}`,
-          'user-agent': 'got (https://github.com/sindresorhus/got)',
-          'x-forwarded-for': '::ffff:127.0.0.1',
-        })
+        t.is(response.headers.host, `${server.host}:${server.port}`)
         t.is(response.httpMethod, 'GET')
         t.is(response.isBase64Encoded, false)
         t.is(response.path, '/api/echo')
@@ -392,17 +387,9 @@ testMatrix.forEach(({ args }) => {
           .json()
 
         t.is(response.body, 'some=thing')
-        t.deepEqual(response.headers, {
-          accept: 'application/json',
-          'accept-encoding': 'gzip, deflate, br',
-          'client-ip': '127.0.0.1',
-          connection: 'close',
-          host: `${server.host}:${server.port}`,
-          'content-type': 'application/x-www-form-urlencoded',
-          'content-length': '10',
-          'user-agent': 'got (https://github.com/sindresorhus/got)',
-          'x-forwarded-for': '::ffff:127.0.0.1',
-        })
+        t.is(response.headers.host, `${server.host}:${server.port}`)
+        t.is(response.headers['content-type'], 'application/x-www-form-urlencoded')
+        t.is(response.headers['content-length'], '10')
         t.is(response.httpMethod, 'POST')
         t.is(response.isBase64Encoded, false)
         t.is(response.path, '/api/echo')
@@ -475,17 +462,9 @@ testMatrix.forEach(({ args }) => {
           })
           .json()
 
-        t.deepEqual(response.headers, {
-          accept: 'application/json',
-          'accept-encoding': 'gzip, deflate, br',
-          'client-ip': '127.0.0.1',
-          connection: 'close',
-          host: `${server.host}:${server.port}`,
-          'content-length': '164',
-          'content-type': `multipart/form-data; boundary=${expectedBoundary}`,
-          'user-agent': 'got (https://github.com/sindresorhus/got)',
-          'x-forwarded-for': '::ffff:127.0.0.1',
-        })
+        t.is(response.headers.host, `${server.host}:${server.port}`)
+        t.is(response.headers['content-type'], `multipart/form-data; boundary=${formBoundary}`)
+        t.is(response.headers['content-length'], 164)
         t.is(response.httpMethod, 'POST')
         t.is(response.isBase64Encoded, false)
         t.is(response.path, '/api/echo')
@@ -496,7 +475,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should return 404 when redirecting to a non existing function', args), async (t) => {
-    await withSiteBuilder('site-with-multi-part-function', async (builder) => {
+    await withSiteBuilder('site-with-missing-function', async (builder) => {
       builder.withNetlifyToml({
         config: {
           build: { functions: 'functions' },
@@ -579,17 +558,9 @@ testMatrix.forEach(({ args }) => {
 
         const body = JSON.parse(response.body)
 
-        t.deepEqual(response.headers, {
-          accept: 'application/json',
-          'accept-encoding': 'gzip, deflate, br',
-          'client-ip': '127.0.0.1',
-          connection: 'close',
-          host: `${server.host}:${server.port}`,
-          'content-length': '276',
-          'content-type': 'application/json',
-          'user-agent': 'got (https://github.com/sindresorhus/got)',
-          'x-forwarded-for': '::ffff:127.0.0.1',
-        })
+        t.is(response.headers.host, `${server.host}:${server.port}`)
+        t.is(response.headers['content-length'], '276')
+        t.is(response.headers['content-type'], 'application/json')
         t.is(response.httpMethod, 'POST')
         t.is(response.isBase64Encoded, false)
         t.is(response.path, '/')
@@ -1030,7 +1001,7 @@ testMatrix.forEach(({ args }) => {
   })
 
   test(testName('should not shadow an existing file that has unsafe URL characters', args), async (t) => {
-    await withSiteBuilder('site-with-same-name-for-file-and-folder', async (builder) => {
+    await withSiteBuilder('site-with-unsafe-url-file-names', async (builder) => {
       builder
         .withContentFile({
           path: 'public/index.html',


### PR DESCRIPTION
This brings a new version of the TM agent that fixes most of the tests
failing for it in the dev suite. It also modifies some of the test
to change expectations that are not required to work exactly equally
across both proxies, like common response headers.

Signed-off-by: David Calavera <david.calavera@gmail.com>

Fixes #1724