### PR TITLE
fix: override CONTEXT env variable

### DIFF
--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -153,6 +153,7 @@ const injectEnvVariables = async ({ env, log, site, warn }) => {
     }
   }
 
+  process.env.CONTEXT = 'dev'
   process.env.NETLIFY_DEV = 'true'
 }
 


### PR DESCRIPTION
**- Summary**

Force the value of the `CONTEXT` environment variable to `dev`. Reinstates https://github.com/netlify/cli/pull/1685.

**- Test plan**

Added integration tests to ensure this regression is not introduced again.

**- Description for the changelog**

fix: override CONTEXT env variable

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/4162329/104725132-8b766580-5729-11eb-918d-eadf20793607.jpg)

