### PR TITLE
fix(command-dev): call middleware next on invalid content-type

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -176,7 +176,7 @@ const serverSettings = async (devConfig, flags, projectDir, log) => {
   settings.jwtRolePath = devConfig.jwtRolePath || 'app_metadata.authorization.roles'
   settings.functions = devConfig.functions || settings.functions
   if (settings.functions) {
-    settings.functionsPort = await getPort({ port: settings.functionsPort || 0 })
+    settings.functionsPort = await getPort({ port: devConfig.functionsPort || 0 })
   }
 
   return settings

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -249,7 +249,7 @@ const createHandler = async function ({ dir, capabilities, warn }) {
   }
 }
 
-const createFormSubmissionHandler = function ({ siteUrl }) {
+const createFormSubmissionHandler = function ({ siteUrl, warn }) {
   return async function formSubmissionHandler(req, res, next) {
     if (req.url.startsWith('/.netlify/') || req.method !== 'POST') return next()
 
@@ -305,10 +305,12 @@ const createFormSubmissionHandler = function ({ siteUrl }) {
           })
         })
       } catch (error) {
-        return console.error(error)
+        warn(error)
+        return next()
       }
     } else {
-      return console.error('Invalid Content-Type for Netlify Dev forms request')
+      warn('Invalid Content-Type for Netlify Dev forms request')
+      return next()
     }
     const data = JSON.stringify({
       payload: {
@@ -370,7 +372,7 @@ const getFunctionsServer = async function ({ dir, siteUrl, capabilities, warn })
     }),
   )
   app.use(bodyParser.raw({ limit: '6mb', type: '*/*' }))
-  app.use(createFormSubmissionHandler({ siteUrl }))
+  app.use(createFormSubmissionHandler({ siteUrl, warn }))
   app.use(
     expressLogging(console, {
       blacklist: ['/favicon.ico'],

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1374,6 +1374,27 @@ testMatrix.forEach(({ args }) => {
         })
       })
     })
+
+    test(testName(`doesn't hang when sending a application/json POST request to function server`, args), async (t) => {
+      await withSiteBuilder('site-with-functions', async (builder) => {
+        const functionsPort = 6666
+        await builder
+          .withNetlifyToml({ config: { build: { functions: 'functions' }, dev: { functionsPort } } })
+          .buildAsync()
+
+        await withDevServer({ cwd: builder.directory, args }, async ({ url, port }) => {
+          const response = await gotCatch404(`${url.replace(port, functionsPort)}/test`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: '{}',
+          })
+          t.is(response.statusCode, 404)
+          t.is(response.body, 'Function not found...')
+        })
+      })
+    })
   }
 })
 /* eslint-enable require-await */


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1279

**- Test plan**

Added a test case

**- Description for the changelog**

Call the `next` function when an invalid request was sent to the functions form submission handler to avoid blocking forever.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/109517981-80e21680-7ab2-11eb-8acf-83ec08ae39da.png)
