### PR TITLE
chore(renovate): ignore Node.js>=12 packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 10
-      packageNames: ['path-type', 'open', 'inquirer'],
+      packageNames: ['path-type', 'open', 'inquirer', 'p-timeout', 'configstore', 'p-wait-for', 'path-key'],
       major: {
         enabled: false,
       },


### PR DESCRIPTION
This should auto close 
![image](https://user-images.githubusercontent.com/26760571/114395105-af203f00-9ba4-11eb-8dfe-9ee4b9f78c64.png)
