### PR TITLE
fix(command-link): don't modify gitignore if a pattern includes .netlify

### DIFF
--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -92,7 +92,7 @@ const ensureNetlifyIgnore = async function (dir) {
     // ignore
   }
   /* Not ignoring .netlify folder. Add to .gitignore */
-  if (!ignorePatterns || !ignorePatterns.patterns.includes('.netlify')) {
+  if (!ignorePatterns || !ignorePatterns.patterns.some((pattern) => pattern.includes('.netlify'))) {
     const newContents = `${gitIgnoreContents}\n${ignoreContent}`
     await writeFileAsync(gitIgnorePath, newContents, 'utf8')
   }

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -92,7 +92,7 @@ const ensureNetlifyIgnore = async function (dir) {
     // ignore
   }
   /* Not ignoring .netlify folder. Add to .gitignore */
-  if (!ignorePatterns || !ignorePatterns.patterns.some((pattern) => /(^|\/)\.netlify($|\/)/.test(pattern))) {
+  if (!ignorePatterns || !ignorePatterns.patterns.some((pattern) => /(^|\/|\\)\.netlify($|\/|\\)/.test(pattern))) {
     const newContents = `${gitIgnoreContents}\n${ignoreContent}`
     await writeFileAsync(gitIgnorePath, newContents, 'utf8')
   }

--- a/src/utils/gitignore.js
+++ b/src/utils/gitignore.js
@@ -92,7 +92,7 @@ const ensureNetlifyIgnore = async function (dir) {
     // ignore
   }
   /* Not ignoring .netlify folder. Add to .gitignore */
-  if (!ignorePatterns || !ignorePatterns.patterns.some((pattern) => pattern.includes('.netlify'))) {
+  if (!ignorePatterns || !ignorePatterns.patterns.some((pattern) => /(^|\/)\.netlify($|\/)/.test(pattern))) {
     const newContents = `${gitIgnoreContents}\n${ignoreContent}`
     await writeFileAsync(gitIgnorePath, newContents, 'utf8')
   }


### PR DESCRIPTION
**- Summary**

Partially fixes https://github.com/netlify/cli/issues/2029 (I'll open other separates issue per https://github.com/netlify/cli/issues/2029#issuecomment-803581401)

**- Test plan**

On a linked repo change your `.gitignore` `.netlify` pattern to `/.netlify` and re-run `ntl link`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/111908922-be0f4800-8a63-11eb-8d84-4b419c84743c.png)
