### PR TITLE
feat: add warning for native modules

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -276,6 +276,7 @@ const runDeploy = async ({
       // pass an existing deployId to update
       deployId,
       filter: getDeployFilesFilter({ site, deployFolder }),
+      warn,
     })
   } catch (error_) {
     if (deployId) {

--- a/src/utils/deploy/deploy-site.js
+++ b/src/utils/deploy/deploy-site.js
@@ -71,10 +71,11 @@ const deploySite = async (
     warn(`Modules with native dependencies\n
 ${functionsWithNativeModules.map(({ name }) => `- ${name}`).join('\n')}    
 
-These functions use Node.js modules with native dependencies, which must be installed
-on a system with the same architecture as the runtime. Failing to do so might lead to
-errors when invoking your functions.
-To ensure your functions work as expected, we recommend using continuous deployment.
+The serverless functions above use Node.js modules with native dependencies, which
+must be installed on a system with the same architecture as the function runtime. A
+mismatch in the system and runtime may lead to errors when invoking your functions.
+To ensure your functions work as expected, we recommend using continuous deployment
+instead of manual deployment.
 
 For more information, visit https://ntl.fyi/cli-native-modules.`)
   }

--- a/src/utils/deploy/deploy-site.js
+++ b/src/utils/deploy/deploy-site.js
@@ -40,6 +40,7 @@ const deploySite = async (
     },
     syncFileLimit = DEFAULT_SYNC_LIMIT,
     tmpDir = tempy.directory(),
+    warn,
   } = {},
 ) => {
   statusCb({
@@ -48,7 +49,7 @@ const deploySite = async (
     phase: 'start',
   })
 
-  const [{ files, filesShaMap }, { functions, fnShaMap }] = await Promise.all([
+  const [{ files, filesShaMap }, { functions, functionsWithNativeModules, fnShaMap }] = await Promise.all([
     hashFiles(dir, configPath, { concurrentHash, hashAlgorithm, assetType, statusCb, filter }),
     hashFns(fnDir, { functionsConfig, tmpDir, concurrentHash, hashAlgorithm, statusCb, assetType }),
   ])
@@ -64,6 +65,18 @@ const deploySite = async (
 
   if (filesCount === 0 && functionsCount === 0) {
     throw new Error('No files or functions to deploy')
+  }
+
+  if (functionsWithNativeModules.length !== 0) {
+    warn(`Modules with native dependencies\n
+${functionsWithNativeModules.map(({ name }) => `- ${name}`).join('\n')}    
+
+These functions use Node.js modules with native dependencies, which must be installed
+on a system with the same architecture as the runtime. Failing to do so might lead to
+errors when invoking your functions.
+To ensure your functions work as expected, we recommend using continuous deployment.
+
+For more information, visit https://ntl.fyi/cli-native-modules.`)
   }
 
   statusCb({

--- a/src/utils/deploy/hash-fns.js
+++ b/src/utils/deploy/hash-fns.js
@@ -28,6 +28,10 @@ const hashFns = async (
     runtime,
   }))
 
+  const functionsWithNativeModules = functionZips.filter(
+    ({ nativeNodeModules }) => nativeNodeModules !== undefined && Object.keys(nativeNodeModules).length !== 0,
+  )
+
   const functionStream = fromArray.obj(fileObjs)
 
   const hasher = hasherCtor({ concurrentHash, hashAlgorithm })
@@ -41,7 +45,7 @@ const hashFns = async (
 
   await pump(functionStream, hasher, manifestCollector)
 
-  return { functions, fnShaMap }
+  return { functions, functionsWithNativeModules, fnShaMap }
 }
 
 module.exports = { hashFns }

--- a/src/utils/deploy/hash-fns.js
+++ b/src/utils/deploy/hash-fns.js
@@ -12,7 +12,7 @@ const hashFns = async (
   { tmpDir, concurrentHash, functionsConfig, hashAlgorithm = 'sha256', assetType = 'function', statusCb },
 ) => {
   // early out if the functions dir is omitted
-  if (!dir) return { functions: {}, shaMap: {} }
+  if (!dir) return { functions: {}, functionsWithNativeModules: [], shaMap: {} }
   if (!tmpDir) throw new Error('Missing tmpDir directory for zipping files')
 
   const functionZips = await zipIt.zipFunctions(dir, tmpDir, { config: functionsConfig })


### PR DESCRIPTION
**- Summary**

Shows a warning when running `netlify deploy` on a site that uses at least one function with native Node.js dependencies.

![Screenshot 2021-05-14 at 10 28 51](https://user-images.githubusercontent.com/4162329/118251233-36f8b200-b49f-11eb-9f1c-c03950889bba.png)

Closes #2363.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

![__opt__aboutcom__coeus__resources__content_migration__mnn__images__2018__08__19390959_1583394328369857_3239544490769925887_o-f9f097f036ed4ea9b7c0951819f0b343](https://user-images.githubusercontent.com/4162329/118251076-0add3100-b49f-11eb-96ec-a1f23607d14d.jpg)
