### PR TITLE
chore(release-please): add missing env variables

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,3 +33,6 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          # required for tests to pass
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Another follow up (see https://github.com/netlify/cli/pull/2149).

The tests we run on `prePublishOnly` hit the Netlify API so they need the auth token passed as a secret