### PR TITLE
Compute slug for site name suggestions when user does not have one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13145,7 +13145,20 @@
     "p-event": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ=="
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "requires": {
+        "p-timeout": "^3.1.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
+      }
     },
     "p-filter": {
       "version": "2.1.0",
@@ -13215,7 +13228,20 @@
     "p-wait-for": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
-      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA=="
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "requires": {
+        "p-timeout": "^3.0.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
+      }
     },
     "package-hash": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@oclif/plugin-not-found": "^1.1.4",
     "@oclif/plugin-plugins": "^1.9.3",
     "@octokit/rest": "^16.28.1",
+    "@sindresorhus/slugify": "^1.1.0",
     "@ungap/from-entries": "^0.2.1",
     "ansi-styles": "^5.0.0",
     "ascii-table": "0.0.9",

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -1,14 +1,18 @@
 const { flags: flagsLib } = require('@oclif/command')
+const slugify = require('@sindresorhus/slugify')
 const chalk = require('chalk')
 const inquirer = require('inquirer')
 const pick = require('lodash/pick')
 const sample = require('lodash/sample')
 const prettyjson = require('prettyjson')
+const { v4: uuidv4 } = require('uuid')
 
 const Command = require('../../utils/command')
 const { getRepoData } = require('../../utils/get-repo-data')
 const { configureRepo } = require('../../utils/init/config')
 const { track } = require('../../utils/telemetry')
+
+const SITE_NAME_SUGGESTION_SUFFIX_LENGTH = 5
 
 class SitesCreateCommand extends Command {
   async run() {
@@ -43,21 +47,31 @@ class SitesCreateCommand extends Command {
     }
 
     const { name: nameFlag } = flags
-    let userName
+    let user
     let site
 
     // Allow the user to reenter site name if selected one isn't available
     const inputSiteName = async (name) => {
-      if (!userName) userName = await api.getCurrentUser()
+      if (!user) user = await api.getCurrentUser()
 
       if (!name) {
+        let { slug } = user
+        let suffix = ''
+
+        // If the user doesn't have a slug, we'll compute one. Because `full_name` is not guaranteed to be unique, we
+        // append a short randomly-generated ID to reduce the likelihood of a conflict.
+        if (!slug) {
+          slug = slugify(user.full_name)
+          suffix = `-${uuidv4().slice(0, SITE_NAME_SUGGESTION_SUFFIX_LENGTH)}`
+        }
+
         const suggestions = [
-          `super-cool-site-by-${userName.slug}`,
-          `the-awesome-${userName.slug}-site`,
-          `${userName.slug}-makes-great-sites`,
-          `netlify-thinks-${userName.slug}-is-great`,
-          `the-great-${userName.slug}-site`,
-          `isnt-${userName.slug}-awesome`,
+          `super-cool-site-by-${slug}${suffix}`,
+          `the-awesome-${slug}-site${suffix}`,
+          `${slug}-makes-great-sites${suffix}`,
+          `netlify-thinks-${slug}-is-great${suffix}`,
+          `the-great-${slug}-site${suffix}`,
+          `isnt-${slug}-awesome${suffix}`,
         ]
         const siteSuggestion = sample(suggestions)
 

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -61,7 +61,7 @@ class SitesCreateCommand extends Command {
         // If the user doesn't have a slug, we'll compute one. Because `full_name` is not guaranteed to be unique, we
         // append a short randomly-generated ID to reduce the likelihood of a conflict.
         if (!slug) {
-          slug = slugify(user.full_name)
+          slug = slugify(user.full_name || user.email)
           suffix = `-${uuidv4().slice(0, SITE_NAME_SUGGESTION_SUFFIX_LENGTH)}`
         }
 


### PR DESCRIPTION
**- Summary**

When CLI offers suggestions for a new site name (e.g. as part of `ntl init`), it uses the user's `slug` property, which isn't guaranteed to exist. This PR addresses that by computing a slug in those cases, using the `full_name` property.

Closes #1730 

**- Test plan**

- Verified that the behaviour for a user that does have the `slug` property remains unchanged
- Verified that the behaviour for a user that does not have the `slug` property now includes a slug

**- Description for the changelog**

fix: compute slug for site name suggestions when user does not have one

**- A picture of a cute animal (not mandatory but encouraged)**

![3-toed-sloth-TRR](https://user-images.githubusercontent.com/4162329/104911610-0c7c6980-5983-11eb-9bce-e66ef4f375ea.jpg)

