### PR TITLE
fix(command-link): retrieve all sites using pagination params

### DIFF
--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -4,6 +4,7 @@ const process = require('process')
 const { flags: flagsLib } = require('@oclif/command')
 const chalk = require('chalk')
 
+const { listSites } = require('../lib/api')
 const Command = require('../utils/command')
 const { ensureNetlifyIgnore } = require('../utils/gitignore')
 const linkPrompt = require('../utils/link/link-by-prompt')
@@ -77,9 +78,12 @@ class LinkCommand extends Command {
     if (flags.name) {
       let results
       try {
-        results = await api.listSites({
-          name: flags.name,
-          filter: 'all',
+        results = await listSites({
+          api,
+          options: {
+            name: flags.name,
+            filter: 'all',
+          },
         })
       } catch (error) {
         if (error.status === 404) {

--- a/src/commands/sites/list.js
+++ b/src/commands/sites/list.js
@@ -2,6 +2,7 @@ const { flags: flagsLib } = require('@oclif/command')
 const chalk = require('chalk')
 const { cli } = require('cli-ux')
 
+const { listSites } = require('../../lib/api')
 const Command = require('../../utils/command')
 
 class SitesListCommand extends Command {
@@ -20,7 +21,7 @@ class SitesListCommand extends Command {
       },
     })
 
-    const sites = await api.listSites({ filter: 'all' })
+    const sites = await listSites({ api, options: { filter: 'all' } })
     if (!flags.json) {
       cli.action.stop()
     }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -77,4 +77,17 @@ const cancelDeploy = async ({ api, deployId, warn }) => {
   }
 }
 
-module.exports = { uploadEdgeHandlers, cancelDeploy }
+const FIRST_PAGE = 1
+const MAX_PAGES = 10
+const MAX_PER_PAGE = 100
+const listSites = async ({ api, options }) => {
+  const { page = FIRST_PAGE, maxPages = MAX_PAGES, ...rest } = options
+  const sites = await api.listSites({ page, per_page: MAX_PER_PAGE, ...rest })
+  // TODO: use pagination headers when js-client returns them
+  if (sites.length === MAX_PER_PAGE && page + 1 <= maxPages) {
+    return [...sites, ...(await listSites({ api, options: { page: page + 1, maxPages, ...rest } }))]
+  }
+  return sites
+}
+
+module.exports = { uploadEdgeHandlers, cancelDeploy, listSites }

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -161,7 +161,6 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
       let sites
       try {
         sites = await listSites({ api, options: { maxPages: 1, filter: 'all' } })
-        console.log(sites.length)
       } catch (error) {
         context.error(error)
       }

--- a/src/utils/link/link-by-prompt.js
+++ b/src/utils/link/link-by-prompt.js
@@ -4,6 +4,7 @@ const chalk = require('chalk')
 const inquirer = require('inquirer')
 const isEmpty = require('lodash/isEmpty')
 
+const { listSites } = require('../../lib/api')
 const { getRepoData } = require('../get-repo-data')
 const { track } = require('../telemetry')
 
@@ -46,7 +47,7 @@ module.exports = async function linkPrompts(context, flags = {}) {
       context.log()
       context.log(`Looking for sites connected to '${repoData.httpsUrl}'...`)
       context.log()
-      const sites = await api.listSites({ filter: 'all' })
+      const sites = await listSites({ api, options: { filter: 'all' } })
 
       if (isEmpty(sites)) {
         context.error(
@@ -112,9 +113,9 @@ Run ${chalk.cyanBright('git remote -v')} to see a list of your git remotes.`)
 
       let matchingSites
       try {
-        matchingSites = await api.listSites({
-          name: searchTerm,
-          filter: 'all',
+        matchingSites = await listSites({
+          api,
+          options: { name: searchTerm, filter: 'all' },
         })
       } catch (error) {
         if (error.status === 404) {
@@ -159,7 +160,8 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
 
       let sites
       try {
-        sites = await api.listSites({ filter: 'all' })
+        sites = await listSites({ api, options: { maxPages: 1, filter: 'all' } })
+        console.log(sites.length)
       } catch (error) {
         context.error(error)
       }


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1898
Doesn't fix https://github.com/netlify/cli/issues/258 since that issue is now related to [strict SAML support](https://docs.netlify.com/accounts-and-billing/team-management/saml-single-sign-on/#only-sso-allowed) in the CLI.

**- Test plan**

Tested manually 
```sh
$ ntl sites:list --json | jq length
$ 226
```

**- Description for the changelog**

Paginate on all sites when calling `listSites`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/108232740-bc442300-714b-11eb-8821-53aaa54a6de7.png)
