### PR TITLE
fix(command-dev): pass dev context to '@netlify/config'

### DIFF
--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -4,6 +4,11 @@ const Command = require('../../utils/command')
 const { injectEnvVariables } = require('../../utils/dev')
 
 class ExecCommand extends Command {
+  async init() {
+    this.commandContext = 'dev'
+    await super.init()
+  }
+
   async run() {
     const { log, warn, netlify } = this
     const { cachedConfig, site } = netlify

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -203,6 +203,11 @@ const printBanner = ({ url, log }) => {
 }
 
 class DevCommand extends Command {
+  async init() {
+    this.commandContext = 'dev'
+    await super.init()
+  }
+
   async run() {
     this.log(`${NETLIFYDEV}`)
     const { error: errorExit, log, warn, exit } = this

--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -4,6 +4,11 @@ const Command = require('../../utils/command')
 const { runProcess } = require('../../utils/traffic-mesh')
 
 class TraceCommand extends Command {
+  async init() {
+    this.commandContext = 'dev'
+    await super.init()
+  }
+
   async run() {
     this.parse(TraceCommand)
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -142,7 +142,7 @@ class BaseCommand extends Command {
       return await resolveConfig({
         config: argv.config,
         cwd,
-        context: argv.context,
+        context: argv.context || this.commandContext,
         debug: argv.debug,
         siteId: argv.siteId || (typeof argv.site === 'string' && argv.site) || state.get('siteId'),
         token,

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -153,7 +153,6 @@ const injectEnvVariables = async ({ env, log, site, warn }) => {
     }
   }
 
-  process.env.CONTEXT = 'dev'
   process.env.NETLIFY_DEV = 'true'
 }
 


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1873

**- Test plan**

Added a couple of tests

**- Description for the changelog**

Pass `context: dev` to `@netlify/config` when running dev related commands. This should tell `@netlify/config` to resolve settings from the correct `context`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/107881824-b1d91d80-6eee-11eb-802a-45dc1004f782.png)
