### PR TITLE
chore: use default rangeStrategy

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  rangeStrategy: 'bump',
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 10


### PR DESCRIPTION
Use the default renovate strategy to avoid restricting ranges for non Netlify packages.

For Netlify packages we still use `bump` from https://github.com/netlify/renovate-config/blob/e7e66c5e8ec56923e0acfcb8b335564e86e7ff2d/default.json#L23

This should close all of theses PRs 
![image](https://user-images.githubusercontent.com/26760571/109474618-5f1a6c80-7a7d-11eb-9220-92e2a0214278.png)
