### PR TITLE
chore(telemetry): switch the telemetry backend via redirects

### DIFF
--- a/functions/telemetry.js
+++ b/functions/telemetry.js
@@ -4,7 +4,7 @@ const TELEMETRY_SERVICE_URL = 'https://cli-telemetry.netlify.engineering'
 
 // This function is a workaround for our inability to redirect traffic to a ntl function in another site
 // using redirects (see https://github.com/netlify/cli-telemetry-service/issues/14)
-const handler = function ({ path, httpMethod, headers, body }) {
+const handler = async function ({ path, httpMethod, headers, body }, context) {
   const upstreamPath = path.replace(/^\/telemetry\//, '/')
 
   // Filter out some headers that shouldn't be fwded
@@ -25,6 +25,7 @@ const handler = function ({ path, httpMethod, headers, body }) {
   // We don't wait for the telemetry service response because the CLI does not care about
   // it. We want to return as soon and as fast as possible while making these requests in
   // the background.
+  context.callbackWaitsForEmptyEventLoop = false
   response
     // eslint-disable-next-line promise/prefer-await-to-then
     .then((res) => console.log(`Telemetry service responded with ${res.status}`))

--- a/functions/telemetry.js
+++ b/functions/telemetry.js
@@ -1,0 +1,41 @@
+const fetch = require('node-fetch')
+
+const TELEMETRY_SERVICE_URL = 'https://cli-telemetry.netlify.engineering'
+
+// This function is a workaround for our inability to redirect traffic to a ntl function in another site
+// using redirects (see https://github.com/netlify/cli-telemetry-service/issues/14)
+const handler = function ({ path, httpMethod, headers, body }) {
+  const upstreamPath = path.replace(/^\/telemetry\//, '/')
+
+  // Filter out some headers that shouldn't be fwded
+  const headersToFilter = ['host']
+  const upstreamHeaders = Object.entries(headers)
+    .filter(([headerName]) => headersToFilter.find((hToFilter) => hToFilter !== headerName))
+    .reduce((resultingHeaders, [headerName, value]) => {
+      resultingHeaders[headerName] = value
+      return resultingHeaders
+    }, {})
+
+  const response = fetch(`${TELEMETRY_SERVICE_URL}${upstreamPath}`, {
+    method: httpMethod,
+    headers: upstreamHeaders,
+    body,
+  })
+
+  // We don't wait for the telemetry service response because the CLI does not care about
+  // it. We want to return as soon and as fast as possible while making these requests in
+  // the background.
+  response
+    // eslint-disable-next-line promise/prefer-await-to-then
+    .then((res) => console.log(`Telemetry service responded with ${res.status}`))
+    // eslint-disable-next-line promise/prefer-await-to-callbacks
+    .catch((error) => console.error('Telemetry service call failed', error))
+
+  return {
+    statusCode: 200,
+  }
+}
+
+module.exports = {
+  handler,
+}

--- a/functions/telemetry.js
+++ b/functions/telemetry.js
@@ -4,7 +4,7 @@ const TELEMETRY_SERVICE_URL = 'https://cli-telemetry.netlify.engineering'
 
 // This function is a workaround for our inability to redirect traffic to a ntl function in another site
 // using redirects (see https://github.com/netlify/cli-telemetry-service/issues/14)
-const handler = async function ({ path, httpMethod, headers, body }, context) {
+const handler = async function ({ path, httpMethod, headers, body }) {
   const upstreamPath = path.replace(/^\/telemetry\//, '/')
 
   // Filter out some headers that shouldn't be fwded
@@ -16,21 +16,16 @@ const handler = async function ({ path, httpMethod, headers, body }, context) {
       return resultingHeaders
     }, {})
 
-  const response = fetch(`${TELEMETRY_SERVICE_URL}${upstreamPath}`, {
-    method: httpMethod,
-    headers: upstreamHeaders,
-    body,
-  })
-
-  // We don't wait for the telemetry service response because the CLI does not care about
-  // it. We want to return as soon and as fast as possible while making these requests in
-  // the background.
-  context.callbackWaitsForEmptyEventLoop = false
-  response
-    // eslint-disable-next-line promise/prefer-await-to-then
-    .then((res) => console.log(`Telemetry service responded with ${res.status}`))
-    // eslint-disable-next-line promise/prefer-await-to-callbacks
-    .catch((error) => console.error('Telemetry service call failed', error))
+  try {
+    const response = await fetch(`${TELEMETRY_SERVICE_URL}${upstreamPath}`, {
+      method: httpMethod,
+      headers: upstreamHeaders,
+      body,
+    })
+    console.log(`Telemetry service responded with ${response.status}`)
+  } catch (error) {
+    console.error('Telemetry service call failed', error)
+  }
 
   return {
     statusCode: 200,

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,22 +6,24 @@
 
   [build.environment]
     NODE_VERSION = "12"
+    AWS_LAMBDA_JS_RUNTIME = "nodejs14.x"
+
+[functions]
+  # Sets a custom directory for Netlify Functions
+  directory = "functions"
+
+  # Specifies `esbuild` for functions bundling
+  node_bundler = "esbuild"
 
 #####################
 #  Redirect Rules   #
 #####################
 [[redirects]]
   # Telemetry link
-  from = "/telemetry/track"
-  to = "https://cli-telemetry.netlify.engineering/.netlify/functions/track"
-  status = 302
-  force = false
-[[redirects]]
-   # Telemetry link
-  from = "/telemetry/identify"
-  to = "https://cli-telemetry.netlify.engineering/.netlify/functions/identify"
-  status = 302
-  force = false
+  from = "/telemetry/*"
+  to = "/.netlify/functions/telemetry"
+  status = 200
+  force = true
 [[redirects]]
   # Old CLI download links.
   from = "/download/latest/mac"

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,13 +14,13 @@
   # Telemetry link
   from = "/telemetry/track"
   to = "https://cli-telemetry.netlify.engineering/.netlify/functions/track"
-  status = 200
+  status = 302
   force = false
 [[redirects]]
    # Telemetry link
   from = "/telemetry/identify"
   to = "https://cli-telemetry.netlify.engineering/.netlify/functions/identify"
-  status = 200
+  status = 302
   force = false
 [[redirects]]
   # Old CLI download links.

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,13 +13,13 @@
 [[redirects]]
   # Telemetry link
   from = "/telemetry/track"
-  to = "https://api.netlify-services.com/telemetry/track"
+  to = "https://cli-telemetry.netlify.engineering/track"
   status = 200
   force = false
 [[redirects]]
    # Telemetry link
   from = "/telemetry/identify"
-  to = "https://api.netlify-services.com/telemetry/identify"
+  to = "https://cli-telemetry.netlify.engineering/identify"
   status = 200
   force = false
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,13 +13,13 @@
 [[redirects]]
   # Telemetry link
   from = "/telemetry/track"
-  to = "https://cli-telemetry.netlify.engineering/track"
+  to = "https://cli-telemetry-proxy.netlify.app/track"
   status = 200
   force = false
 [[redirects]]
    # Telemetry link
   from = "/telemetry/identify"
-  to = "https://cli-telemetry.netlify.engineering/identify"
+  to = "https://cli-telemetry-proxy.netlify.app/identify"
   status = 200
   force = false
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,13 +13,13 @@
 [[redirects]]
   # Telemetry link
   from = "/telemetry/track"
-  to = "https://cli-telemetry-proxy.netlify.app/track"
+  to = "https://cli-telemetry.netlify.engineering/.netlify/functions/track"
   status = 200
   force = false
 [[redirects]]
    # Telemetry link
   from = "/telemetry/identify"
-  to = "https://cli-telemetry-proxy.netlify.app/identify"
+  to = "https://cli-telemetry.netlify.engineering/.netlify/functions/identify"
   status = 200
   force = false
 [[redirects]]


### PR DESCRIPTION
**- Summary**

This is a follow up of the work in https://github.com/netlify/cli-telemetry-service/issues/14 and developed under https://github.com/netlify/pod-workflow/issues/160

**- Test plan**

I've tested this work locally, however I'll probably give the redirects a try once the deploy preview is up and running 👍 

**- A picture of a cute animal (not mandatory but encouraged)**
🐥 
