### PR TITLE
fix: add missing watch command to docs site

### DIFF
--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -1,6 +1,6 @@
 ---
 title: Netlify CLI watch command
-hidden: true
+description: Watch for site deploy to finish
 ---
 
 # `watch`

--- a/site/src/_app.js
+++ b/site/src/_app.js
@@ -53,6 +53,7 @@ const navOrder = [
   'sites',
   'status',
   'unlink',
+  'watch',
   'netlify-dev',
   'contributing',
 ]


### PR DESCRIPTION
**- Summary**

The watch command is available when someone runs `ntl help`. It doesn't make any sense to hide it in the site docs.

**- Test plan**

See preview URL

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/111075944-df67b580-84f2-11eb-88c6-469aae8dda58.png)
