### PR TITLE
test(command-functions): increase wait port timeout

### DIFF
--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -156,7 +156,7 @@ test('should not create a new function directory when one is found', async (t) =
 })
 
 const DEFAULT_PORT = 9999
-const SERVE_TIMEOUT = 60000
+const SERVE_TIMEOUT = 180000
 
 const withFunctionsServer = async ({ builder, args = [], port = DEFAULT_PORT }, testHandler) => {
   let ps


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/2450

Increases the `functions:serve` wait port timeout since it's flaky on CI