### PR TITLE
test: generate only json coverage file in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:init:cli-help": "npm run start -- --help",
     "test:init:install-deps": "npm ci --prefix tests/site-cra",
     "test:dev:ava": "ava --verbose",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava --verbose",
+    "test:ci:ava": "nyc -r json ava",
     "docs": "node ./site/scripts/docs.js",
     "watch": "nyc --reporter=lcov ava --watch",
     "prepack": "oclif-dev manifest && npm prune --prod",


### PR DESCRIPTION
Removes `verbose` flag from `ava` and only keep the JSON coverage file in CI.

I'm hoping this will help with our CI jobs getting stuck during tests.