### PR TITLE
chore: remove redundant changelog header in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,11 +25,4 @@ Demonstrate the code is solid.
 Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
 -->
 
-**- Description for the changelog**
-
-<!--
-Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
--->
-
 **- A picture of a cute animal (not mandatory but encouraged)**


### PR DESCRIPTION
We don't really need the `Description for the changelog` part in the PR template as we autogenerate the changelog.