### PR TITLE
test(command-dev): don't pass auth token to CLI

### DIFF
--- a/tests/utils/dev-server.js
+++ b/tests/utils/dev-server.js
@@ -29,9 +29,15 @@ const startServer = async ({ cwd, env = {}, args = [] }) => {
   const host = 'localhost'
   const url = `http://${host}:${port}`
   console.log(`Starting dev server on port: ${port} in directory ${path.basename(cwd)}`)
+  // In CI we set a NETLIFY_AUTH_TOKEN which means the CLI will hit the live API in some cases
+  // as we don't need it for dev tests we can omit it
+  // eslint-disable-next-line no-unused-vars
+  const { NETLIFY_AUTH_TOKEN, ...processEnv } = process.env
   const ps = execa(cliPath, ['dev', '-p', port, '--staticServerPort', port + FRAMEWORK_PORT_SHIFT, ...args], {
     cwd,
-    env: { BROWSER: 'none', ...env },
+
+    extendEnv: false,
+    env: { ...processEnv, BROWSER: 'none', ...env },
     encoding: 'utf8',
   })
   let output = ''


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2209

In CI we pass a NETLIFY_AUTH_TOKEN. When this env variable exists `@netlify/config` infers that we should retrieve site information from the production API:
https://github.com/netlify/build/blob/b442daf2efa2a31057e8628309903f6ec3976945/packages/config/src/options/main.js#L40
https://github.com/netlify/build/blob/b442daf2efa2a31057e8628309903f6ec3976945/packages/config/src/api/client.js#L9

This is not required for `dev` command tests.

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
🐢 