### PR TITLE
fix(deps): upgrading memoize-one to 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "make-dir": "^3.0.0",
-        "memoize-one": "^5.2.0",
+        "memoize-one": "^5.2.1",
         "minimist": "^1.2.5",
         "multiparty": "^4.2.1",
         "netlify": "^6.1.20",
@@ -2306,11 +2306,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@netlify/build/node_modules/memoize-one": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
     },
     "node_modules/@netlify/build/node_modules/p-cancelable": {
       "version": "1.1.0",
@@ -15802,9 +15797,9 @@
       }
     },
     "node_modules/memoize-one": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -24584,11 +24579,6 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
-        },
-        "memoize-one": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-          "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
         },
         "p-cancelable": {
           "version": "1.1.0",
@@ -35062,9 +35052,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.0.tgz",
-      "integrity": "sha512-OiKwjWuxDPHRN5yL9gskqJHT1dr9N99AH95ceiwvpXjE6fpcwAtPHDRoe8CFL1+TMrLG9NzO5WerQ32Q35iD4w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "make-dir": "^3.0.0",
-    "memoize-one": "^5.2.0",
+    "memoize-one": "^5.2.1",
     "minimist": "^1.2.5",
     "multiparty": "^4.2.1",
     "netlify": "^6.1.20",

--- a/src/utils/get-global-config.js
+++ b/src/utils/get-global-config.js
@@ -1,5 +1,5 @@
 const Configstore = require('configstore')
-const { memoizeOne } = require('memoize-one')
+const memoizeOne = require('memoize-one')
 const { v4: uuidv4 } = require('uuid')
 
 const { readFileAsync } = require('../lib/fs')


### PR DESCRIPTION
Context: https://github.com/netlify/cli/issues/2202

`memoize-one@5.2.0` introduced an unintentional breaking change to the CommonJS bundle. `5.2.0` has been deprecated, and `5.2.1` removes the named import to revert the breaking change to the CommonJS bundle.

This PR simply bumps you back to `5.2.1` and moves away from the named import which is no longer supported (as `5.2.0` has been deprecated)