### PR TITLE
fix(deps): pin memoize-one to 5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "netlify-cli",
-      "version": "3.21.4",
+      "version": "3.21.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -75,7 +75,7 @@
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "make-dir": "^3.0.0",
-        "memoize-one": "^5.1.1",
+        "memoize-one": "5.1.1",
         "minimist": "^1.2.5",
         "multiparty": "^4.2.1",
         "netlify": "^6.1.20",
@@ -2993,6 +2993,11 @@
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@netlify/traffic-mesh-agent/-/traffic-mesh-agent-0.27.10.tgz",
       "integrity": "sha512-HZXEdIXzg8CpysYRDVXkBpmjOj/C8Zb8Q/qkkt9x+npJ56HeX6sXAE4vK4SMCRLkkbQ2VyYTaDKg++GefeB2Gg==",
+      "dependencies": {
+        "@netlify/traffic-mesh-agent-darwin-x64": "^0.27.10",
+        "@netlify/traffic-mesh-agent-linux-x64": "^0.27.10",
+        "@netlify/traffic-mesh-agent-win32-x64": "^0.27.10"
+      },
       "optionalDependencies": {
         "@netlify/traffic-mesh-agent-darwin-x64": "^0.27.10",
         "@netlify/traffic-mesh-agent-linux-x64": "^0.27.10",
@@ -3690,6 +3695,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3827,6 +3835,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4087,6 +4098,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6697,6 +6711,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7078,6 +7093,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9774,7 +9792,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -12758,6 +12777,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -14509,6 +14529,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -18786,6 +18807,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -19606,6 +19630,9 @@
       "version": "2.45.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.45.2.tgz",
       "integrity": "sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==",
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -25399,6 +25426,7 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "repository": "netlify/cli",
   "main": "src/index.js",
   "bin": {
-    "ntl": "./bin/run",
-    "netlify": "./bin/run"
+    "ntl": "bin/run",
+    "netlify": "bin/run"
   },
   "bugs": {
     "url": "https://github.com/netlify/cli/issues"
@@ -140,7 +140,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "make-dir": "^3.0.0",
-    "memoize-one": "^5.1.1",
+    "memoize-one": "5.1.1",
     "minimist": "^1.2.5",
     "multiparty": "^4.2.1",
     "netlify": "^6.1.20",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "repository": "netlify/cli",
   "main": "src/index.js",
   "bin": {
-    "ntl": "bin/run",
-    "netlify": "bin/run"
+    "ntl": "./bin/run",
+    "netlify": "./bin/run"
   },
   "bugs": {
     "url": "https://github.com/netlify/cli/issues"


### PR DESCRIPTION
This fixes https://github.com/netlify/cli/issues/2202 (and https://github.com/alexreardon/memoize-one/issues/80).

Since currently we're using `^5.1.1` format, `5.2.0` is used for the CLI and it is causing the error. By pinning the memoize-one version to `5.1.1`, the error will be gone.
We can look into for upgrading `5.2.0` or not later on.