### PR TITLE
feat: rename trafficMesh flag to edgeHandlers

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -136,7 +136,7 @@ const FRAMEWORK_PORT_TIMEOUT = 6e5
 
 const startProxyServer = async ({ flags, settings, site, log, exit, addonsUrls }) => {
   let url
-  if (flags.trafficMesh) {
+  if (flags.edgeHandlers || flags.trafficMesh) {
     url = await startForwardProxy({
       port: settings.port,
       frameworkPort: settings.frameworkPort,
@@ -221,6 +221,12 @@ class DevCommand extends Command {
       ...(config.build.publish && { publish: config.build.publish }),
       ...config.dev,
       ...flags,
+    }
+
+    if (flags.trafficMesh) {
+      warn(
+        '--trafficMesh and -t are deprecated and will be removed in the near future. Please use --edgeHandlers or -e instead.',
+      )
     }
 
     await injectEnvVariables({ env: this.netlify.cachedConfig.env, log, site, warn })
@@ -311,10 +317,15 @@ DevCommand.flags = {
     char: 'l',
     description: 'start a public live session',
   }),
+  edgeHandlers: flagsLib.boolean({
+    char: 'e',
+    hidden: true,
+    description: 'activates the Edge Handlers runtime',
+  }),
   trafficMesh: flagsLib.boolean({
     char: 't',
     hidden: true,
-    description: 'uses Traffic Mesh for proxying requests',
+    description: '(DEPRECATED: use --edgeHandlers or -e instead) uses Traffic Mesh for proxying requests',
   }),
   locationDb: flagsLib.string({
     description: 'specify the path to a local GeoIP location database in MMDB format',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
The `--trafficMesh` flag is not a super clear term to users, let's go for `--edgeHandlers` which is more to the point. Deprecate the current flag in favor of a. new flag and add a warning to users that use the old one.

![image](https://user-images.githubusercontent.com/11183523/108767506-896fa580-7524-11eb-9f23-58e92dcde37e.png)

**- Test plan**

Choose your poison:
- `npm run test` (follow Contributing.md for instructions)
- `netlify dev --edgeHandlers`
- `netlify dev -eh`

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Rename `netlify dev` flag `--trafficMesh` (short: `-t`) to `--edgeHandlers` (short: `-eh`) and update description to `activates the edge handlers runtime`.

**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://user-images.githubusercontent.com/11183523/108517314-41871f00-7295-11eb-94b0-c545dcbb2ce6.png" width=300/>
