### PR TITLE
fix(command-dev): revert usage of listFunctionsFiles

### DIFF
--- a/src/utils/get-functions.js
+++ b/src/utils/get-functions.js
@@ -1,6 +1,4 @@
-const path = require('path')
-
-const { listFunctions, listFunctionsFiles } = require('@netlify/zip-it-and-ship-it')
+const { listFunctions } = require('@netlify/zip-it-and-ship-it')
 
 const { fileExistsAsync } = require('../lib/fs')
 
@@ -26,27 +24,17 @@ const getFunctions = async (functionsSrcDir) => {
   return functionsWithProps
 }
 
-const getWatchDirs = (functionsSrcDir, functions) => {
-  const localFilesDirs = functions
-    .filter(({ srcFile }) => !srcFile.startsWith(functionsSrcDir) && !srcFile.includes('node_modules'))
-    .map(({ srcFile }) => path.dirname(srcFile))
-
-  return [functionsSrcDir, ...new Set(localFilesDirs)]
-}
-
 const getFunctionsAndWatchDirs = async (functionsSrcDir) => {
   if (!(await fileExistsAsync(functionsSrcDir))) {
     return { functions: [], watchDirs: [functionsSrcDir] }
   }
 
   // get all functions files so we know which directories to watch
-  const functions = await listFunctionsFiles(functionsSrcDir)
-  const watchDirs = getWatchDirs(functionsSrcDir, functions)
+  const functions = await listFunctions(functionsSrcDir)
+  const watchDirs = [functionsSrcDir]
 
   // filter for only main files to serve
-  const functionsWithProps = functions
-    .filter(({ runtime, srcFile, mainFile }) => runtime === JS && srcFile === mainFile)
-    .map((func) => addFunctionProps(func))
+  const functionsWithProps = functions.filter(({ runtime }) => runtime === JS).map((func) => addFunctionProps(func))
 
   return { functions: functionsWithProps, watchDirs }
 }

--- a/src/utils/get-functions.test.js
+++ b/src/utils/get-functions.test.js
@@ -77,7 +77,7 @@ test('should mark background functions based on filenames', async (t) => {
   })
 })
 
-test('should return additional watch dirs when functions requires a file outside function dir', async (t) => {
+test.skip('should return additional watch dirs when functions requires a file outside function dir', async (t) => {
   await withSiteBuilder('site-with-functions-require-outside-functions-dir', async (builder) => {
     await builder
       .withFunction({


### PR DESCRIPTION
**- Summary**

Partially reverts https://github.com/netlify/cli/pull/2143 as the code doesn't work with `esbuild` [yet](https://github.com/netlify/cli/pull/2228).
Fixes https://github.com/netlify/cli/issues/2227
Fixes https://github.com/netlify/cli/issues/2238

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
🐒 