### PR TITLE
feat(command-dev): watch all functions files

### DIFF
--- a/src/utils/get-functions.js
+++ b/src/utils/get-functions.js
@@ -1,4 +1,6 @@
-const { listFunctions } = require('@netlify/zip-it-and-ship-it')
+const path = require('path')
+
+const { listFunctions, listFunctionsFiles } = require('@netlify/zip-it-and-ship-it')
 
 const { fileExistsAsync } = require('../lib/fs')
 
@@ -24,4 +26,29 @@ const getFunctions = async (functionsSrcDir) => {
   return functionsWithProps
 }
 
-module.exports = { getFunctions }
+const getWatchDirs = (functionsSrcDir, functions) => {
+  const localFilesDirs = functions
+    .filter(({ srcFile }) => !srcFile.startsWith(functionsSrcDir) && !srcFile.includes('node_modules'))
+    .map(({ srcFile }) => path.dirname(srcFile))
+
+  return [functionsSrcDir, ...new Set(localFilesDirs)]
+}
+
+const getFunctionsAndWatchDirs = async (functionsSrcDir) => {
+  if (!(await fileExistsAsync(functionsSrcDir))) {
+    return { functions: [], watchDirs: [functionsSrcDir] }
+  }
+
+  // get all functions files so we know which directories to watch
+  const functions = await listFunctionsFiles(functionsSrcDir)
+  const watchDirs = getWatchDirs(functionsSrcDir, functions)
+
+  // filter for only main files to serve
+  const functionsWithProps = functions
+    .filter(({ runtime, srcFile, mainFile }) => runtime === JS && srcFile === mainFile)
+    .map((func) => addFunctionProps(func))
+
+  return { functions: functionsWithProps, watchDirs }
+}
+
+module.exports = { getFunctions, getFunctionsAndWatchDirs }

--- a/src/utils/get-functions.test.js
+++ b/src/utils/get-functions.test.js
@@ -106,6 +106,6 @@ test('should return additional watch dirs when functions requires a file outside
         urlPath: '/.netlify/functions/index',
       },
     ])
-    t.deepEqual(watchDirs, [`${builder.directory}/functions`, `${builder.directory}/utils`])
+    t.deepEqual(watchDirs, [path.join(builder.directory, 'functions'), path.join(builder.directory, 'utils')])
   })
 })

--- a/src/utils/get-functions.test.js
+++ b/src/utils/get-functions.test.js
@@ -78,7 +78,7 @@ test('should mark background functions based on filenames', async (t) => {
 })
 
 test('should return additional watch dirs when functions requires a file outside function dir', async (t) => {
-  await withSiteBuilder('site-without-functions', async (builder) => {
+  await withSiteBuilder('site-with-functions-require-outside-functions-dir', async (builder) => {
     await builder
       .withFunction({
         path: 'index.js',

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -19,7 +19,7 @@ const winston = require('winston')
 const { getLogMessage } = require('../lib/log')
 
 const { detectFunctionsBuilder } = require('./detect-functions-builder')
-const { getFunctions } = require('./get-functions')
+const { getFunctionsAndWatchDirs } = require('./get-functions')
 const { NETLIFYDEVLOG, NETLIFYDEVERR } = require('./logo')
 
 const formatLambdaLocalError = (err) => `${err.errorType}: ${err.errorMessage}\n  ${err.stackTrace.join('\n  ')}`
@@ -180,9 +180,9 @@ const validateFunctions = function ({ functions, capabilities, warn }) {
 }
 
 const createHandler = async function ({ dir, capabilities, omitFileChangesLog, warn }) {
-  const functions = await getFunctions(dir)
+  const { functions, watchDirs } = await getFunctionsAndWatchDirs(dir)
   validateFunctions({ functions, capabilities, warn })
-  const watcher = chokidar.watch(dir, { ignored: /node_modules/ })
+  const watcher = chokidar.watch(watchDirs, { ignored: /node_modules/ })
   watcher
     .on('change', clearCache({ action: 'modified', omitLog: omitFileChangesLog }))
     .on('unlink', clearCache({ action: 'deleted', omitLog: omitFileChangesLog }))


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/909

~~Still in draft since I need to test it more~~

I believe we would need to add similar code to the functions builders to make this work for `esbuild`.

Another way to implement this is via configuration (e.g. flags/`netlify.toml` or both)

**- Test plan**

Added a test case

**- A picture of a cute animal (not mandatory but encouraged)**

🐼 