### PR TITLE
chore: add package size benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: npm install --production
       - name: Get size
-        run: du -sk node_modules > .delta.packageSize && echo "b (Package size)" >> .delta.packageSize
+        run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "b (Package size)" >> .delta.packageSize
       - name: Run Delta
         uses: netlify/delta-action@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,27 @@
+name: Package size
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Install dependencies
+        run: npm install --production
+      - name: Get size
+        run: du -sk node_modules > .delta.packageSize && echo "b (Package size)" >> .delta.packageSize
+      - name: Run Delta
+        uses: netlify/delta-action@v1
+        with:
+          title: '📊 Benchmark results'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 15.x
       - name: Install dependencies
         run: npm install --production
       - name: Get size

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: npm install --production
       - name: Get size
-        run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "b (Package size)" >> .delta.packageSize
+        run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "kb (Package size)" >> .delta.packageSize
       - name: Run Delta
         uses: netlify/delta-action@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,9 +2,9 @@ name: Package size
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
**- Summary**

Adds a benchmark workflow to track the evolution of the package size. It works by running `npm install --production` and calculating the size of the generated `node_modules` directory. It makes use of https://github.com/netlify/delta-action to report the results and compare against the baseline.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

![fat_animals_00](https://user-images.githubusercontent.com/4162329/115207893-ee461700-a0f3-11eb-832c-134a74f755f8.jpg)
