### PR TITLE
feat: use zisi function builder when using TypeScript functions

### DIFF
--- a/src/function-builder-detectors/zisi.js
+++ b/src/function-builder-detectors/zisi.js
@@ -4,6 +4,7 @@ const { zipFunction, zipFunctions } = require('@netlify/zip-it-and-ship-it')
 const makeDir = require('make-dir')
 
 const { getPathInProject } = require('../lib/settings')
+const { getFunctions } = require('../utils/get-functions')
 const { NETLIFYDEVERR } = require('../utils/logo')
 
 const bundleFunctions = ({ config, sourceDirectory, targetDirectory, updatedPath }) => {
@@ -52,10 +53,12 @@ const getTargetDirectory = async ({ errorExit }) => {
 }
 
 module.exports = async function handler({ config, errorExit, functionsDirectory: sourceDirectory }) {
+  const functions = await getFunctions(sourceDirectory)
+  const hasTSFunction = functions.some(({ mainFile }) => path.extname(mainFile) === '.ts')
   const functionsConfig = normalizeFunctionsConfig(config.functions)
   const isUsingEsbuild = functionsConfig['*'] && functionsConfig['*'].nodeBundler === 'esbuild_zisi'
 
-  if (!isUsingEsbuild) {
+  if (!hasTSFunction && !isUsingEsbuild) {
     return false
   }
 

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1565,6 +1565,37 @@ export const handler = async function () {
       },
     )
 
+    test(
+      testName('Should use the ZISI function bundler and serve TypeScript functions if not using esbuild', args),
+      async (t) => {
+        await withSiteBuilder('site-with-ts-function', async (builder) => {
+          builder.withNetlifyToml({ config: { functions: { directory: 'functions' } } }).withContentFile({
+            path: path.join('functions', 'ts-function', 'ts-function.ts'),
+            content: `
+type CustomResponse = string;
+
+export const handler = async function () {
+  const response: CustomResponse = "ts";
+
+  return {
+    statusCode: 200,
+    body: response,
+  };
+};
+
+    `,
+          })
+
+          await builder.buildAsync()
+
+          await withDevServer({ cwd: builder.directory, args }, async (server) => {
+            const response = await got(`${server.url}/.netlify/functions/ts-function`).text()
+            t.is(response, 'ts')
+          })
+        })
+      },
+    )
+
     test(testName(`should start https server when https dev block is configured`, args), async (t) => {
       await withSiteBuilder('sites-with-https-certificate', async (builder) => {
         await builder


### PR DESCRIPTION
**- Summary**

Since #2094, `netlify dev` is serving functions after bundling them with `zip-it-and-ship-it`. To contain the risks of that change, we enable it only when we detect that users have opted in to esbuild via the `functions.node_bundler` configuration property.

However, we treat TypeScript support as GA, with no correlation with the opt-in mechanism to the beta feature that `node_bundler` provides. This means that someone who wants to continue to use the legacy bundler for JavaScript functions but also include a TypeScript function will not be able to access the TypeScript function locally, since CLI will serve the raw file.

This PR changes the condition used by the `zisi` function builder, so that it's enable if `node_bundler` is `esbuild` _or_ there's at least one TypeScript function in the functions directory.

**- Test plan**

New test added.

**- A picture of a cute animal (not mandatory but encouraged)**

![foca](https://user-images.githubusercontent.com/4162329/115114806-0b120b80-9f89-11eb-8d25-bf4a1481805a.jpg)
