### PR TITLE
fix(command-dev): add DEPLOY_PRIME_URL

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -274,6 +274,7 @@ class DevCommand extends Command {
 
     process.env.URL = url
     process.env.DEPLOY_URL = url
+    process.env.DEPLOY_PRIME_URL = url
 
     printBanner({ url, log })
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

The `DEPLOY_PRIME_URL` environment variable is [available in the build environment](https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata), but not when running `dev`.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

1. Use `process.env.DEPLOY_PRIME_URL` in your code (eg. in a Netlify function).
2. `process.env.DEPLOY_PRIME_URL` should no longer be `undefined`.