### PR TITLE
fix: recover from unauthorized error in @netlify/config call

### DIFF
--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -26,8 +26,20 @@ class StatusCommand extends Command {
     this.log(`──────────────────────┐
  Current Netlify User │
 ──────────────────────┘`)
-    const accounts = await api.listAccountsForUser()
-    const user = await this.netlify.api.getCurrentUser()
+
+    let accounts
+    let user
+
+    try {
+      accounts = await api.listAccountsForUser()
+      user = await this.netlify.api.getCurrentUser()
+    } catch (error) {
+      if (error.status === 401) {
+        this.error(
+          'Your session has expired. Please try to re-authenticate by running `netlify logout` and `netlify login`.',
+        )
+      }
+    }
 
     const ghuser = this.netlify.globalConfig.get(`users.${current}.auth.github.user`)
     const accountData = {

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -127,7 +127,19 @@ class BaseCommand extends Command {
         offline: argv.offline,
       })
     } catch (error) {
-      const message = error.type === 'userError' ? error.message : error.stack
+      const isUserError = error.type === 'userError'
+
+      // If we're failing due to an error thrown by us, it might be because the token we're using is invalid.
+      // To account for that, we try to retrieve the config again, this time without a token, to avoid making
+      // any API calls.
+      //
+      // @todo Replace this with a mechanism for calling `resolveConfig` with more granularity (i.e. having
+      // the option to say that we don't need API data.)
+      if (isUserError && token) {
+        return this.getConfig(cwd, state)
+      }
+
+      const message = isUserError ? error.message : error.stack
       console.error(message)
       this.exit(1)
     }


### PR DESCRIPTION
**- Summary**

Since #1722, CLI is making an API call for every command, even for the ones that don't require API data (e.g. `login` and `logout`).

As a consequence, users might get locked in their accounts if they have an invalid/revoked token. If they try to login or logout, CLI will still try to use their existing token and fail before the command they're trying to execute has a change to succeed.

This PR adds a temporary solution that re-tries a call to `@netlify/config` _without_  a token if a call with the existing token fails.

It also adds a message to the `status` command checking for an unauthorised call to `api.listAccountsForUser` and `api.getCurrentUser` (currently it only exists for `api.getSite`. We should abstract this behaviour, so that any time we retrieve any user data with an invalid token, we're able to display a helpful error message (and possibly log the user out automatically?).

**- Description for the changelog**

fix: recover from unauthorized error in @netlify/config call

**- A picture of a cute animal (not mandatory but encouraged)**

![maxresdefault](https://user-images.githubusercontent.com/4162329/105842652-6d80ee80-5fce-11eb-9a13-86c97bd4554e.jpg)

