### PR TITLE
Fix links to api docs in `netlify api --list`

### DIFF
--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -25,7 +25,7 @@ class APICommand extends Command {
       table.setHeading('API Method', 'Docs Link')
       methods.forEach((method) => {
         const { operationId } = method
-        table.addRow(operationId, `https://open-api.netlify.com/#/operation/${operationId}`)
+        table.addRow(operationId, `https://open-api.netlify.com/#operation/${operationId}`)
       })
       this.log(table.toString())
       this.log()


### PR DESCRIPTION
**- Summary**
The anchor portion of the links had an extra slash which meant the page wouldn't scroll to the right section.


**- Description for the changelog**
Fixed links to api docs in `netlify api --list`
