### PR TITLE
test(windows): increase port limit and reduce time wait delay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
       fail-fast: false
 
     steps:
+      # This improves Windows network performance, we need this since we open many ports in our tests
+      - name: Increase Windows port limit and reduce time wait delay
+        run: |
+          REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP\Parameters /v MaxUserPort /t REG_DWORD /d 32768 /f
+          REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP\Parameters /v TcpTimedWaitDelay /t REG_DWORD /d 30 /f
+        if: "${{ matrix.config.os == 'windows-latest' }}"
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
**- Summary**
Related to https://github.com/netlify/cli/issues/2209

Another attempt to improve Windows tests.
See https://docs.microsoft.com/en-us/biztalk/technical-guides/settings-that-can-be-modified-to-improve-network-performance#adjust-the-maxuserport-and-tcptimedwaitdelay-settings and https://www.ibm.com/docs/en/records-manager/8.5.0?topic=performance-configuring-maxuserport-maximum-user-ports

Default port limit is between 1024 to 5000 and default time wait delay is 120

**- Test plan**

Existing test

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/117271221-a4369280-ae62-11eb-8afa-12fb3226193f.png)
