### PR TITLE
chore: ignore major updates for 'open' and 'inquirer'

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 10
-      packageNames: ['path-type'],
+      packageNames: ['path-type', 'open', 'inquirer'],
       major: {
         enabled: false,
       },


### PR DESCRIPTION
We can't update these until we drop support for Node.js 10