### PR TITLE
test(command-init): use predictable branch name

### DIFF
--- a/tests/command.init.test.js
+++ b/tests/command.init.test.js
@@ -41,11 +41,11 @@ const assetSiteRequests = (
     {
       plugins,
       repo: {
-        allowed_branches: ['master'],
+        allowed_branches: ['main'],
         cmd: command,
         dir: publish,
         provider: 'manual',
-        repo_branch: 'master',
+        repo_branch: 'main',
         repo_path: 'git@github.com:owner/repo.git',
       },
     },

--- a/tests/utils/site-builder.js
+++ b/tests/utils/site-builder.js
@@ -125,7 +125,7 @@ const createSiteBuilder = ({ siteName }) => {
     },
     withGit: ({ repoUrl }) => {
       tasks.push(async () => {
-        await execa('git', ['init'], { cwd: directory })
+        await execa('git', ['init', '--initial-branch', 'main'], { cwd: directory })
         await execa('git', ['remote', 'add', 'origin', repoUrl], { cwd: directory })
       })
       return builder


### PR DESCRIPTION
This PR fixes an issue with our tests expecting the default branch of `git init` to be `master` (the test fails for users with a different default branch).