### PR TITLE
feat: add a --prodIfUnlocked flag

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -87,6 +87,7 @@ netlify deploy
 - `dir` (*string*) - Specify a folder to deploy
 - `functions` (*string*) - Specify a functions folder to deploy
 - `prod` (*boolean*) - Deploy to production
+- `prodIfUnlocked` (*boolean*) - Deploy to production if unlocked, create a draft otherwise
 - `alias` (*string*) - Specifies the alias for deployment. Useful for creating predictable deployment URLs. Maximum 37 characters.
 - `branch` (*string*) - Serves the same functionality as --alias. Deprecated and will be removed in future versions
 - `open` (*boolean*) - Open site after deploy
@@ -107,6 +108,7 @@ netlify deploy
 netlify deploy
 netlify deploy --prod
 netlify deploy --prod --open
+netlify deploy --prodIfUnlocked
 netlify deploy --message "A message with an $ENV_VAR"
 netlify deploy --auth $NETLIFY_AUTH_TOKEN
 netlify deploy --trigger

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -405,7 +405,7 @@ class DeployCommand extends Command {
       }
     }
 
-    const deployToProduction = flags.prod || (flags['prod-if-unlocked'] && !siteData.published_deploy.locked)
+    const deployToProduction = flags.prod || (flags.prodIfUnlocked && !siteData.published_deploy.locked)
 
     if (flags.trigger) {
       return triggerDeploy({ api, siteId, siteData, log, error })
@@ -546,7 +546,7 @@ DeployCommand.examples = [
   'netlify deploy',
   'netlify deploy --prod',
   'netlify deploy --prod --open',
-  'netlify deploy --prod-if-unlocked',
+  'netlify deploy --prodIfUnlocked',
   'netlify deploy --message "A message with an $ENV_VAR"',
   'netlify deploy --auth $NETLIFY_AUTH_TOKEN',
   'netlify deploy --trigger',
@@ -565,9 +565,9 @@ DeployCommand.flags = {
     char: 'p',
     description: 'Deploy to production',
     default: false,
-    exclusive: ['alias', 'branch', 'prod-if-unlocked'],
+    exclusive: ['alias', 'branch', 'prodIfUnlocked'],
   }),
-  'prod-if-unlocked': flagsLib.boolean({
+  prodIfUnlocked: flagsLib.boolean({
     description: 'Deploy to production if unlocked, create a draft otherwise',
     default: false,
     exclusive: ['alias', 'branch', 'prod'],

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -350,7 +350,6 @@ class DeployCommand extends Command {
       warn('--branch flag has been renamed to --alias and will be removed in future versions')
     }
 
-    const deployToProduction = flags.prod
     await this.authenticate(flags.auth)
 
     await this.config.runHook('analytics', {
@@ -405,6 +404,8 @@ class DeployCommand extends Command {
         siteId = site.id
       }
     }
+
+    const deployToProduction = flags.prod || (flags['prod-if-unlocked'] && !siteData.published_deploy.locked)
 
     if (flags.trigger) {
       return triggerDeploy({ api, siteId, siteData, log, error })
@@ -545,6 +546,7 @@ DeployCommand.examples = [
   'netlify deploy',
   'netlify deploy --prod',
   'netlify deploy --prod --open',
+  'netlify deploy --prod-if-unlocked',
   'netlify deploy --message "A message with an $ENV_VAR"',
   'netlify deploy --auth $NETLIFY_AUTH_TOKEN',
   'netlify deploy --trigger',
@@ -563,7 +565,12 @@ DeployCommand.flags = {
     char: 'p',
     description: 'Deploy to production',
     default: false,
-    exclusive: ['alias', 'branch'],
+    exclusive: ['alias', 'branch', 'prod-if-unlocked'],
+  }),
+  'prod-if-unlocked': flagsLib.boolean({
+    description: 'Deploy to production if unlocked, create a draft otherwise',
+    default: false,
+    exclusive: ['alias', 'branch', 'prod'],
   }),
   alias: flagsLib.string({
     description:


### PR DESCRIPTION
This lets you publish to production if it's unlocked in the Netlfify dashboard and create drafts otherwise.

closes #1392

The oclif/command lib doesn't let us create a `--prod=auto` flag that's also a boolean flag so it's separate. I think it's clearer anyway.

