### PR TITLE
fix(command-link-init): always create gitignore in repo root

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -169,7 +169,7 @@ class InitCommand extends Command {
   async run() {
     const { flags } = this.parse(InitCommand)
     const { log, exit, config, netlify } = this
-    const { site, state } = netlify
+    const { repositoryRoot, state } = netlify
     let { siteInfo } = this.netlify
 
     // Check logged in status
@@ -178,7 +178,7 @@ class InitCommand extends Command {
     await reportAnalytics({ config, flags })
 
     // Add .netlify to .gitignore file
-    await ensureNetlifyIgnore(site.root)
+    await ensureNetlifyIgnore(repositoryRoot)
 
     const repoUrl = getRepoUrl({ siteInfo })
     if (repoUrl && !flags.force) {

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -15,8 +15,12 @@ class LinkCommand extends Command {
     await this.authenticate()
 
     const { flags } = this.parse(LinkCommand)
-    const { api, site, state } = this.netlify
-    const siteId = site.id
+    const {
+      api,
+      repositoryRoot,
+      site: { id: siteId },
+      state,
+    } = this.netlify
 
     await this.config.runHook('analytics', {
       eventName: 'command',
@@ -33,7 +37,7 @@ class LinkCommand extends Command {
     }
 
     // Add .netlify to .gitignore file
-    await ensureNetlifyIgnore(site.root)
+    await ensureNetlifyIgnore(repositoryRoot)
 
     // Site id is incorrect
     if (siteId && !siteData) {

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -97,7 +97,7 @@ class BaseCommand extends Command {
     }
 
     const cachedConfig = await this.getConfig({ cwd, state, token, ...apiUrlOpts })
-    const { configPath, config, buildDir, siteInfo } = cachedConfig
+    const { configPath, config, buildDir, repositoryRoot, siteInfo } = cachedConfig
 
     const { flags } = this.parse(BaseCommand)
     const agent = await getAgent({
@@ -112,6 +112,7 @@ class BaseCommand extends Command {
     this.netlify = {
       // api methods
       api: new API(token || '', apiOpts),
+      repositoryRoot,
       // current site context
       site: {
         root: buildDir,

--- a/tests/command.link.test.js
+++ b/tests/command.link.test.js
@@ -1,0 +1,33 @@
+const test = require('ava')
+
+const { isFileAsync } = require('../src/lib/fs')
+
+const callCli = require('./utils/call-cli')
+const { withMockApi, getCLIOptions } = require('./utils/mock-api')
+const { withSiteBuilder } = require('./utils/site-builder')
+
+test('should create gitignore in repository root when is root', async (t) => {
+  await withSiteBuilder('repo', async (builder) => {
+    await builder.withGit().buildAsync()
+
+    await withMockApi([], async ({ apiUrl }) => {
+      await callCli(['link'], getCLIOptions({ builder, apiUrl }))
+
+      t.true(await isFileAsync(`${builder.directory}/.gitignore`))
+    })
+  })
+})
+
+test('should create gitignore in repository root when cwd is subdirectory', async (t) => {
+  await withSiteBuilder('monorepo', async (builder) => {
+    const projectPath = 'projects/project1'
+    await builder.withGit().withNetlifyToml({ config: {}, pathPrefix: projectPath }).buildAsync()
+
+    await withMockApi([], async ({ apiUrl }) => {
+      const options = getCLIOptions({ builder, apiUrl })
+      await callCli(['link'], { ...options, cwd: `${builder.directory}/${projectPath}` })
+
+      t.true(await isFileAsync(`${builder.directory}/.gitignore`))
+    })
+  })
+})

--- a/tests/utils/site-builder.js
+++ b/tests/utils/site-builder.js
@@ -123,7 +123,7 @@ const createSiteBuilder = ({ siteName }) => {
       })
       return builder
     },
-    withGit: ({ repoUrl }) => {
+    withGit: ({ repoUrl = 'git@github.com:owner/repo.git' } = {}) => {
       tasks.push(async () => {
         await execa('git', ['init', '--initial-branch', 'main'], { cwd: directory })
         await execa('git', ['remote', 'add', 'origin', repoUrl], { cwd: directory })


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/cli/issues/2383

**- Test plan**

Added new tests for the `link` command

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/118156746-63221d80-b422-11eb-879a-6aead72e0980.png)