### PR TITLE
feat: add functions directory creation when non-existent in netlify.toml

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -64,7 +64,7 @@ netlify functions:create
 
 **Arguments**
 
-- name - name of your new function file inside your functions folder
+- name - name of your new function file inside your functions directory
 
 **Flags**
 

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -211,9 +211,7 @@ const ensureFunctionDirExists = async function (context) {
     log(`${NETLIFYDEVLOG} functions directory not specified in netlify.toml or UI settings`)
 
     if (!siteId) {
-      context.error(
-        `${NETLIFYDEVERR} No site id found, please run inside a site directory or \`netlify link\``,
-      )
+      context.error(`${NETLIFYDEVERR} No site id found, please run inside a site directory or \`netlify link\``)
     }
 
     const { functionsDir } = await inquirer.prompt([

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -225,18 +225,18 @@ const ensureFunctionDirExists = async function () {
   }
 
   if (!functionsDirHolder) {
-    log(`${NETLIFYDEVLOG} functions folder not specified in netlify.toml or app settings`)
+    log(`${NETLIFYDEVLOG} functions directory not specified in netlify.toml or UI settings`)
     const { functionsDir } = await inquirer.prompt([
       {
         type: 'input',
         name: 'functionsDir',
-        message: 'Enter the path where your functions should live:',
+        message: 'Enter the path, relative to your site’s base directory in your repository, where your functions should live:',
         default: 'netlify/functions',
       },
     ])
 
     try {
-      log(`${NETLIFYDEVLOG} updating app build settings with ${chalk.magenta.inverse(functionsDirHolder)}`)
+      log(`${NETLIFYDEVLOG} updating site settings with ${chalk.magenta.inverse(functionsDirHolder)}`)
       await api.updateSite({
         siteId,
         body: {
@@ -246,7 +246,7 @@ const ensureFunctionDirExists = async function () {
         },
       })
       log(
-        `${NETLIFYDEVLOG} functions folder ${chalk.magenta.inverse(functionsDirHolder)} updated in app build settings`,
+        `${NETLIFYDEVLOG} functions directory ${chalk.magenta.inverse(functionsDirHolder)} updated in site settings`,
       )
     } catch (error) {
       error('Error updating site settings')
@@ -257,12 +257,12 @@ const ensureFunctionDirExists = async function () {
 
   if (!fs.existsSync(functionsDirHolder)) {
     log(
-      `${NETLIFYDEVLOG} functions folder ${chalk.magenta.inverse(
+      `${NETLIFYDEVLOG} functions directory ${chalk.magenta.inverse(
         functionsDirHolder,
       )} does not exist yet, creating it...`,
     )
     fs.mkdirSync(functionsDirHolder, { recursive: true })
-    log(`${NETLIFYDEVLOG} functions folder ${chalk.magenta.inverse(functionsDirHolder)} created`)
+    log(`${NETLIFYDEVLOG} functions directory ${chalk.magenta.inverse(functionsDirHolder)} created`)
   }
 
   return functionsDirHolder

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -211,7 +211,9 @@ const ensureFunctionDirExists = async function (context) {
     log(`${NETLIFYDEVLOG} functions directory not specified in netlify.toml or UI settings`)
 
     if (!siteId) {
-      context.log(`${NETLIFYDEVERR} Unable to find a site id. Please make sure you are in a directory that is linked to a site with Netlify.`)
+      context.log(
+        `${NETLIFYDEVERR} Unable to find a site id. Please make sure you are in a directory that is linked to a site with Netlify.`,
+      )
       process.exit(1)
     }
 

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -50,7 +50,7 @@ class FunctionsCreateCommand extends Command {
 FunctionsCreateCommand.args = [
   {
     name: 'name',
-    description: 'name of your new function file inside your functions folder',
+    description: 'name of your new function file inside your functions directory',
   },
 ]
 
@@ -211,10 +211,9 @@ const ensureFunctionDirExists = async function (context) {
     log(`${NETLIFYDEVLOG} functions directory not specified in netlify.toml or UI settings`)
 
     if (!siteId) {
-      context.log(
-        `${NETLIFYDEVERR} Unable to find a site id. Please make sure you are in a directory that is linked to a site with Netlify.`,
+      context.error(
+        `${NETLIFYDEVERR} No site id found, please run inside a site directory or \`netlify link\``,
       )
-      process.exit(1)
     }
 
     const { functionsDir } = await inquirer.prompt([
@@ -351,7 +350,7 @@ const scaffoldFromTemplate = async function (context, flags, args, functionsDir)
     const pathToTemplate = path.join(templatesDir, lang, templateName)
     if (!fs.existsSync(pathToTemplate)) {
       throw new Error(
-        `there isnt a corresponding folder to the selected name, ${templateName} template is misconfigured`,
+        `there isnt a corresponding directory to the selected name, ${templateName} template is misconfigured`,
       )
     }
 
@@ -459,7 +458,7 @@ const installAddons = async function (context, functionAddons, fnPath) {
   const { api, site } = context.netlify
   const siteId = site.id
   if (!siteId) {
-    log('No site id found, please run inside a site folder or `netlify link`')
+    log('No site id found, please run inside a site directory or `netlify link`')
     return false
   }
   log(`${NETLIFYDEVLOG} checking Netlify APIs...`)
@@ -491,7 +490,7 @@ const installAddons = async function (context, functionAddons, fnPath) {
 }
 
 // we used to allow for a --dir command,
-// but have retired that to force every scaffolded function to be a folder
+// but have retired that to force every scaffolded function to be a directory
 const ensureFunctionPathIsOk = function (context, functionsDir, name) {
   const functionPath = path.join(functionsDir, name)
   if (fs.existsSync(functionPath)) {

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -206,7 +206,7 @@ const ensureFunctionDirExists = async function (context, flags, config) {
       {
         type: 'input',
         name: 'functionsDir',
-        message: 'Enter the path where your functions should live: netlify/functions:',
+        message: 'Enter the path where your functions should live:',
         default: 'netlify/functions',
       },
     ])

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -203,11 +203,17 @@ const DEFAULT_PRIORITY = 999
  */
 const ensureFunctionDirExists = async function (context) {
   const { api, config, site } = context.netlify
+  const siteId = site.id
   const { log } = context
   let functionsDirHolder = config.functionsDirectory
 
   if (!functionsDirHolder) {
     log(`${NETLIFYDEVLOG} functions directory not specified in netlify.toml or UI settings`)
+
+    if (!siteId) {
+      context.log(`${NETLIFYDEVERR} Unable to find a site id. Please make sure you are in a directory that is linked to a site with Netlify.`)
+      process.exit(1)
+    }
 
     const { functionsDir } = await inquirer.prompt([
       {

--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -259,6 +259,7 @@ const downloadFromURL = async function (context, flags, args, functionsDir) {
   const folderContents = await readRepoURL(flags.url)
   const [functionName] = flags.url.split('/').slice(-1)
   const nameToUse = await getNameFromArgs(args, flags, functionName)
+
   const fnFolder = path.join(functionsDir, nameToUse)
   if (fs.existsSync(`${fnFolder}.js`) && fs.lstatSync(`${fnFolder}.js`).isFile()) {
     context.log(
@@ -347,6 +348,7 @@ const scaffoldFromTemplate = async function (context, flags, args, functionsDir)
     }
 
     const name = await getNameFromArgs(args, flags, templateName)
+
     context.log(`${NETLIFYDEVLOG} Creating function ${chalk.cyan.inverse(name)}`)
     const functionPath = ensureFunctionPathIsOk(context, functionsDir, name)
 

--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -11,8 +11,8 @@ const fs = require('../src/lib/fs')
 
 const cliPath = require('./utils/cli-path')
 const { withDevServer } = require('./utils/dev-server')
-const { handleQuestions, answerWithValue, CONFIRM } = require('./utils/handle-questions');
-const { withMockApi } = require('./utils/mock-api');
+const { handleQuestions, answerWithValue, CONFIRM } = require('./utils/handle-questions')
+const { withMockApi } = require('./utils/mock-api')
 const { withSiteBuilder } = require('./utils/site-builder')
 
 test.beforeEach((t) => {
@@ -47,7 +47,7 @@ test('should return function response when invoked', async (t) => {
 })
 
 test('should create a new function directory when none is found', async (t) => {
-  const { binPath } = t.context;
+  const { binPath } = t.context
 
   const initQuestions = [
     {
@@ -56,12 +56,12 @@ test('should create a new function directory when none is found', async (t) => {
     },
     {
       question: 'Pick a template',
-      answer: answerWithValue(CONFIRM)
+      answer: answerWithValue(CONFIRM),
     },
     {
       question: 'name your function',
-      answer: answerWithValue(CONFIRM)
-    }
+      answer: answerWithValue(CONFIRM),
+    },
   ]
 
   const siteInfo = {
@@ -87,17 +87,16 @@ test('should create a new function directory when none is found', async (t) => {
   ]
 
   await withSiteBuilder('site-with-no-functions-dir', async (builder) => {
-    builder.withNetlifyToml({config: { build: { functions: 'functions' } }})
+    builder.withNetlifyToml({ config: { build: { functions: 'functions' } } })
 
-    await builder.buildAsync();
-
+    await builder.buildAsync()
 
     await withMockApi(routes, async ({ apiUrl }) => {
       // --manual is used to avoid the config-github flow that uses GitHub API
       const childProcess = execa(cliPath, ['functions:create'], {
-        env: { 
-          NETLIFY_API_URL: apiUrl, 
-          NETLIFY_SITE_ID: 'site_id', 
+        env: {
+          NETLIFY_API_URL: apiUrl,
+          NETLIFY_SITE_ID: 'site_id',
           NETLIFY_AUTH_TOKEN: 'fake-token',
           cwd: builder.directory,
         },

--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -62,7 +62,7 @@ test('should create a new function directory when none is found', async (t) => {
     const createFunctionQuestions = [
       {
         question: 'Enter the path, relative to your site',
-        answer: answerWithValue(`${builder.directory}/test/functions`),
+        answer: answerWithValue('test/functions'),
       },
       {
         question: 'Pick a template',
@@ -80,8 +80,8 @@ test('should create a new function directory when none is found', async (t) => {
           NETLIFY_API_URL: apiUrl,
           NETLIFY_SITE_ID: 'site_id',
           NETLIFY_AUTH_TOKEN: 'fake-token',
-          cwd: builder.directory,
         },
+        cwd: builder.directory,
       })
 
       handleQuestions(childProcess, createFunctionQuestions)

--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -1,11 +1,28 @@
 // Handlers are meant to be async outside tests
 /* eslint-disable require-await */
+const path = require('path')
+
 const test = require('ava')
 const execa = require('execa')
+const tempDirectory = require('temp-dir')
+const { v4: uuid } = require('uuid')
+
+const fs = require('../src/lib/fs')
 
 const cliPath = require('./utils/cli-path')
 const { withDevServer } = require('./utils/dev-server')
+const { handleQuestions, answerWithValue, CONFIRM } = require('./utils/handle-questions');
+const { withMockApi } = require('./utils/mock-api');
 const { withSiteBuilder } = require('./utils/site-builder')
+
+test.beforeEach((t) => {
+  const directory = path.join(tempDirectory, `netlify-cli-functions-create`, uuid())
+  t.context.binPath = directory
+})
+
+test.afterEach(async (t) => {
+  await fs.rmdirRecursiveAsync(t.context.binPath)
+})
 
 test('should return function response when invoked', async (t) => {
   await withSiteBuilder('site-with-ping-function', async (builder) => {
@@ -28,4 +45,71 @@ test('should return function response when invoked', async (t) => {
     })
   })
 })
+
+test('should create a new function directory when none is found', async (t) => {
+  const { binPath } = t.context;
+
+  const initQuestions = [
+    {
+      question: 'Enter the path, relative to your site',
+      answer: answerWithValue(binPath),
+    },
+    {
+      question: 'Pick a template',
+      answer: answerWithValue(CONFIRM)
+    },
+    {
+      question: 'name your function',
+      answer: answerWithValue(CONFIRM)
+    }
+  ]
+
+  const siteInfo = {
+    admin_url: 'https://app.netlify.com/sites/site-name/overview',
+    ssl_url: 'https://site-name.netlify.app/',
+    id: 'site_id',
+    name: 'site-name',
+    build_settings: { repo_url: 'https://github.com/owner/repo' },
+  }
+  const routes = [
+    {
+      path: 'accounts',
+      response: [{ slug: 'test-account' }],
+    },
+    { path: 'sites/site_id/service-instances', response: [] },
+    { path: 'sites/site_id', response: siteInfo },
+    {
+      path: 'sites',
+      response: [siteInfo],
+    },
+    { path: 'deploy_keys', method: 'post', response: { public_key: 'public_key' } },
+    { path: 'sites/site_id', method: 'patch', response: { deploy_hook: 'deploy_hook' } },
+  ]
+
+  await withSiteBuilder('site-with-no-functions-dir', async (builder) => {
+    builder.withNetlifyToml({config: { build: { functions: 'functions' } }})
+
+    await builder.buildAsync();
+
+
+    await withMockApi(routes, async ({ apiUrl }) => {
+      // --manual is used to avoid the config-github flow that uses GitHub API
+      const childProcess = execa(cliPath, ['functions:create'], {
+        env: { 
+          NETLIFY_API_URL: apiUrl, 
+          NETLIFY_SITE_ID: 'site_id', 
+          NETLIFY_AUTH_TOKEN: 'fake-token',
+          cwd: builder.directory,
+        },
+      })
+
+      handleQuestions(childProcess, initQuestions)
+
+      await childProcess
+
+      t.is(await fs.fileExistsAsync(`${binPath}/hello-world/hello-world.js`), true)
+    })
+  })
+})
+
 /* eslint-enable require-await */

--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -93,4 +93,62 @@ test('should create a new function directory when none is found', async (t) => {
   })
 })
 
+test('should not create a new function directory when one is found', async (t) => {
+  const siteInfo = {
+    admin_url: 'https://app.netlify.com/sites/site-name/overview',
+    ssl_url: 'https://site-name.netlify.app/',
+    id: 'site_id',
+    name: 'site-name',
+    build_settings: { repo_url: 'https://github.com/owner/repo' },
+  }
+
+  const routes = [
+    {
+      path: 'accounts',
+      response: [{ slug: 'test-account' }],
+    },
+    { path: 'sites/site_id/service-instances', response: [] },
+    { path: 'sites/site_id', response: siteInfo },
+    {
+      path: 'sites',
+      response: [siteInfo],
+    },
+    { path: 'sites/site_id', method: 'patch', response: {} },
+  ]
+
+  await withSiteBuilder('site-with-functions-dir', async (builder) => {
+    builder.withNetlifyToml({ config: { build: { functions: 'functions' } } })
+
+    await builder.buildAsync()
+
+    const createFunctionQuestions = [
+      {
+        question: 'Pick a template',
+        answer: answerWithValue(CONFIRM),
+      },
+      {
+        question: 'name your function',
+        answer: answerWithValue(CONFIRM),
+      },
+    ]
+
+    await withMockApi(routes, async ({ apiUrl }) => {
+      const childProcess = execa(cliPath, ['functions:create'], {
+        env: {
+          NETLIFY_API_URL: apiUrl,
+          NETLIFY_SITE_ID: 'site_id',
+          NETLIFY_AUTH_TOKEN: 'fake-token',
+        },
+        cwd: builder.directory,
+      })
+
+      handleQuestions(childProcess, createFunctionQuestions)
+
+      await childProcess
+
+      t.is(await fs.fileExistsAsync(`${builder.directory}/functions/hello-world/hello-world.js`), true)
+    })
+  })
+})
+
 /* eslint-enable require-await */

--- a/tests/command.init.test.js
+++ b/tests/command.init.test.js
@@ -1,5 +1,3 @@
-const { Buffer } = require('buffer')
-
 const test = require('ava')
 const execa = require('execa')
 const toml = require('toml')
@@ -7,26 +5,9 @@ const toml = require('toml')
 const { readFileAsync } = require('../src/lib/fs')
 
 const cliPath = require('./utils/cli-path')
+const { handleQuestions, answerWithValue, CONFIRM, DOWN } = require('./utils/handle-questions')
 const { withMockApi } = require('./utils/mock-api')
 const { withSiteBuilder } = require('./utils/site-builder')
-
-const handleQuestions = (process, questions) => {
-  const remainingQuestions = [...questions]
-  let buffer = ''
-  process.stdout.on('data', (data) => {
-    buffer += data
-    const index = remainingQuestions.findIndex(({ question }) => buffer.includes(question))
-    if (index >= 0) {
-      buffer = ''
-      process.stdin.write(Buffer.from(remainingQuestions[index].answer))
-      remainingQuestions.splice(index, 1)
-    }
-  })
-}
-
-const CONFIRM = '\n'
-const DOWN = '\u001B[B'
-const answerWithValue = (value) => `${value}${CONFIRM}`
 
 const assetSiteRequests = (
   t,

--- a/tests/utils/handle-questions.js
+++ b/tests/utils/handle-questions.js
@@ -1,0 +1,34 @@
+const { Buffer } = require('buffer')
+
+/**
+ * Utility to mock the stdin of the cli. You must provide the correct number of
+ * questions correctly typed or the process will keep waiting for input.
+ * @param {ExecaChildProcess<string>} process
+ * @param {Array<{question: string, answer: string}>} questions
+ *  - questions that you know the CLI will ask and respective answers to mock
+ */
+const handleQuestions = (process, questions) => {
+  const remainingQuestions = [...questions]
+  let buffer = ''
+  process.stdout.on('data', (data) => {
+    buffer += data
+    const index = remainingQuestions.findIndex(({ question }) => buffer.includes(question))
+    if (index >= 0) {
+      buffer = ''
+      process.stdin.write(Buffer.from(remainingQuestions[index].answer))
+      remainingQuestions.splice(index, 1)
+    }
+  })
+}
+
+const answerWithValue = (value) => `${value}${CONFIRM}`;
+
+const CONFIRM = '\n'
+const DOWN = '\u001B[B'
+
+module.exports = {
+  handleQuestions,
+  answerWithValue,
+  CONFIRM,
+  DOWN
+}

--- a/tests/utils/handle-questions.js
+++ b/tests/utils/handle-questions.js
@@ -21,7 +21,7 @@ const handleQuestions = (process, questions) => {
   })
 }
 
-const answerWithValue = (value) => `${value}${CONFIRM}`;
+const answerWithValue = (value) => `${value}${CONFIRM}`
 
 const CONFIRM = '\n'
 const DOWN = '\u001B[B'
@@ -30,5 +30,5 @@ module.exports = {
   handleQuestions,
   answerWithValue,
   CONFIRM,
-  DOWN
+  DOWN,
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Currently, if no directory is specified for functions in the user's `netlify.toml`, you get an error. The user is required to go to the docs to learn how to configure the setting in netlify.toml. This PR creates a directory for the user with a default to `netlify/functions`

Also updates instances of `folder` to `directory` in the functions command.

Closes #1822, #1957 

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Run `netlify functions:create`

With a functions directory already existing:
![image](https://user-images.githubusercontent.com/11183523/111095103-1f3e9500-8513-11eb-9b3b-a6bcd3e36c2e.png)

Without a functions directory:
![image](https://user-images.githubusercontent.com/11183523/111890413-79ca6c00-89bf-11eb-9ba5-b7bcb3828f2f.png)



**- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://user-images.githubusercontent.com/11183523/111095159-42694480-8513-11eb-8773-302c78cf0217.png" width=300/>
