### PR TITLE
test(command-init): make tests pass on forked PRs

### DIFF
--- a/tests/command.init.test.js
+++ b/tests/command.init.test.js
@@ -206,7 +206,7 @@ test('netlify init new site', async (t) => {
       // --manual is used to avoid the config-github flow that uses GitHub API
       const childProcess = execa(cliPath, ['init', '--manual'], {
         cwd: builder.directory,
-        env: { NETLIFY_API_URL: apiUrl },
+        env: { NETLIFY_API_URL: apiUrl, NETLIFY_AUTH_TOKEN: 'fake-token' },
         encoding: 'utf8',
       })
 
@@ -285,7 +285,7 @@ test('netlify init new Next.js site', async (t) => {
       // --manual is used to avoid the config-github flow that uses GitHub API
       const childProcess = execa(cliPath, ['init', '--manual'], {
         cwd: builder.directory,
-        env: { NETLIFY_API_URL: apiUrl },
+        env: { NETLIFY_API_URL: apiUrl, NETLIFY_AUTH_TOKEN: 'fake-token' },
       })
 
       handleQuestions(childProcess, initQuestions)


### PR DESCRIPTION
**- Summary**

See https://github.com/netlify/cli/pull/2028/commits/1c34d24e9b268203cffcf92f71a562491d94fc31

These tests were failing on forked PRs since forks don't have access to the Netlify access token configured as a repo secret (so the CLI prompted the user to login).

For these specific tests we can use a fake token, since we're using a mock API.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/111909152-ce73f280-8a64-11eb-8c87-30872a9b8548.png)
