### PR TITLE
chore(release-please): fix release process

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,10 @@ jobs:
           node-version: '15'
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
+      # required for linting to pass
+      - name: Install site dependencies
+        run: npm run site:build:install
+        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         if: ${{ steps.release.outputs.release_created }}
         env:


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/2141

We need to install `./site` dependencies so linting passes (we run the linter on the `prePublishOnly` script).
See failure here https://github.com/netlify/cli/runs/2372808042?check_suite_focus=true