### PR TITLE
fix: reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "/oclif.manifest.json",
     "/scripts/postinstall.js",
     "/src/**/*.js",
-    "/src/utils/lm/scripts",
+    "/src/**/*.sh",
+    "/src/**/*.ps1",
+    "!/src/**/node_modules/**",
     "!/src/**/*.test.js"
   ],
   "homepage": "https://github.com/netlify/cli",


### PR DESCRIPTION
This removes `src/functions-templates/**/node_modules` from the package published to npm.

Before: `305.8 KB` (packed), `1.3 MB` (unpacked)
After: `160.5 KB` (packed), `599.2 KB` (unpacked)