### PR TITLE
fix(command-dev): handle headers with colon in value

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -67,6 +67,8 @@ const headersForPath = function (rules, path) {
   return pathObject
 }
 
+const HEADER_SEPARATOR = ':'
+
 const parseHeadersFile = function (filePath) {
   if (!fs.existsSync(filePath)) {
     return {}
@@ -94,9 +96,9 @@ const parseHeadersFile = function (filePath) {
       throw new Error('path should come before headers')
     }
 
-    if (line.includes(':')) {
-      const [key = '', value = ''] = line.split(':', 2)
-      const [trimmedKey, trimmedValue] = [key.trim(), value.trim()]
+    if (line.includes(HEADER_SEPARATOR)) {
+      const [key = '', ...value] = line.split(HEADER_SEPARATOR)
+      const [trimmedKey, trimmedValue] = [key.trim(), value.join(HEADER_SEPARATOR).trim()]
       if (trimmedKey.length === 0 || trimmedValue.length === 0) {
         throw new Error(`invalid header at line: ${index}\n${line}\n`)
       }

--- a/src/utils/headers.test.js
+++ b/src/utils/headers.test.js
@@ -35,6 +35,10 @@ const headers = [
     path: '/directory/*/test.html',
     headers: ['X-Frame-Options: test'],
   },
+  {
+    path: '/with-colon',
+    headers: ['Custom-header: http://www.example.com'],
+  },
 ]
 
 test.before(async (t) => {
@@ -98,6 +102,9 @@ test('_headers: validate rules', (t) => {
     },
     '/directory/*/test.html': {
       'X-Frame-Options': ['test'],
+    },
+    '/with-colon': {
+      'Custom-header': ['http://www.example.com'],
     },
   })
 })


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/1777 to fix header values such as `https://www.example.com`