### PR TITLE
feat: add environment variable for esbuild

### DIFF
--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -1,3 +1,5 @@
+const { env } = require('process')
+
 const build = require('@netlify/build')
 
 // We have already resolved the configuration using `@netlify/config`
@@ -10,7 +12,19 @@ const getBuildOptions = ({ context, token, flags }) => {
   // buffer = true will not stream output
   const buffer = flags.json || flags.silent
 
-  return { cachedConfig: serializedConfig, token, dry, debug, mode: 'cli', telemetry: false, buffer }
+  // @todo Remove once esbuild has been fully rolled out.
+  const featureFlags = env.NETLIFY_EXPERIMENTAL_ESBUILD ? 'buildbot_esbuild' : undefined
+
+  return {
+    cachedConfig: serializedConfig,
+    token,
+    dry,
+    debug,
+    mode: 'cli',
+    telemetry: false,
+    buffer,
+    featureFlags,
+  }
 }
 
 const runBuild = async (options) => {


### PR DESCRIPTION
**- Summary**

With the rollout of esbuild (https://github.com/netlify/zip-it-and-ship-it/pull/339 and https://github.com/netlify/build/pull/2308), `zip-it-and-ship-it` will no longer look for a `NETLIFY_EXPERIMENTAL_ESBUILD` environment variable. This means that people who want to bundle locally using esbuild will lose their ability to opt-in.

Until we have #1913, there's no feature flag mechanism extended to the CLI, so this PR reuses the same environment variable that `zip-it-and-ship-it` was using. When it's detected, the correct feature flag (i.e. `buildbot_esbuild`) is passed along to Netlify Build.

**- Description for the changelog**

feat: add environment variable for esbuild

**- A picture of a cute animal (not mandatory but encouraged)**

![shutterstock_132484832](https://user-images.githubusercontent.com/4162329/109147331-c8883b80-775c-11eb-894c-21a9a207d47e.jpg)

