### PR TITLE
fix(command-init): remove functions dir workaround

### DIFF
--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -202,6 +202,7 @@ module.exports = async function configGithub({ context, siteId, repoOwner, repoN
     allowed_branches: [githubRepo.default_branch],
     deploy_key_id: deployKey.id,
     dir: buildDir,
+    functions_dir: functionsDir,
     ...(buildCmd && { cmd: buildCmd }),
   }
 
@@ -211,7 +212,6 @@ module.exports = async function configGithub({ context, siteId, repoOwner, repoN
     failAndExit,
     siteId,
     repo,
-    functionsDir,
     configPlugins: config.plugins,
     pluginsToInstall,
   })

--- a/src/utils/init/config-manual.js
+++ b/src/utils/init/config-manual.js
@@ -72,6 +72,7 @@ module.exports = async function configManual({ context, siteId, repoData }) {
     allowed_branches: [repoData.branch],
     deploy_key_id: deployKey.id,
     dir: buildDir,
+    functions_dir: functionsDir,
     ...(buildCmd && { cmd: buildCmd }),
   }
 
@@ -80,7 +81,6 @@ module.exports = async function configManual({ context, siteId, repoData }) {
     failAndExit,
     siteId,
     repo,
-    functionsDir,
     configPlugins: config.plugins,
     pluginsToInstall,
   })

--- a/src/utils/init/utils.js
+++ b/src/utils/init/utils.js
@@ -218,20 +218,13 @@ const updateSite = async ({ siteId, api, failAndExit, options }) => {
   }
 }
 
-const setupSite = async ({ api, failAndExit, siteId, repo, functionsDir, configPlugins, pluginsToInstall }) => {
-  await updateSite({
+const setupSite = async ({ api, failAndExit, siteId, repo, configPlugins, pluginsToInstall }) => {
+  const updatedSite = await updateSite({
     siteId,
     api,
     failAndExit,
     // merge existing plugins with new ones
     options: { repo, plugins: [...getUIPlugins(configPlugins), ...pluginsToInstall] },
-  })
-  // calling updateSite with { repo } resets the functions dir so we need to sync it
-  const updatedSite = await updateSite({
-    siteId,
-    api,
-    failAndExit,
-    options: { build_settings: { functions_dir: functionsDir } },
   })
 
   return updatedSite


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2302 and https://github.com/netlify/cli/issues/2380
During `ntl init` we used to set the functions directory in a separate API call due to a bug in our API.
That bug has been fixed so we can remove the workaround.

**- Test plan**

Updated the tests to use `requestBody` instead of validating requests. `requestBody` was added recently to the mock API and asserts that the request body sent by the CLI matches the expected one.

**- A picture of a cute animal (not mandatory but encouraged)**
🐦 