### PR TITLE
fix: delete the directory from which functions will be served

### DIFF
--- a/src/function-builder-detectors/zisi.js
+++ b/src/function-builder-detectors/zisi.js
@@ -59,7 +59,7 @@ module.exports = async function handler({ config, errorExit, functionsDirectory:
   // Emptying the directory from which functions will be served, to clear any
   // deleted functions from a previous run.
   try {
-    await del(targetDirectory)
+    await del(targetDirectory, { force: true })
   } catch (_) {
     // no-op
   }


### PR DESCRIPTION
**- Summary**

Delete the functions serving directory when the ZISI function builder is initialised.

Closes #2190.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐦 