### PR TITLE
test(command-addons): use mock api

### DIFF
--- a/tests/command.addons.test.js
+++ b/tests/command.addons.test.js
@@ -1,65 +1,162 @@
-const process = require('process')
-
 const test = require('ava')
 
 const callCli = require('./utils/call-cli')
-const { generateSiteName, createLiveTestSite } = require('./utils/create-live-test-site')
-const { createSiteBuilder } = require('./utils/site-builder')
+const { withMockApi } = require('./utils/mock-api')
+const { withSiteBuilder } = require('./utils/site-builder')
 
-const siteName = generateSiteName('netlify-test-addons-')
+const getCLIOptions = ({ builder: { directory: cwd }, apiUrl }) => ({
+  cwd,
+  env: { NETLIFY_AUTH_TOKEN: 'fake-token', NETLIFY_SITE_ID: 'site_id', NETLIFY_API_URL: apiUrl },
+})
 
-if (process.env.IS_FORK !== 'true') {
-  test.before(async (t) => {
-    const { siteId } = await createLiveTestSite(siteName)
-    const builder = createSiteBuilder({ siteName: 'site-with-addons' })
+const siteInfo = {
+  account_slug: 'test-account',
+  id: 'site_id',
+  name: 'site-name',
+}
+const routes = [
+  { path: 'sites/site_id', response: siteInfo },
+  { path: 'sites/site_id/service-instances', response: [] },
+  {
+    path: 'accounts',
+    response: [{ slug: siteInfo.account_slug }],
+  },
+]
+
+test('netlify addons:list', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
     await builder.buildAsync()
 
-    t.context.execOptions = { cwd: builder.directory, env: { NETLIFY_SITE_ID: siteId } }
-    t.context.builder = builder
+    await withMockApi(routes, async ({ apiUrl }) => {
+      const cliResponse = await callCli(['addons:list'], getCLIOptions({ builder, apiUrl }))
+      t.true(cliResponse.includes('No addons currently installed'))
+    })
   })
+})
 
-  test.serial('netlify addons:list', async (t) => {
-    const cliResponse = await callCli(['addons:list'], t.context.execOptions)
-    t.true(cliResponse.includes('No addons currently installed'))
+test('netlify addons:list --json', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
+    await builder.buildAsync()
+
+    await withMockApi(routes, async ({ apiUrl }) => {
+      const cliResponse = await callCli(['addons:list', '--json'], getCLIOptions({ builder, apiUrl }))
+      const json = JSON.parse(cliResponse)
+      t.true(Array.isArray(json))
+      t.is(json.length, 0)
+    })
   })
+})
 
-  test.serial('netlify addons:list --json', async (t) => {
-    const cliResponse = await callCli(['addons:list', '--json'], t.context.execOptions)
-    const json = JSON.parse(cliResponse)
-    t.true(Array.isArray(json))
-    t.is(json.length, 0)
+test('netlify addons:create demo', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
+    await builder.buildAsync()
+
+    const createRoutes = [
+      ...routes,
+      { path: 'services/demo/manifest', response: {} },
+      {
+        path: 'sites/site_id/services/demo/instances',
+        response: {},
+        method: 'POST',
+        requestBody: JSON.stringify({ config: { TWILIO_ACCOUNT_SID: 'foo' } }),
+      },
+    ]
+
+    await withMockApi(createRoutes, async ({ apiUrl }) => {
+      const cliResponse = await callCli(
+        ['addons:create', 'demo', '--TWILIO_ACCOUNT_SID', 'foo'],
+        getCLIOptions({ builder, apiUrl }),
+      )
+      t.true(cliResponse.includes('Add-on "demo" created'))
+    })
   })
+})
 
-  test.serial('netlify addons:create demo', async (t) => {
-    const cliResponse = await callCli(['addons:create', 'demo', '--TWILIO_ACCOUNT_SID', 'foo'], t.context.execOptions)
-    t.true(cliResponse.includes('Add-on "demo" created'))
+test('After creation netlify addons:list --json', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
+    await builder.buildAsync()
+
+    const withExistingAddon = [
+      { path: 'sites/site_id', response: siteInfo },
+      {
+        path: 'sites/site_id/service-instances',
+        response: [{ service_slug: 'demo' }],
+      },
+      {
+        path: 'accounts',
+        response: [{ slug: siteInfo.account_slug }],
+      },
+    ]
+
+    await withMockApi(withExistingAddon, async ({ apiUrl }) => {
+      const cliResponse = await callCli(['addons:list', '--json'], getCLIOptions({ builder, apiUrl }))
+      const json = JSON.parse(cliResponse)
+      t.true(Array.isArray(json))
+      t.is(json.length, 1)
+      t.is(json[0].service_slug, 'demo')
+    })
   })
+})
 
-  test.serial('After creation netlify addons:list --json', async (t) => {
-    const cliResponse = await callCli(['addons:list', '--json'], t.context.execOptions)
-    const json = JSON.parse(cliResponse)
-    t.true(Array.isArray(json))
-    t.is(json.length, 1)
-    t.is(json[0].service_slug, 'demo')
+test('netlify addons:config demo', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
+    await builder.buildAsync()
+
+    const configRoutes = [
+      { path: 'sites/site_id', response: siteInfo },
+      {
+        path: 'sites/site_id/service-instances',
+        response: [{ id: 'demo', service_slug: 'demo', config: { TWILIO_ACCOUNT_SID: 'foo' } }],
+      },
+      {
+        path: 'accounts',
+        response: [{ slug: siteInfo.account_slug }],
+      },
+      { path: 'services/demo/manifest', response: { config: { TWILIO_ACCOUNT_SID: '' } } },
+      {
+        path: 'sites/site_id/services/demo/instances/demo',
+        response: {},
+        method: 'PUT',
+        requestBody: JSON.stringify({ config: { TWILIO_ACCOUNT_SID: 'bar' } }),
+      },
+    ]
+
+    await withMockApi(configRoutes, async ({ apiUrl }) => {
+      const cliResponse = await callCli(
+        ['addons:config', 'demo', '--TWILIO_ACCOUNT_SID', 'bar'],
+        getCLIOptions({ builder, apiUrl }),
+      )
+      t.true(cliResponse.includes('Updating demo add-on config values'))
+      t.true(cliResponse.includes('Add-on "demo" successfully updated'))
+    })
   })
+})
 
-  test.serial('netlify addons:config demo', async (t) => {
-    const cliResponse = await callCli(['addons:config', 'demo', '--TWILIO_ACCOUNT_SID', 'bar'], t.context.execOptions)
-    t.true(cliResponse.includes('Updating demo add-on config values'))
-    t.true(cliResponse.includes('Add-on "demo" successfully updated'))
+test('netlify addon:delete demo', async (t) => {
+  await withSiteBuilder('site-with-addons', async (builder) => {
+    await builder.buildAsync()
+
+    const deleteRoutes = [
+      { path: 'sites/site_id', response: siteInfo },
+      {
+        path: 'sites/site_id/service-instances',
+        response: [{ id: 'demo', service_slug: 'demo', config: { TWILIO_ACCOUNT_SID: 'foo' } }],
+      },
+      {
+        path: 'accounts',
+        response: [{ slug: siteInfo.account_slug }],
+      },
+      { path: 'services/demo/manifest', response: {} },
+      {
+        path: 'sites/site_id/services/demo/instances/demo',
+        response: {},
+        method: 'DELETE',
+      },
+    ]
+
+    await withMockApi(deleteRoutes, async ({ apiUrl }) => {
+      const cliResponse = await callCli(['addons:delete', 'demo', '-f'], getCLIOptions({ builder, apiUrl }))
+      t.true(cliResponse.includes('Addon "demo" deleted'))
+    })
   })
-
-  test.serial('netlify addon:delete demo', async (t) => {
-    const cliResponse = await callCli(['addons:delete', 'demo', '-f'], t.context.execOptions)
-    t.true(cliResponse.includes('Addon "demo" deleted'))
-  })
-
-  test.after('cleanup', async (t) => {
-    const { execOptions, builder } = t.context
-    console.log('Performing cleanup')
-    console.log(`deleting test site "${siteName}". ${execOptions.env.NETLIFY_SITE_ID}`)
-    await callCli(['sites:delete', execOptions.env.NETLIFY_SITE_ID, '--force'], execOptions)
-
-    await builder.cleanupAsync()
-  })
-}
+})

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -16,8 +16,14 @@ const startMockApi = ({ routes }) => {
   app.use(bodyParser.json())
   app.use(bodyParser.raw())
 
-  routes.forEach(({ method = 'get', path, response = {}, status = 200 }) => {
+  routes.forEach(({ method = 'get', path, response = {}, status = 200, requestBody }) => {
     app[method.toLowerCase()](`/api/v1/${path}`, function onRequest(req, res) {
+      // validate request body
+      if (requestBody !== undefined && requestBody !== JSON.stringify(req.body)) {
+        res.status(500)
+        res.json({ message: `Request body doesn't match` })
+        return
+      }
       addRequest(requests, req)
       res.status(status)
       res.json(response)
@@ -26,7 +32,7 @@ const startMockApi = ({ routes }) => {
 
   app.all('*', function onRequest(req, res) {
     addRequest(requests, req)
-    console.warn(`Route not found: ${req.url}`)
+    console.warn(`Route not found: (${req.method.toUpperCase()}) ${req.url}`)
     res.status(404)
     res.json({ message: 'Not found' })
   })


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2209

Uses a mock API for our addons tests. I'll port each set of tests in a separate PR.

As a bonus this allows running tests in parallel and also removes the need to skip these tests on forked PRs

**- Test plan**

See modified tests

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/117001095-98c05b80-acea-11eb-99d9-aa6cc06fa609.png)
