### PR TITLE
feat(errors): add more verbose errors

### DIFF
--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -85,7 +85,12 @@ const scanScripts = function ({ preferredScriptsArr, preferredCommand }) {
      * to recursively call itself.
      */
     if (/netlify dev(?!:)/.test(scriptCommand)) {
-      throw new InternalCliError('Cannot call `netlify dev` inside `netlify dev`.', { packageJsonScripts })
+      throw new InternalCliError(
+        '`netlify dev` is attempting to call a package.json script that also ' +
+          'calls `netlify dev`. Please run the script manually with `npm run ' +
+          '[script]` instead of trying to call `netlify dev`.',
+        { packageJsonScripts },
+      )
     }
     /**
      * Otherwise, push the match.

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -80,8 +80,11 @@ const scanScripts = function ({ preferredScriptsArr, preferredCommand }) {
     /**
      * Throw if trying to call Netlify dev from within Netlify dev. Include
      * detailed information about the CLI setup in the error text.
+     *
+     * Do not include `netlify dev:exec`, etc., as they will not cause the CLI
+     * to recursively call itself.
      */
-    if (scriptCommand.includes('netlify dev')) {
+    if (/netlify dev(?!:)/.test(scriptCommand)) {
       throw new InternalCliError('Cannot call `netlify dev` inside `netlify dev`.', { packageJsonScripts })
     }
     /**

--- a/src/utils/detect-server.test.js
+++ b/src/utils/detect-server.test.js
@@ -188,7 +188,7 @@ test('serverSettings: no config', async (t) => {
   t.is(settings.noCmd, true)
 })
 
-test('chooseDefaultArgs', (t) => {
+test('chooseDefaultArgs: select first from possibleArgsArrs', (t) => {
   const possibleArgsArrs = [['run', 'dev'], ['run develop']]
   const args = chooseDefaultArgs(possibleArgsArrs)
   t.deepEqual(args, possibleArgsArrs[0])

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,0 +1,27 @@
+/**
+ * An unrecoverable internal CLI error which should be reported.
+ */
+class InternalCliError extends Error {
+  /**
+   * Log a stack trace and the given context object for opening an issue, then
+   * throw.
+   *
+   * @param {string!} message
+   * @param {Object!} context
+   */
+  constructor(message, context) {
+    super(message)
+    this.name = 'InternalCliError'
+
+    console.trace(
+      `INTERNAL CLI ERROR. ${message}\n` +
+        'Please open an issue at https://github.com/netlify/cli/issues/new ' +
+        'and include the following information:' +
+        `\n${JSON.stringify(context, null, 2)}\n`,
+    )
+  }
+}
+
+module.exports = {
+  InternalCliError,
+}


### PR DESCRIPTION
# Adding more verbose errors
This PR adds a `class InternalCliError extends Error {}` utility (which **logs a stack trace and context object** before throwing), and implements it in two locations.

## Required fields
### Summary
I tried to run `netlify dev` in the [netlify/netlify-faunadb-example](https://github.com/netlify/netlify-faunadb-example) project and received a confusing error that prevented me from moving forward. I dug into the CLI source again and modified the error logic to be clearer (and I now more or less understand why the CLI was throwing). This class can be used throughout the codebase as desired for throwing unrecoverable runtime errors.

### Test plan
This only modifies two existing errors at present, and should not require testing.

### Changelog
`Added clearer and more verbose error messages for a few edge cases.`

## Changes

### Current behavior
In trying to use `netlify dev` with the [netlify/netlify-faunadb-example](https://github.com/netlify/netlify-faunadb-example) project, I received the following error:

```none
◈ Netlify Dev ◈
◈ Ignored general context env var: LANG (defined in process)
◈ Empty args assigned, this is an internal Netlify Dev bug, please report your settings and scripts so we can improve
```

This same error message would be provided in both cases below (no `possibleArgsArrs`, or `netlify dev` in a matching package.json script, as we see in [netlify/netlify-faunadb-example](https://github.com/netlify/netlify-faunadb-example)).

### Proposed changes
My philosophy here was that if the CLI fails, it should log as much information as possible. The signature of the constructor is `InternalCliError(msg: string, context: object)`, and it will produce an `Error` with the same message as usual, but it will also use `console.trace(...)` to pretty-print the context object provided at throw-time.

With these changes merged, if no possible args array are found in `scanScripts`:

```none
◈ Netlify Dev ◈
◈ Ignored general context env var: LANG (defined in process)
Trace: INTERNAL CLI ERROR. No possible args found.
Please open an issue at https://github.com/netlify/cli/issues/new and include the following information:
{
  "packageJsonScripts": {
    "docs": "md-magic --path '**/*.md' --ignore 'node_modules'",
    "prebuild": "echo 'setup faunaDB' && npm run bootstrap",
    "build": "react-scripts build"
  },
  "possibleArgsArrs": []
}

    at new InternalCliError (/home/christian/PersonalProjects/netlify-cli/src/utils/error.js:13:17)
    at chooseDefaultArgs (/home/christian/PersonalProjects/netlify-cli/src/utils/detect-server.js:247:11)
    at serverSettings (/home/christian/PersonalProjects/netlify-cli/src/utils/detect-server.js:49:23)
    at DevCommand.run (/home/christian/PersonalProjects/netlify-cli/src/commands/dev/index.js:234:24)
    at async DevCommand._run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/command.js:43:20)
    at async Config.runCommand (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/config/lib/config.js:173:24)
    at async Main.run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/main.js:27:9)
    at async Main._run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/command.js:43:20)
◈ No possible args found.
```

And for the `netlify dev` error (which presents when a detector matches a script that contains a call to `netlify dev`, to ensure it does not recursively call itself):

```none
◈ Netlify Dev ◈
◈ Ignored general context env var: LANG (defined in process)
Trace: INTERNAL CLI ERROR. Cannot call `netlify dev` inside `netlify dev`.
Please open an issue at https://github.com/netlify/cli/issues/new and include the following information:
{
  "packageJsonScripts": {
    "bootstrap": "netlify dev:exec node ./scripts/bootstrap-fauna-database.js",
    "docs": "md-magic --path '**/*.md' --ignore 'node_modules'",
    "start": "netlify dev",
    "prebuild": "echo 'setup faunaDB' && npm run bootstrap",
    "build": "react-scripts build"
  }
}

    at new InternalCliError (/home/christian/PersonalProjects/netlify-cli/src/utils/error.js:13:17)
    at scanScripts (/home/christian/PersonalProjects/netlify-cli/src/detectors/utils/jsdetect.js:84:13)
    at detector (/home/christian/PersonalProjects/netlify-cli/src/detectors/create-react-app.js:17:28)
    at serverSettings (/home/christian/PersonalProjects/netlify-cli/src/utils/detect-server.js:43:30)
    at DevCommand.run (/home/christian/PersonalProjects/netlify-cli/src/commands/dev/index.js:234:24)
    at async DevCommand._run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/command.js:43:20)
    at async Config.runCommand (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/config/lib/config.js:173:24)
    at async Main.run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/main.js:27:9)
    at async Main._run (/home/christian/PersonalProjects/netlify-cli/node_modules/@oclif/command/lib/command.js:43:20)
◈ Cannot call `netlify dev` inside `netlify dev`.
```

Thrown errors throughout the CLI could theoretically be replaced pretty easily, and should help with bug reports as it will be much easier to copy-paste details.

A separate error was also added for the `netlify dev` in package.json issue, as it would just bubble up to the `possibleArgsArr` error before.

---

#### Footnotes

Super boring stylistic changes and comments were cleaned up, mostly just to save real estate and clarify the purpose of different statements. Some of the changes were required to silence the linter.
