### PR TITLE
fix(deps): update dependency memoize-one to 5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "netlify-cli",
-      "version": "3.21.4",
+      "version": "3.21.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -75,7 +75,7 @@
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "make-dir": "^3.0.0",
-        "memoize-one": "^5.1.1",
+        "memoize-one": "5.1.1",
         "minimist": "^1.2.5",
         "multiparty": "^4.2.1",
         "netlify": "^6.1.20",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "make-dir": "^3.0.0",
-    "memoize-one": "^5.1.1",
+    "memoize-one": "5.1.1",
     "minimist": "^1.2.5",
     "multiparty": "^4.2.1",
     "netlify": "^6.1.20",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

Fixes #2202

**- Summary**

The npm package for memoize-one was updated a few hours ago, and those changes showed incompatible to netlify/cli. This fixes #2202 by enforcing use of the last known good release of memoize-one.

**- Test plan**

Ran `npm test` to ensure version is still working.

**- A picture of a cute animal (not mandatory but encouraged)**
A good boy: 
![C3485AF8-EBB5-45A1-9EE5-B7F22CB61AA6_1_105_c](https://user-images.githubusercontent.com/16076622/115801032-cb448d00-a3a9-11eb-8ed8-bba727b33de4.jpeg)
