### PR TITLE
fix(command-dev): use custom functions timeout if present

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -231,7 +231,7 @@ class DevCommand extends Command {
 
     await injectEnvVariables({ env: this.netlify.cachedConfig.env, log, site, warn })
 
-    const { addonsUrls, siteUrl, capabilities } = await getSiteInformation({
+    const { addonsUrls, siteUrl, capabilities, timeouts } = await getSiteInformation({
       flags,
       api,
       site,
@@ -257,6 +257,7 @@ class DevCommand extends Command {
       errorExit,
       siteUrl,
       capabilities,
+      timeouts,
     })
     await startFrameworkServer({ settings, log, exit })
 

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -98,22 +98,18 @@ const DEFAULT_LAMBDA_OPTIONS = {
   verboseLevel: 3,
 }
 
-// 10 seconds for synchronous functions
-const SYNCHRONOUS_FUNCTION_TIMEOUT = 1e4
-const executeSynchronousFunction = ({ event, lambdaPath, clientContext, response }) =>
+const executeSynchronousFunction = ({ event, lambdaPath, timeout, clientContext, response }) =>
   lambdaLocal.execute({
     ...DEFAULT_LAMBDA_OPTIONS,
     event,
     lambdaPath,
     clientContext,
     callback: createSynchronousFunctionCallback(response),
-    timeoutMs: SYNCHRONOUS_FUNCTION_TIMEOUT,
+    timeoutMs: timeout,
   })
 
-// 15 minuets for background functions
-const BACKGROUND_FUNCTION_TIMEOUT = 9e5
 const BACKGROUND_FUNCTION_STATUS_CODE = 202
-const executeBackgroundFunction = ({ event, lambdaPath, clientContext, response, functionName }) => {
+const executeBackgroundFunction = ({ event, lambdaPath, timeout, clientContext, response, functionName }) => {
   console.log(`${NETLIFYDEVLOG} Queueing background function ${styleFunctionName(functionName)} for execution`)
   response.status(BACKGROUND_FUNCTION_STATUS_CODE)
   response.end()
@@ -124,7 +120,7 @@ const executeBackgroundFunction = ({ event, lambdaPath, clientContext, response,
     lambdaPath,
     clientContext,
     callback: createBackgroundFunctionCallback(functionName),
-    timeoutMs: BACKGROUND_FUNCTION_TIMEOUT,
+    timeoutMs: timeout,
   })
 }
 
@@ -189,7 +185,7 @@ const validateFunctions = function ({ functions, capabilities, warn }) {
 
 const DEBOUNCE_WAIT = 300
 
-const createHandler = function ({ getFunctionByName }) {
+const createHandler = function ({ getFunctionByName, timeouts }) {
   const logger = winston.createLogger({
     levels: winston.config.npm.levels,
     transports: [new winston.transports.Console({ level: 'warn' })],
@@ -252,12 +248,19 @@ const createHandler = function ({ getFunctionByName }) {
       return executeBackgroundFunction({
         event,
         lambdaPath,
+        timeout: timeouts.backgroundFunctions,
         clientContext,
         response,
         functionName,
       })
     }
-    return executeSynchronousFunction({ event, lambdaPath, clientContext, response })
+    return executeSynchronousFunction({
+      event,
+      lambdaPath,
+      timeout: timeouts.syncFunctions,
+      clientContext,
+      response,
+    })
   }
 }
 
@@ -433,7 +436,7 @@ const createFormSubmissionHandler = function ({ siteUrl, warn }) {
   }
 }
 
-const getFunctionsServer = async function ({ getFunctionByName, siteUrl, warn }) {
+const getFunctionsServer = async function ({ getFunctionByName, siteUrl, warn, timeouts }) {
   const app = express()
   app.set('query parser', 'simple')
 
@@ -455,7 +458,7 @@ const getFunctionsServer = async function ({ getFunctionByName, siteUrl, warn })
     res.status(204).end()
   })
 
-  app.all('*', await createHandler({ getFunctionByName }))
+  app.all('*', await createHandler({ getFunctionByName, timeouts }))
 
   return app
 }
@@ -548,7 +551,17 @@ const startServer = async ({ server, settings, log, errorExit }) => {
   })
 }
 
-const startFunctionsServer = async ({ config, settings, site, log, warn, errorExit, siteUrl, capabilities }) => {
+const startFunctionsServer = async ({
+  config,
+  settings,
+  site,
+  log,
+  warn,
+  errorExit,
+  siteUrl,
+  capabilities,
+  timeouts,
+}) => {
   // serve functions from zip-it-and-ship-it
   // env variables relies on `url`, careful moving this code
   if (settings.functions) {
@@ -572,6 +585,7 @@ const startFunctionsServer = async ({ config, settings, site, log, warn, errorEx
       getFunctionByName,
       siteUrl,
       warn,
+      timeouts,
     })
 
     await startServer({ server, settings, log, errorExit })

--- a/tests/utils/dev-server.js
+++ b/tests/utils/dev-server.js
@@ -35,7 +35,6 @@ const startServer = async ({ cwd, env = {}, args = [] }) => {
   const { NETLIFY_AUTH_TOKEN, ...processEnv } = process.env
   const ps = execa(cliPath, ['dev', '-p', port, '--staticServerPort', port + FRAMEWORK_PORT_SHIFT, ...args], {
     cwd,
-
     extendEnv: false,
     env: { ...processEnv, BROWSER: 'none', ...env },
     encoding: 'utf8',


### PR DESCRIPTION
**- Summary**

The CLI synchronous functions timeout was hardcoded to 10 seconds.
This PR retrieves the timeout based on the site information and uses it, if present.

**- Test plan**

Added a test

**- A picture of a cute animal (not mandatory but encouraged)**
🐼 

Fixes https://github.com/netlify/pod-workflow/issues/198 and https://answers.netlify.com/t/increase-function-timeout/26361/12