### PR TITLE
fix(command-init): use GitHub instead of Github

### DIFF
--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -150,7 +150,7 @@ const upsertHook = async ({ ntlHooks, event, api, siteId, token }) => {
 }
 
 const addNotificationHooks = async ({ log, failAndExit, siteId, api, token }) => {
-  log(`Creating Netlify Github Notification Hooks...`)
+  log(`Creating Netlify GitHub Notification Hooks...`)
 
   let ntlHooks
   try {


### PR DESCRIPTION
This PR fixes a typo in one of our `ntl init` messages