### PR TITLE
test(command-dev): remove test.serial in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "failFast": false,
     "failWithoutAssertions": false,
     "tap": false,
-    "timeout": "2m"
+    "timeout": "5m"
   },
   "oclif": {
     "bin": "netlify",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:init:eleventy-deps": "npm ci --prefix tests/eleventy-site",
     "test:init:hugo-deps": "npm ci --prefix tests/hugo-site",
     "test:dev:ava": "ava --verbose",
-    "test:ci:ava": "nyc -r json ava",
+    "test:ci:ava": "nyc -r json ava -- --concurrency 2 --node-arguments \"--max-old-space-size=4096\"",
     "docs": "node ./site/scripts/docs.js",
     "watch": "nyc --reporter=lcov ava --watch",
     "prepack": "oclif-dev manifest && npm prune --prod",

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -4,8 +4,7 @@ const http = require('http')
 const path = require('path')
 const process = require('process')
 
-// eslint-disable-next-line ava/use-test
-const avaTest = require('ava')
+const test = require('ava')
 const dotProp = require('dot-prop')
 const FormData = require('form-data')
 const jwt = require('jsonwebtoken')
@@ -28,8 +27,6 @@ const gotCatch404 = async (url, options) => {
     throw error
   }
 }
-
-const test = process.env.CI === 'true' ? avaTest.serial.bind(avaTest) : avaTest
 
 const testMatrix = [
   { args: [] },


### PR DESCRIPTION
**- Summary**
Related to https://github.com/netlify/cli/issues/2209

We made the change to run the dev commands tests serially in CI to improve stability.
I'm hoping https://github.com/netlify/cli/pull/2315 can help us the stability issues we had.

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/117301397-49f9f980-ae83-11eb-80d3-504aa32684a8.png)