### PR TITLE
chore: support Node 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 15.x]
       fail-fast: false
 
     steps:
@@ -29,7 +29,7 @@ jobs:
         run: npm run site:build:install
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == '14.x' }}"
+        if: "${{ matrix.node-version == '15.x' }}"
       - name: Tests
         run: npm run test:ci
         env:


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/1

This tests Node 15 in CI.

This only tests Node 10 and 15, not 12. In my experience, it is quite rare to find a bug that fails on a specific major Node.js release but neither on an older nor newer one. Please let me know what you think.