### PR TITLE
fix(sites-delete): use siteId instead of cwdSiteId for warning messages

### DIFF
--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -42,7 +42,7 @@ class SitesDeleteCommand extends Command {
     /* Verify the user wants to delete the site */
     if (noForce) {
       this.log(`${chalk.redBright('Warning')}: You are about to permanently delete "${chalk.bold(siteData.name)}"`)
-      this.log(`         Verify this siteID "${cwdSiteId}" supplied is correct and proceed.`)
+      this.log(`         Verify this siteID "${siteId}" supplied is correct and proceed.`)
       this.log('         To skip this prompt, pass a --force flag to the delete command')
       this.log()
       this.log(`${chalk.bold('Be careful here. There is no undo!')}`)
@@ -66,7 +66,7 @@ class SitesDeleteCommand extends Command {
       this.log(`Supplied:       "${siteId}"`)
       this.log(`Current Site:   "${cwdSiteId}"`)
       this.log()
-      this.log(`Verify this siteID "${cwdSiteId}" supplied is correct and proceed.`)
+      this.log(`Verify this siteID "${siteId}" supplied is correct and proceed.`)
       this.log('To skip this prompt, pass a --force flag to the delete command')
       const { wantsToDelete } = await inquirer.prompt({
         type: 'confirm',


### PR DESCRIPTION
**- Summary**

When running `ntl sites:delete <site-id>` from a directory not linked to a site the prompt before deleting the site had `undefined` in the warning message.

This PR fixes it.

**- Test plan**

Before:
![image](https://user-images.githubusercontent.com/26760571/110656658-d01dfa80-81c8-11eb-97e5-0a0c4210bb93.png)

After:
![image](https://user-images.githubusercontent.com/26760571/110656589-c1cfde80-81c8-11eb-9903-24346e1ff32d.png)

**- Description for the changelog**

Fix `undefined` in warning message when deleting a site.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/110657138-43277100-81c9-11eb-966b-fc38fda8098f.png)
