### PR TITLE
fix(command-dev): serve static file if exists for non forced redirects

### DIFF
--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -179,7 +179,13 @@ const serveRedirect = async function ({ req, res, proxy, match, options }) {
   )
 
   const staticFile = await getStatic(decodeURIComponent(reqUrl.pathname), options.publicFolder)
-  if (staticFile) req.url = staticFile + reqUrl.search
+  if (staticFile) {
+    req.url = staticFile + reqUrl.search
+    // if there is an existing static file and it is not a forced redirect, return the file
+    if (!match.force) {
+      return proxy.web(req, res, options)
+    }
+  }
   if (match.force404) {
     res.writeHead(404)
     res.end(await render404(options.publicFolder))

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -724,7 +724,7 @@ testMatrix.forEach(({ args }) => {
     })
   })
 
-  test(testName('should return existing local file even when redirect matches when force=false', args), async (t) => {
+  test(testName('should return existing local file even when rewrite matches when force=false', args), async (t) => {
     await withSiteBuilder('site-with-shadowing-force-false', async (builder) => {
       builder
         .withContentFile({
@@ -738,6 +738,32 @@ testMatrix.forEach(({ args }) => {
         .withNetlifyToml({
           config: {
             redirects: [{ from: '/foo', to: '/not-foo', status: 200, force: false }],
+          },
+        })
+
+      await builder.buildAsync()
+
+      await withDevServer({ cwd: builder.directory, args }, async (server) => {
+        const response = await got(`${server.url}/foo?ping=pong`).text()
+        t.is(response, '<html><h1>foo')
+      })
+    })
+  })
+
+  test(testName('should return existing local file even when redirect matches when force=false', args), async (t) => {
+    await withSiteBuilder('site-with-shadowing-force-false', async (builder) => {
+      builder
+        .withContentFile({
+          path: 'foo.html',
+          content: '<html><h1>foo',
+        })
+        .withContentFile({
+          path: path.join('not-foo', 'index.html'),
+          content: '<html><h1>not-foo',
+        })
+        .withNetlifyToml({
+          config: {
+            redirects: [{ from: '/foo', to: '/not-foo', status: 301, force: false }],
           },
         })
 


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/1299
Fixes https://github.com/netlify/cli/issues/1221

This worked and served `a.html` instead of rewriting if `a.html` existed 

```toml
[[redirects]]
from = "/a"
status = 200
to = "/docs/a"
```

This didn't (default status is `301`) and always redirected even if `a.html` existed 
```toml
[[redirects]]
from = "/a"
to = "/docs/a"
```

**- Test plan**

Added a test

**- A picture of a cute animal (not mandatory but encouraged)**
