### PR TITLE
chore: only test Node.js 10 on linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         node-version: [10.x, 15.x]
+        exclude:
+          - os: macOS-latest
+            node-version: 10.x
+          - os: windows-latest
+            node-version: 10.x
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Only test Node.js 10 on linux.

Aligns the testing matrix with our other Node.js repos