### PR TITLE
chore(ci): switch to cms shell on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Testing for CLI
 
 on:
   push:
-    branches: [main, chore/use_cmd_windows_ci]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,22 +2,28 @@ name: Testing for CLI
 
 on:
   push:
-    branches: [main]
+    branches: [main, chore/use_cmd_windows_ci]
   pull_request:
     branches: [main]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: ${{ matrix.config.shell }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        config:
+          - { os: macOS-latest, shell: bash }
+          - { os: ubuntu-latest, shell: bash }
+          - { os: windows-latest, shell: cmd }
         node-version: [10.x, 15.x]
         exclude:
-          - os: macOS-latest
+          - config: { os: macOS-latest, shell: bash }
             node-version: 10.x
-          - os: windows-latest
+          - config: { os: windows-latest, shell: cmd }
             node-version: 10.x
       fail-fast: false
 
@@ -47,7 +53,7 @@ jobs:
       - name: Get test coverage flags
         id: test-coverage-flags
         run: |-
-          os=${{ matrix.os }}
+          os=${{ matrix.config.os }}
           node=${{ matrix.node-version }}
           echo "::set-output name=os::${os/-latest/}"
           echo "::set-output name=node::node_${node//./}"


### PR DESCRIPTION
**- Summary**

A shot in the dark trying to prevent our Windows CI from hanging. The default shell for windows is PowerShell.

I couldn't reproduce this on my Windows VM and also getting nowhere with this https://github.community/t/github-actions-times-out-with-no-logs/156707/2

**- Test plan**

Merge to `main` and see if this makes a difference

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/115581189-71bc5f80-a2d0-11eb-957a-11765db20815.png)