### PR TITLE
fix(command-status): site info is missing for sites without netlify.toml

### DIFF
--- a/src/commands/status/index.js
+++ b/src/commands/status/index.js
@@ -57,13 +57,6 @@ class StatusCommand extends Command {
 
     this.log(prettyjson.render(cleanAccountData))
 
-    if (!site.configPath) {
-      this.logJson({
-        account: cleanAccountData,
-      })
-      this.exit()
-    }
-
     if (!siteId) {
       this.warn('Did you run `netlify link` yet?')
       this.error(`You don't appear to be in a folder that is linked to a site`)


### PR DESCRIPTION
**- Summary**

I noticed `ntl status` only prints the site information if the site has a `netlify.toml`.
This doesn't make sense to me.

`site.configPath` is used later on in the code in `logJson` and `prettyjson.render`. Both filter out `undefined`.

**- Test plan**

Run `ntl status` on a site without `netlify.toml`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/111175189-d3422d80-85b0-11eb-9b53-e1bd6134683d.png)