### PR TITLE
fix(command-lm-install): fix gitconfig path in windows

### DIFF
--- a/src/utils/lm/install.js
+++ b/src/utils/lm/install.js
@@ -196,7 +196,7 @@ const getCurrentCredentials = async () => {
 const getGitConfigContent = (gitConfigPath) => `
 # This next lines include Netlify's Git Credential Helper configuration in your Git configuration.
 [include]
-  path = ${path.posix.normalize(gitConfigPath)}
+  path = ${gitConfigPath.replace(/\\/g, '/')}
 `
 
 const configureGitConfig = async function () {


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/1879#discussion_r576247092

@ehmicky we can't use `unixify` as it replaces drive names 