### PR TITLE
test(mock-api): use object comparison

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -136,6 +136,7 @@
         "@oclif/dev-cli": "^1.23.1",
         "@oclif/test": "^1.2.5",
         "ava": "^3.15.0",
+        "fast-deep-equal": "^3.1.3",
         "form-data": "^4.0.0",
         "from2-string": "^1.1.0",
         "got": "^11.8.1",
@@ -23717,7 +23718,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "requires": {
-        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -136,7 +136,6 @@
         "@oclif/dev-cli": "^1.23.1",
         "@oclif/test": "^1.2.5",
         "ava": "^3.15.0",
-        "fast-deep-equal": "^3.1.3",
         "form-data": "^4.0.0",
         "from2-string": "^1.1.0",
         "got": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "@oclif/dev-cli": "^1.23.1",
     "@oclif/test": "^1.2.5",
     "ava": "^3.15.0",
-    "fast-deep-equal": "^3.1.3",
     "form-data": "^4.0.0",
     "from2-string": "^1.1.0",
     "got": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "@oclif/dev-cli": "^1.23.1",
     "@oclif/test": "^1.2.5",
     "ava": "^3.15.0",
+    "fast-deep-equal": "^3.1.3",
     "form-data": "^4.0.0",
     "from2-string": "^1.1.0",
     "got": "^11.8.1",

--- a/tests/command.addons.test.js
+++ b/tests/command.addons.test.js
@@ -53,7 +53,7 @@ test('netlify addons:create demo', async (t) => {
         path: 'sites/site_id/services/demo/instances',
         response: {},
         method: 'POST',
-        requestBody: JSON.stringify({ config: { TWILIO_ACCOUNT_SID: 'foo' } }),
+        requestBody: { config: { TWILIO_ACCOUNT_SID: 'foo' } },
       },
     ]
 
@@ -112,7 +112,7 @@ test('netlify addons:config demo', async (t) => {
         path: 'sites/site_id/services/demo/instances/demo',
         response: {},
         method: 'PUT',
-        requestBody: JSON.stringify({ config: { TWILIO_ACCOUNT_SID: 'bar' } }),
+        requestBody: { config: { TWILIO_ACCOUNT_SID: 'bar' } },
       },
     ]
 

--- a/tests/command.env.test.js
+++ b/tests/command.env.test.js
@@ -57,9 +57,9 @@ test('env:set --json should create and return new var', async (t) => {
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,
@@ -94,9 +94,9 @@ test('env:set --json should update existing var', async (t) => {
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,
@@ -170,9 +170,9 @@ test('env:import --json should import new vars and override existing vars', asyn
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,
@@ -256,9 +256,9 @@ test('env:set --json should be able to set var with empty value', async (t) => {
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,
@@ -289,9 +289,9 @@ test('env:unset --json should remove existing variable', async (t) => {
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,
@@ -329,9 +329,9 @@ test('env:import --json --replace-existing should replace all existing vars and 
       {
         path: 'sites/site_id',
         method: 'PATCH',
-        requestBody: JSON.stringify({
+        requestBody: {
           build_settings: newBuildSettings,
-        }),
+        },
         response: {
           ...siteInfo,
           build_settings: newBuildSettings,

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -1,5 +1,6 @@
 const bodyParser = require('body-parser')
 const express = require('express')
+const equal = require('fast-deep-equal')
 
 const addRequest = (requests, request) => {
   requests.push({
@@ -19,7 +20,7 @@ const startMockApi = ({ routes }) => {
   routes.forEach(({ method = 'get', path, response = {}, status = 200, requestBody }) => {
     app[method.toLowerCase()](`/api/v1/${path}`, function onRequest(req, res) {
       // validate request body
-      if (requestBody !== undefined && requestBody !== JSON.stringify(req.body)) {
+      if (requestBody !== undefined && !equal(requestBody, req.body)) {
         res.status(500)
         res.json({ message: `Request body doesn't match` })
         return

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -1,6 +1,7 @@
+const { isDeepStrictEqual } = require('util')
+
 const bodyParser = require('body-parser')
 const express = require('express')
-const equal = require('fast-deep-equal')
 
 const addRequest = (requests, request) => {
   requests.push({
@@ -20,7 +21,7 @@ const startMockApi = ({ routes }) => {
   routes.forEach(({ method = 'get', path, response = {}, status = 200, requestBody }) => {
     app[method.toLowerCase()](`/api/v1/${path}`, function onRequest(req, res) {
       // validate request body
-      if (requestBody !== undefined && !equal(requestBody, req.body)) {
+      if (requestBody !== undefined && !isDeepStrictEqual(requestBody, req.body)) {
         res.status(500)
         res.json({ message: `Request body doesn't match` })
         return


### PR DESCRIPTION
**- Summary**

A bit of refactoring before opening a PR for https://github.com/netlify/cli/issues/2302 to make the upcoming PR easier to review.

This PR changes the mock API to use object comparison instead of string comparison when matching request body to allow comparing the same object with different properties order.

**- Test plan**

Exiting tests

**- A picture of a cute animal (not mandatory but encouraged)**
🐐 