### PR TITLE
fix(headers): add support for consistent * wildcard

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -140,8 +140,7 @@ const parseHeadersFile = function (filePath) {
 
     if (line.includes(':')) {
       const [key = '', value = ''] = line.split(':', 2)
-      const trimmedKey = key.trim()
-      const trimmedValue = value.trim()
+      const [trimmedKey, trimmedValue] = [key.trim(), value.trim()]
       if (trimmedKey.length === 0 || trimmedValue.length === 0) {
         throw new Error(`invalid header at line: ${index}\n${line}\n`)
       }

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -7,6 +7,7 @@ const trimEnd = require('lodash/trimEnd')
 const TOKEN_COMMENT = '#'
 const TOKEN_PATH = '/'
 
+// Our production logic uses regex too
 const getRulePattern = (rule) => {
   const ruleParts = rule.split('/').filter(Boolean)
   if (ruleParts.length === 0) {
@@ -17,8 +18,10 @@ const getRulePattern = (rule) => {
 
   ruleParts.forEach((part) => {
     if (part.startsWith(':')) {
+      // :placeholder wildcard (e.g. /segment/:placeholder/test) - match everything up to a /
       pattern += '/([^/]+)/?'
     } else if (part === '*') {
+      // standalone asterisk wildcard (e.g. /segment/*) - match everything
       if (pattern === '^') {
         pattern += '/?(.*)/?'
       } else {
@@ -26,8 +29,10 @@ const getRulePattern = (rule) => {
         pattern += '(?:|/|/(.*)/?)'
       }
     } else if (part.includes('*')) {
+      // non standalone asterisk wildcard (e.g. /segment/hello*world/test)
       pattern += `/${part.replace(/\*/g, '(.*)')}`
     } else if (part.trim() !== '') {
+      // not a wildcard
       pattern += `/${escapeRegExp(part)}/?`
     }
   })

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -94,7 +94,7 @@ const matchPaths = function (rule, path) {
 /**
  * Get the matching headers for `path` given a set of `rules`.
  *
- * @param {Object<string,string[]>!} rules
+ * @param {Object<string,Object<string,string[]>>!} rules
  * The rules to use for matching.
  *
  * @param {string!} path
@@ -103,18 +103,11 @@ const matchPaths = function (rule, path) {
  * @returns {Object<string,string[]>}
  */
 const objectForPath = function (rules, path) {
-  /**
-   * Iterate over the rules and assign the matching headers.
-   */
-  const pathObject = {}
-  for (const [rule, headers] of Object.entries(rules)) {
-    /**
-     * If the rule matches the math, assign the respective headers.
-     */
-    const isMatch = matchPaths(rule, path)
-    if (isMatch) Object.assign(pathObject, headers)
-  }
-  /** Return matched headers. */
+  const matchingHeaders = Object.entries(rules)
+    .filter(([rule]) => matchPaths(rule, path))
+    .map(([, headers]) => headers)
+
+  const pathObject = Object.assign({}, ...matchingHeaders)
   return pathObject
 }
 

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -59,16 +59,17 @@ const matchPaths = function (rule, path) {
      */
     if (ruleIsWildcard) {
       /**
-       * 1. all ruleParts and pathParts have been iterated over, e.g.
-       *    `/path/to/:placeholder` & `/path/to/*` matched against
-       *    `/path/to/something` (and `/static/*` matched against `/static`)
-       */
-      if (noMorePathParts && noMoreRuleParts) return true
-      /**
-       * 2. the rulePart is a (*) wildcard AND it is the final rulePart, e.g.
+       * 1. the rulePart is a (*) wildcard AND it is the final rulePart, e.g.
        *    `/path/to/*` matched against `/path/to/multiple/subdirs`.
        */
       if (noMoreRuleParts && ruleIsAsterisk) return true
+      /**
+       * 2. all ruleParts and pathParts have been iterated over, e.g.
+       *    `/path/to/:placeholder` and `/path/to/*` matched against
+       *    `/path/to/something`, as well as `/static/*` and
+       *    `/static/:placeholder` matched against `/static`)
+       */
+      if (noMorePathParts && noMoreRuleParts) return true
     } else if (rulePart !== pathPart) {
       /**
        * If a mismatch is found, the rule does not match.

--- a/src/utils/headers.test.js
+++ b/src/utils/headers.test.js
@@ -131,6 +131,10 @@ test('_headers: matchPaths matches rules as expected', (t) => {
    */
   t.assert(!matchPaths('/:placeholder', '/'))
   /**
+   * Make sure (:placeholder) will NOT recursively match subdirs.
+   */
+  t.assert(!matchPaths('/path/to/:placeholder', '/path/two/dir/one/two/three'))
+  /**
    * (:placeholder) wildcard tests.
    */
   t.assert(matchPaths('/directory/:placeholder', '/directory/test'))
@@ -150,14 +154,19 @@ test('_headers: matchPaths matches rules as expected', (t) => {
   t.assert(matchPaths('/path/to/*', '/path/to/oneDir'))
   t.assert(matchPaths('/path/to/*', '/path/to/oneDir/twoDir/threeDir'))
   /**
-   * Trailing (*) wildcard matches parent dir. This is caught automagically by
-   * index >= pathParts.length && index >= ruleParts.length check.
+   * Trailing wildcards match parent dir.
+   *
+   * This is caught automagically by the `index >= pathParts.length - 1 && index
+   * >= ruleParts.length - 1` checks.
    */
   t.assert(matchPaths('/path/to/dir/*', '/path/to/dir'))
+  t.assert(matchPaths('/path/to/dir/:placeholder', '/path/to/dir'))
+  t.assert(matchPaths('/path/to/dir/*/:placeholder', '/path/to/dir/test'))
   /**
    * Mixed (*) and (:placeholder) wildcards.
    */
   t.assert(matchPaths('/path/*/to/:placeholder/:placeholder/*', '/path/placeholder/to/placeholder/dir/test'))
   t.assert(matchPaths('/path/*/:placeholder', '/path/to/dir'))
   t.assert(matchPaths('/path/:placeholder/:placeholder/*', '/path/to/dir/one/two/three'))
+  t.assert(matchPaths('/path/to/dir/*/:placeholder/test', '/path/to/dir/asterisk/placeholder/test'))
 })

--- a/src/utils/headers.test.js
+++ b/src/utils/headers.test.js
@@ -39,9 +39,20 @@ const headers = [
 
 test.before(async (t) => {
   const builder = createSiteBuilder({ siteName: 'site-for-detecting-server' })
-  builder.withHeadersFile({
-    headers,
-  })
+  builder
+    .withHeadersFile({
+      headers,
+    })
+    .withContentFile({
+      path: '_invalid_headers',
+      content: `
+/
+  # This is valid
+  X-Frame-Options: SAMEORIGIN
+  # This is not valid
+  X-Frame-Thing:
+`,
+    })
 
   await builder.buildAsync()
 
@@ -57,6 +68,12 @@ test.after(async (t) => {
  */
 test('_headers: syntax validates as expected', (t) => {
   parseHeadersFile(path.resolve(t.context.builder.directory, '_headers'))
+})
+
+test('_headers: throws on invalid syntax', (t) => {
+  t.throws(() => parseHeadersFile(path.resolve(t.context.builder.directory, '_invalid_headers')), {
+    message: /invalid header at line: 5/,
+  })
 })
 
 test('_headers: validate rules', (t) => {
@@ -83,6 +100,10 @@ test('_headers: validate rules', (t) => {
       'X-Frame-Options': ['test'],
     },
   })
+})
+
+test('_headers: throws ', (t) => {
+  parseHeadersFile(path.resolve(t.context.builder.directory, '_headers'))
 })
 
 test('_headers: rulesForPath testing', (t) => {

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -17,7 +17,7 @@ const toReadableStream = require('to-readable-stream')
 const { readFileAsync, fileExistsAsync, isFileAsync } = require('../lib/fs.js')
 
 const { createStreamPromise } = require('./create-stream-promise')
-const { parseHeadersFile, objectForPath } = require('./headers')
+const { parseHeadersFile, headersForPath } = require('./headers')
 const { NETLIFYDEVLOG, NETLIFYDEVWARN } = require('./logo')
 const { createRewriter } = require('./rules-proxy')
 const { onChanges } = require('./rules-proxy')
@@ -291,7 +291,7 @@ const initializeProxy = function (port, distDir, projectDir) {
       }
     }
     const requestURL = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
-    const pathHeaderRules = objectForPath(headerRules, requestURL.pathname)
+    const pathHeaderRules = headersForPath(headerRules, requestURL.pathname)
     if (!isEmpty(pathHeaderRules)) {
       Object.entries(pathHeaderRules).forEach(([key, val]) => {
         res.setHeader(key, val)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

### Summary
The CLI's current behavior is to only allow the asterisk wildcard `*` at the end of a rule. This PR aims to add support for wildcard which matches Netlify's deploy logic, which does not seem to have the same restriction.
 
1. See https://github.com/netlify/next-on-netlify/issues/151
2. Closes #1148

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

### Test plan
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->
Tests were updated in `headers.test.js`. More robust testing should likely be added before merging.

### Changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```none
Previously, (*) wildcards had to appear at the end of a rule path, as in /path/to/dir/*. The CLI now supports the asterisk wildcard at any part of the rule, i.e. /test/*/test/*/test.
```