### PR TITLE
fix(command-init): use netlify/functions instead of functions

### DIFF
--- a/src/utils/init/utils.js
+++ b/src/utils/init/utils.js
@@ -41,7 +41,7 @@ const getDefaultSettings = async ({ siteRoot, config }) => {
   return {
     defaultBuildCmd,
     defaultBuildDir: normalizeDir({ siteRoot, dir: defaultBuildDir, defaultValue: '.' }),
-    defaultFunctionsDir: normalizeDir({ siteRoot, dir: defaultFunctionsDir, defaultValue: 'functions' }),
+    defaultFunctionsDir: normalizeDir({ siteRoot, dir: defaultFunctionsDir, defaultValue: 'netlify/functions' }),
   }
 }
 


### PR DESCRIPTION
**- Summary**

fixes https://github.com/netlify/cli/issues/1909

**- Test plan**

![image](https://user-images.githubusercontent.com/26760571/108888255-e302cd80-7613-11eb-91e2-9d26d1ee9485.png)

**- Description for the changelog**

Updates the default functions directory recommendation to `netlify/functions`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/26760571/108888424-23624b80-7614-11eb-95a6-7189794dfe48.png)
