### PR TITLE
fix(telemetry): fix tracking of --telemetry-enable flag

### DIFF
--- a/src/hooks/analytics.js
+++ b/src/hooks/analytics.js
@@ -1,6 +1,6 @@
 const { track } = require('../utils/telemetry')
 
-const hook = function (options) {
-  track(options.eventName, options.payload)
+const hook = function ({ eventName, payload }) {
+  track(eventName, payload)
 }
 module.exports = hook

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -19,9 +19,7 @@ module.exports = async function initHooks(context) {
     globalConfig.set('telemetryDisabled', false)
     console.log('Netlify telemetry has been enabled')
     console.log('You can disable it anytime with the --telemetry-disable flag')
-    track('user_telemetryEnabled', {
-      force: true,
-    })
+    await track('user_telemetryEnabled')
     process.exit()
   }
 

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -283,13 +283,12 @@ class BaseCommand extends Command {
       chalk: this.chalk,
     })
 
-    const user = await this.netlify.api.getCurrentUser()
-    const userID = user.id
+    const { id: userId, full_name: name, email } = await this.netlify.api.getCurrentUser()
 
-    const userData = merge(this.netlify.globalConfig.get(`users.${userID}`), {
-      id: userID,
-      name: user.full_name,
-      email: user.email,
+    const userData = merge(this.netlify.globalConfig.get(`users.${userId}`), {
+      id: userId,
+      name,
+      email,
       auth: {
         token: accessToken,
         github: {
@@ -299,19 +298,18 @@ class BaseCommand extends Command {
       },
     })
     // Set current userId
-    this.netlify.globalConfig.set('userId', userID)
+    this.netlify.globalConfig.set('userId', userId)
     // Set user data
-    this.netlify.globalConfig.set(`users.${userID}`, userData)
+    this.netlify.globalConfig.set(`users.${userId}`, userData)
 
-    const { email } = user
     await identify({
-      name: user.full_name,
+      name,
       email,
-    }).then(() =>
-      track('user_login', {
-        email,
-      }),
-    )
+      userId,
+    })
+    await track('user_login', {
+      email,
+    })
 
     // Log success
     this.log()

--- a/src/utils/telemetry/index.js
+++ b/src/utils/telemetry/index.js
@@ -1,16 +1,16 @@
-const { spawn } = require('child_process')
 const path = require('path')
 const process = require('process')
 
-const ci = require('ci-info')
+const { isCI } = require('ci-info')
+const execa = require('execa')
 
 const getGlobalConfig = require('../get-global-config')
 
 const isValidEventName = require('./validation')
 
-const IS_INSIDE_CI = ci.isCI
-
-const DEBUG = false
+const isTelemetryDisabled = function (config) {
+  return config.get('telemetryDisabled')
+}
 
 const send = function (type, payload) {
   const requestFile = path.join(__dirname, 'request.js')
@@ -19,18 +19,18 @@ const send = function (type, payload) {
     type,
   })
 
-  if (DEBUG) {
-    console.log(`${type} call`, payload)
-    return Promise.resolve()
+  const args = [process.execPath, [requestFile, options]]
+  if (process.env.NETLIFY_TEST_TELEMETRY_WAIT === 'true') {
+    return execa(...args, {
+      stdio: 'inherit',
+    })
   }
 
   // spawn detached child process to handle send
-  spawn(process.execPath, [requestFile, options], {
+  execa(...args, {
     detached: true,
     stdio: 'ignore',
   }).unref()
-
-  return Promise.resolve()
 }
 
 const eventConfig = {
@@ -45,36 +45,17 @@ const eventConfig = {
   ],
 }
 
-const track = async function (eventName, payload) {
-  const properties = payload || {}
-
-  if (IS_INSIDE_CI) {
-    if (DEBUG) {
-      console.log('Abort .identify call inside CI')
-    }
-    return Promise.resolve()
+const track = async function (eventName, payload = {}) {
+  if (isCI) {
+    return
   }
 
   const globalConfig = await getGlobalConfig()
-  // exit early if tracking disabled
-  const TELEMETRY_DISABLED = globalConfig.get('telemetryDisabled')
-  if (TELEMETRY_DISABLED && !properties.force) {
-    if (DEBUG) {
-      console.log('Abort .track call TELEMETRY_DISABLED')
-    }
-    return Promise.resolve()
+  if (isTelemetryDisabled(globalConfig)) {
+    return
   }
 
-  let userId = properties.userID
-  let { cliId } = properties
-
-  if (!userId) {
-    userId = globalConfig.get('userId')
-  }
-
-  if (!cliId) {
-    cliId = globalConfig.get('cliId')
-  }
+  const [userId, cliId] = [globalConfig.get('userId'), globalConfig.get('cliId')]
 
   // automatically add `cli:` prefix if missing
   if (!eventName.includes('cli:')) {
@@ -88,70 +69,39 @@ const track = async function (eventName, payload) {
     return false
   }
 
-  const defaultProperties = {
-    // cliId: cliId
-  }
-
-  delete properties.force
-
   const defaultData = {
     event: eventName,
     userId,
     anonymousId: cliId,
-    properties: { ...defaultProperties, ...properties },
+    properties: payload,
   }
 
   return send('track', defaultData)
 }
 
 const identify = async function (payload) {
-  const data = payload || {}
-
-  if (IS_INSIDE_CI) {
-    if (DEBUG) {
-      console.log('Abort .identify call inside CI')
-    }
-    return Promise.resolve()
+  if (isCI) {
+    return
   }
 
   const globalConfig = await getGlobalConfig()
-  // exit early if tracking disabled
-  const TELEMETRY_DISABLED = globalConfig.get('telemetryDisabled')
-  if (TELEMETRY_DISABLED && !data.force) {
-    if (DEBUG) {
-      console.log('Abort .identify call TELEMETRY_DISABLED')
-    }
-    return Promise.resolve()
+  if (isTelemetryDisabled(globalConfig, payload)) {
+    return
   }
 
-  let userId = data.userID
-  let { cliId } = data
-
-  if (!userId) {
-    userId = globalConfig.get('userId')
-  }
-
-  if (!cliId) {
-    cliId = globalConfig.get('cliId')
-  }
-
-  const userProfile = globalConfig.get(`users.${userId}`)
+  const cliId = globalConfig.get('cliId')
+  const { userId, name, email } = payload
 
   const defaultTraits = {
-    name: userProfile.name,
-    email: userProfile.email,
+    name,
+    email,
     cliId,
-    telemetryDisabled: TELEMETRY_DISABLED,
   }
 
-  // remove force key
-  delete data.force
-
-  // Payload to send to segment
   const identifyData = {
     anonymousId: cliId,
     userId,
-    traits: { ...defaultTraits, ...data },
+    traits: { ...defaultTraits, ...payload },
   }
 
   return send('identify', identifyData)

--- a/src/utils/telemetry/request.js
+++ b/src/utils/telemetry/request.js
@@ -6,8 +6,8 @@ const fetch = require('node-fetch')
 const options = JSON.parse(process.argv[2])
 
 const CLIENT_ID = 'NETLIFY_CLI'
-const TRACK_URL = 'https://cli.netlify.com/telemetry/track'
-const IDENTIFY_URL = 'https://cli.netlify.com/telemetry/identify'
+const TRACK_URL = process.env.NETLIFY_TEST_TRACK_URL || 'https://cli.netlify.com/telemetry/track'
+const IDENTIFY_URL = process.env.NETLIFY_TEST_IDENTIFY_URL || 'https://cli.netlify.com/telemetry/identify'
 
 const API_URL = options.type && options.type === 'track' ? TRACK_URL : IDENTIFY_URL
 

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -1,0 +1,38 @@
+const test = require('ava')
+const { version: uuidVersion } = require('uuid')
+
+const callCli = require('./utils/call-cli')
+const { withMockApi } = require('./utils/mock-api')
+
+const getCLIOptions = (apiUrl) => ({
+  env: {
+    NETLIFY_TEST_TRACK_URL: `${apiUrl}/track`,
+    NETLIFY_TEST_IDENTIFY_URL: `${apiUrl}/identify`,
+    NETLIFY_TEST_TELEMETRY_WAIT: true,
+    CI: undefined,
+  },
+})
+
+const routes = [{ path: 'track', method: 'POST', response: {} }]
+
+test.serial('should not track --telemetry-disable', async (t) => {
+  await withMockApi(routes, async ({ apiUrl, requests }) => {
+    await callCli(['--telemetry-disable'], getCLIOptions(apiUrl))
+    t.deepEqual(requests, [])
+  })
+})
+
+const UUID_VERSION = 4
+
+test.serial('should track --telemetry-enable', async (t) => {
+  await withMockApi(routes, async ({ apiUrl, requests }) => {
+    await callCli(['--telemetry-enable'], getCLIOptions(apiUrl))
+    t.is(requests.length, 1)
+    t.is(requests[0].method, 'POST')
+    t.is(requests[0].path, '/api/v1/track')
+    t.is(requests[0].body.event, 'cli:user_telemetryEnabled')
+    t.regex(requests[0].body.userId, /[a-zA-Z\d]{24}/)
+    t.is(uuidVersion(requests[0].body.anonymousId), UUID_VERSION)
+    t.deepEqual(requests[0].body.properties, {})
+  })
+})

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -1,3 +1,5 @@
+const process = require('process')
+
 const test = require('ava')
 const { version: uuidVersion } = require('uuid')
 
@@ -9,8 +11,9 @@ const getCLIOptions = (apiUrl) => ({
     NETLIFY_TEST_TRACK_URL: `${apiUrl}/track`,
     NETLIFY_TEST_IDENTIFY_URL: `${apiUrl}/identify`,
     NETLIFY_TEST_TELEMETRY_WAIT: true,
-    CI: undefined,
+    PATH: process.env.PATH,
   },
+  extendEnv: false,
 })
 
 const routes = [{ path: 'track', method: 'POST', response: {} }]
@@ -31,7 +34,6 @@ test.serial('should track --telemetry-enable', async (t) => {
     t.is(requests[0].method, 'POST')
     t.is(requests[0].path, '/api/v1/track')
     t.is(requests[0].body.event, 'cli:user_telemetryEnabled')
-    t.regex(requests[0].body.userId, /[a-zA-Z\d]{24}/)
     t.is(uuidVersion(requests[0].body.anonymousId), UUID_VERSION)
     t.deepEqual(requests[0].body.properties, {})
   })

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -15,7 +15,11 @@ const startMockApi = ({ routes }) => {
   const requests = []
   const app = express()
   app.use(bodyParser.urlencoded({ extended: true }))
-  app.use(bodyParser.json())
+  app.use(
+    bodyParser.json({
+      type: () => true,
+    }),
+  )
   app.use(bodyParser.raw())
 
   routes.forEach(({ method = 'get', path, response = {}, status = 200, requestBody }) => {


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2458

Cleans up our telemetry code a bit and also fixes a bug with `netlify --telemetry-enable` not being tracked

**- Test plan**

Added 2 new tests for `--telemetry-disable` and `--telemetry-enable` using a mock API

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/119513428-e0cc1e80-bd7c-11eb-935b-d10d893b83e9.png)
