### PR TITLE
test(http-agent): fix flaky test

### DIFF
--- a/src/lib/http-agent.test.js
+++ b/src/lib/http-agent.test.js
@@ -1,5 +1,4 @@
 const http = require('http')
-const process = require('process')
 
 const test = require('ava')
 const { createProxyServer } = require('http-proxy')
@@ -42,11 +41,9 @@ test(`should exit with error when proxy is no available`, async (t) => {
 
   await t.throwsAsync(getAgent({ httpProxy, log, exit }))
 
-  if (process.platform === 'win32') {
-    t.is(log.getCall(0).args[1], "Could not connect to 'https://unknown:7979'")
-  } else {
-    t.is(log.getCall(0).args[1], 'https://unknown:7979 is not available.')
-  }
+  const [, actual] = log.getCall(0).args
+
+  t.true(["Could not connect to 'https://unknown:7979'", 'https://unknown:7979 is not available.'].includes(actual))
 })
 
 test(`should return agent for a valid proxy`, async (t) => {


### PR DESCRIPTION
This test has been randomly failing. See https://github.com/netlify/cli/pull/1747/checks?check_run_id=1708215271#step:7:357

I updated it to check for either message without being platform dependent 