### PR TITLE
fix(command-lm-install): remove legacy version on install

### DIFF
--- a/src/utils/lm/install.js
+++ b/src/utils/lm/install.js
@@ -92,6 +92,8 @@ const installedWithPackageManager = async function () {
 }
 
 const installHelper = async function ({ log }) {
+  // remove any old versions that might still exist in `~/.netlify/helper/bin`
+  await rmdirRecursiveAsync(getLegacyBinPath())
   const binPath = getBinPath()
   const shouldFetch = await shouldFetchLatestVersion({
     binPath,


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/1895

On Windows we append to `PATH` and not prepend:
https://github.com/netlify/cli/blob/75742eeae55b57ef8b657811ddeb443167f9f9e5/src/utils/lm/scripts/path.ps1#L26
https://github.com/netlify/cli/blob/75742eeae55b57ef8b657811ddeb443167f9f9e5/src/utils/lm/scripts/zsh.sh#L3
https://github.com/netlify/cli/blob/75742eeae55b57ef8b657811ddeb443167f9f9e5/src/utils/lm/scripts/bash.sh#L14

So if you have a version in the old location it takes precedence.
I think we should remove those regardless when installing a version to the new location.

We could also do some cleanup, but I'm a bit worried breaking users environments by removing stuff from `PATH`.
In addition, we could also prepend to `PATH`.
