### PR TITLE
fix(command-dev): fix query params handling in redirects

### DIFF
--- a/tests/utils/site-builder.js
+++ b/tests/utils/site-builder.js
@@ -77,7 +77,7 @@ const createSiteBuilder = ({ siteName }) => {
       const dest = path.join(directory, pathPrefix, '_redirects')
       tasks.push(async () => {
         const content = redirects
-          .map(({ from, to, status, condition = '' }) => `${from} ${to} ${status} ${condition}`)
+          .map(({ from, to, status, condition = '' }) => [from, to, status, condition].filter(Boolean).join(' '))
           .join(os.EOL)
         await ensureDir(path.dirname(dest))
         await fs.writeFileAsync(dest, content)


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/2013
Fixes https://github.com/netlify/cli/issues/1605

Also see https://answers.netlify.com/t/querystringparameters-not-working-with-redirect-on-production/3828 and https://github.com/netlify/proxy/issues/449

This PR aligns the way query parameters redirects work in `netlify dev` with our production environment.
Given the following `_redirects` file:
```
/api/* /.netlify/functions/test?foo=1&foo=2 200
/foo / 302
/bar /?a=1&a=2&b=3 302
/test id=:id /?param=:id
```

The expected behavior based on the repo https://github.com/erezrokah/fn-payload-test deploy to https://erez-redirects-query.netlify.app/

1. Rewrites to functions always strip the redirect rule query params in favor of passing through the request query params.
2. If a non function redirect rule doesn't have query params in the rule the request params are passed through.
3. If a non function redirect rule has query params those supersede the request params.
4. If a non function redirect rule has param matching syntax those supersede the request params (we can think of this as a specific version of 3).

Before this change the CLI code kind of tried to merge both the request params and the redirect rule params, overriding multiple values of the same param with the last value (since it was doing `set` instead of `append`).

**- Test plan**

See new test

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/111479272-7aea6780-8739-11eb-87eb-52e23e0a0e34.png)
