### PR TITLE
chore(deps): update renovate to use  rangeStrategy bump

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
+  rangeStrategy: 'bump',
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 10


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/1663

Testing this configuration so we don't get releases with just a package lock file change