### PR TITLE
fix(deps): memoize-one cjs exports breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "make-dir": "^3.0.0",
-        "memoize-one": "5.1.1",
+        "memoize-one": "^5.2.0",
         "minimist": "^1.2.5",
         "multiparty": "^4.2.1",
         "netlify": "^6.1.20",
@@ -15802,9 +15802,9 @@
       }
     },
     "node_modules/memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
+      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -25409,6 +25409,7 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",
@@ -35061,9 +35062,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
+      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "make-dir": "^3.0.0",
-    "memoize-one": "5.1.1",
+    "memoize-one": "^5.2.0",
     "minimist": "^1.2.5",
     "multiparty": "^4.2.1",
     "netlify": "^6.1.20",

--- a/src/utils/get-global-config.js
+++ b/src/utils/get-global-config.js
@@ -1,5 +1,5 @@
 const Configstore = require('configstore')
-const memoizeOne = require('memoize-one')
+const { memoizeOne } = require('memoize-one')
 const { v4: uuidv4 } = require('uuid')
 
 const { readFileAsync } = require('../lib/fs')


### PR DESCRIPTION
**- Summary**

Following up on #2204 and #2202. The latest release of memoize-one introduced a breaking change for the cjs exports - https://github.com/alexreardon/memoize-one/releases/tag/v5.2.0 - this PR bumps the `memoize-one` dep and addresses the breaking changes.

**- A picture of a cute animal (not mandatory but encouraged)**

![monkey-stealing-stuff](https://i.giphy.com/media/5cdenDXni65aM/giphy.webp)