### PR TITLE
ci(github): skip CLI tests for docs changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,12 @@ name: Testing for CLI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
**- Summary**

We don't need to run the full test suite if we only changed files under `docs/`, for example https://github.com/netlify/cli/pull/2320

Please note this is only relevant for the manually created docs as most commands docs are autogenerated based on the CLI code (meaning most docs changes are coupled to code changes).

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
🐱 