### PR TITLE
Fix memoize one version

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "make-dir": "^3.0.0",
-    "memoize-one": "^5.1.1",
+    "memoize-one": "5.1.1",
     "minimist": "^1.2.5",
     "multiparty": "^4.2.1",
     "netlify": "^6.1.20",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This is a fix for [#2202](https://github.com/netlify/cli/issues/2202) - where the updated memoize-one version caused the CLI to break. 

**- Test plan**

Ran `npm test`, along with a few of the build commands to verify it was functional. 

**- A picture of a cute animal **

![90A44480-8DC0-4CAF-BEB7-53A4B05623C9_1_105_c](https://user-images.githubusercontent.com/16076622/115800156-080f8480-a3a8-11eb-8248-66ff622b8a8a.jpeg)

