### PR TITLE
chore: remove esbuild feature flag

### DIFF
--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -1,5 +1,3 @@
-const { env } = require('process')
-
 const build = require('@netlify/build')
 
 // We have already resolved the configuration using `@netlify/config`
@@ -12,9 +10,6 @@ const getBuildOptions = ({ context, token, flags }) => {
   // buffer = true will not stream output
   const buffer = flags.json || flags.silent
 
-  // @todo Remove once esbuild has been fully rolled out.
-  const featureFlags = env.NETLIFY_EXPERIMENTAL_ESBUILD ? 'buildbot_esbuild' : undefined
-
   return {
     cachedConfig: serializedConfig,
     token,
@@ -23,7 +18,6 @@ const getBuildOptions = ({ context, token, flags }) => {
     mode: 'cli',
     telemetry: false,
     buffer,
-    featureFlags,
   }
 }
 


### PR DESCRIPTION
**- Summary**

This PR removes the esbuild feature flag that is no longer in used. It was deprecated in favour of the functions configuration API.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

![a7b21eaeb8dbba8ed4bc40e4b211b3e0](https://user-images.githubusercontent.com/4162329/111774863-f407cd00-88a7-11eb-9bbd-43d427a6f918.jpg)

