### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: '*'
+          check-latest: true
       - name: Install dependencies
         run: npm install --production
       - name: Get size

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - { os: macOS-latest, shell: bash }
           - { os: ubuntu-latest, shell: bash }
           - { os: windows-latest, shell: cmd }
-        node-version: [10.x, 16.x]
+        node-version: [10.x, '*']
         exclude:
           - config: { os: macOS-latest, shell: bash }
             node-version: 10.x
@@ -44,13 +44,14 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Install core dependencies
         run: npm ci
       - name: Install site dependencies
         run: npm run site:build:install
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == '16.x' }}"
+        if: "${{ matrix.node-version == '*' }}"
       - name: Tests
         run: npm run test:ci
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '*'
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       # required for linting to pass

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -10,16 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        node-version: [16.x]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '*'
+          check-latest: true
       - name: Install core dependencies
         run: npm ci
       - name: Install site dependencies


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.