### PR TITLE
fix(command-dev): detect other Jekyll config file names

### DIFF
--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -3,7 +3,7 @@ const { existsSync } = require('fs')
 const FRAMEWORK_PORT = 4000
 
 module.exports = function detector() {
-  if (!existsSync('_config.yml')) {
+  if (!existsSync('_config.yml') && !existsSync('_config.yaml') && !existsSync('_config.toml')) {
     return false
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Detects Jekyll if the project uses `_config.yaml` or `_config.toml` as the configuration file instead of `_config.yml` which is currently the only detected config file name for Jekyll.

I've recently started using Netlify dev, and found that while it worked as I expected in an Angular project (when running `netlify dev`, I saw the expected output from `ng serve` and the server updated as file changes were made), it didn't run `jekyll serve` in a Jekyll project, even though I've defined the project as a Jekyll project (Netlify build command is `jekyll build`, and `jekyll serve` is defined as the `start` script in `package.json`).  When I forced Netlify dev to use Jekyll by setting

```toml
[dev]
    framework = "jekyll"
```

in my `netlify.toml` file, the cli gave the error message

> Specified "framework" detector "jekyll" did not pass requirements for your project

I then looked at the detector for Jekyll, and found that it basically works by checking to see if a file `_config.yml` exists in the project root, and then the error made sense, since I was using a file named `_config.yaml` for my Jekyll project.  From the Jekyll documentation, it also looks like a file named `_config.toml` is supported as a Jekyll configuration file.  This pull request makes the Jekyll detector only conclude that the current project isn't a Jekyll project if it can't find `_config.yml`, `_config.yaml`, or `_config.toml` in the project root.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

While I haven't specifically tested this code, from looking at the way the detector works, this is just adding filenames to the list of what it looks for to detect a Jekyll project, so this isn't a big change.  The only problem it might cause is if systems other than Jekyll also use one of `_config.yml`, `_config.yaml`, or `_config.toml` as their configuration file name.  From looking at the other detectors, the only other detector that has a conflicting file name is Hexo, which also apparently uses `_config.yml` as its config file name, however, the Jekyll detector already used this as its detection name before this pull request, and no other detectors look for files named `_config.yaml` or `_config.toml`, so this shouldn't add any conflicts.

**- A picture of a cute animal (not mandatory but encouraged)**