### PR TITLE
feat: warn when project has netlify dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "p-wait-for": "^3.0.0",
     "parse-github-url": "^1.0.2",
     "parse-gitignore": "^1.0.1",
+    "path-exists": "^4.0.0",
     "path-type": "^4.0.0",
     "prettyjson": "^1.2.1",
     "random-item": "^3.0.0",

--- a/src/lib/deprecations.js
+++ b/src/lib/deprecations.js
@@ -1,0 +1,66 @@
+const path = require('path')
+const process = require('process')
+
+const pathExists = require('path-exists')
+const semverLessThan = require('semver/functions/lt')
+
+const { NETLIFYDEVWARN } = require('../utils/logo')
+
+const warnOnOldNodeVersion = ({ log, chalk }) => {
+  if (semverLessThan(process.version, '10.0.0')) {
+    log(
+      `${NETLIFYDEVWARN} ${chalk.bold('Netlify CLI')} will require ${chalk.magenta.bold(
+        'Node.js 10',
+      )} or greater soon. Please update your Node.js version.`,
+    )
+  }
+}
+
+const NETLIFY_DIR = 'netlify'
+const DEFAULT_FUNCTIONS_SRC = path.join(NETLIFY_DIR, 'functions')
+
+const formatDirectory = (chalk, directory) => chalk.redBright(directory)
+
+const getCommunityLink = (chalk) =>
+  chalk.magenta(
+    'community.netlify.com/t/upcoming-change-netlify-functions-as-zero-config-default-folder-for-deploying-netlify-functions/28789',
+  )
+
+const logDefaultFunctionsSrcWarning = (log, chalk, netlifyDir, defaultFunctionsSrc) => {
+  log(
+    `${NETLIFYDEVWARN} Detected site repository path: ${formatDirectory(chalk, defaultFunctionsSrc)}
+${NETLIFYDEVWARN} Starting in February 2021, this path will be used to detect and deploy Netlify functions.
+${NETLIFYDEVWARN} To avoid potential build failures or irregularities, we recommend changing the name of the ${formatDirectory(
+      chalk,
+      netlifyDir,
+    )} directory.
+${NETLIFYDEVWARN} For more information, visit the Community update notification: ${getCommunityLink(chalk)}`,
+  )
+}
+
+const logNetlifyDirWarning = (log, chalk, netlifyDir, defaultFunctionsSrc) => {
+  log(
+    `${NETLIFYDEVWARN} Detected site repository path: ${formatDirectory(chalk, netlifyDir)}
+${NETLIFYDEVWARN} Netlify will begin using this path for detecting default deployment features, starting with ${formatDirectory(
+      chalk,
+      defaultFunctionsSrc,
+    )} in February 2021.
+${NETLIFYDEVWARN} To avoid potential build failures or irregularities in the future, we recommend changing the name of the ${formatDirectory(
+      chalk,
+      netlifyDir,
+    )} directory.
+${NETLIFYDEVWARN} For more information, visit the Community update notification: ${getCommunityLink(chalk)}`,
+  )
+}
+
+const warnOnNetlifyDir = async ({ log, chalk, buildDir }) => {
+  if (await pathExists(`${buildDir}/${DEFAULT_FUNCTIONS_SRC}`)) {
+    logDefaultFunctionsSrcWarning(log, chalk, NETLIFY_DIR, DEFAULT_FUNCTIONS_SRC)
+    return
+  }
+  if (await pathExists(`${buildDir}/${NETLIFY_DIR}`)) {
+    logNetlifyDirWarning(log, chalk, NETLIFY_DIR, DEFAULT_FUNCTIONS_SRC)
+  }
+}
+
+module.exports = { warnOnOldNodeVersion, warnOnNetlifyDir }

--- a/src/lib/deprecations.js
+++ b/src/lib/deprecations.js
@@ -23,7 +23,7 @@ const formatDirectory = (chalk, directory) => chalk.redBright(directory)
 
 const getCommunityLink = (chalk) =>
   chalk.magenta(
-    'community.netlify.com/t/upcoming-change-netlify-functions-as-zero-config-default-folder-for-deploying-netlify-functions/28789',
+    'https://community.netlify.com/t/upcoming-change-netlify-functions-as-zero-config-default-folder-for-deploying-netlify-functions/28789',
   )
 
 const logDefaultFunctionsSrcWarning = (log, chalk, netlifyDir, defaultFunctionsSrc) => {

--- a/tests/command.test.js
+++ b/tests/command.test.js
@@ -1,0 +1,40 @@
+const process = require('process')
+
+const test = require('ava')
+
+const callCli = require('./utils/call-cli')
+const { withSiteBuilder } = require('./utils/site-builder')
+
+test('should warn when "netlify" dir exists', async (t) => {
+  await withSiteBuilder('site-with-index-file', async (builder) => {
+    builder.withContentFile({
+      path: 'netlify/test.txt',
+      content: 'Hello World',
+    })
+
+    await builder.buildAsync()
+
+    const cliResponse = await callCli(['dev:exec', 'arp'], {
+      cwd: builder.directory,
+    })
+    t.true(cliResponse.includes('Detected site repository path: netlify'))
+  })
+})
+
+test('should warn when "netlify/functions" dir exists', async (t) => {
+  await withSiteBuilder('site-with-index-file', async (builder) => {
+    builder.withContentFile({
+      path: 'netlify/functions/script.js',
+      content: 'console.log("Hello World")',
+    })
+
+    await builder.buildAsync()
+
+    const cliResponse = await callCli(['dev:exec', 'arp'], {
+      cwd: builder.directory,
+    })
+
+    const path = process.platform === 'win32' ? 'netlify\\functions' : 'netlify/functions'
+    t.true(cliResponse.includes(`Detected site repository path: ${path}`))
+  })
+})


### PR DESCRIPTION
Related to https://github.com/netlify/product/issues/257#issuecomment-746446846 and https://github.com/netlify/build/pull/2175

See example log:
![image](https://user-images.githubusercontent.com/26760571/104739664-a78cfd80-574f-11eb-8334-75d8fae92ea6.png)

Not sure if we should avoid duplicating the logic by having `@netlify/conifg` or `@netlify/build` return it.
Since it's a temporary message I think we can live with it.