### PR TITLE
chore: verify docs using a GitHub action

### DIFF
--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -1,0 +1,36 @@
+name: Verify Docs
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install core dependencies
+        run: npm ci
+      - name: Install site dependencies
+        run: npm run site:build:install
+      - name: Generate docs
+        run: npm run docs
+      - name: Check for changes
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to docs files detected"
+          else
+            echo "Changes to docs files detected, please run 'npm run docs' to sync docs"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,8 @@ We actively welcome your pull requests.
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
+4. Run `npm test` to run linting, formatting and tests.
+5. Make sure to sync the docs by running `npm run docs`.
 
 ## Releasing
 


### PR DESCRIPTION
Related to https://github.com/netlify/cli/issues/1665.

Solves the blocker for adding a release PR workflow by verifying docs are synced using a GitHub action.
Makes sure a change to a command has the relevant doc change (instead of pushing the docs to the default branch during publishing).

Useful until we do https://github.com/netlify/cli/issues/304