### PR TITLE
fix: disable local server polling for Next.js

### DIFF
--- a/src/detectors/next.js
+++ b/src/detectors/next.js
@@ -21,5 +21,6 @@ module.exports = function detector() {
     frameworkPort: FRAMEWORK_PORT,
     possibleArgsArrs,
     dist: 'out',
+    disableLocalServerPolling: true,
   }
 }


### PR DESCRIPTION
**- Summary**

This PR allows us to toggle the local server polling functionality introduced in #1795 based on the framework being used. For now, we're disabling it for Next.js, since its local server triggers a new page build for every request during the startup phase.

Closes #1815.

fix: disable local server polling for Next.js

**- A picture of a cute animal (not mandatory but encouraged)**

![Sea_Otter_(Enhydra_lutris)_(25169790524)_crop](https://user-images.githubusercontent.com/4162329/105987108-b8b20480-6095-11eb-97a2-ee1418a17f78.jpg)

