### PR TITLE
chore(ci): pass --no-audit flag to npm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '*'
           check-latest: true
       - name: Install dependencies
-        run: npm install --production
+        run: npm install --production --no-audit
       - name: Get size
         run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "kb (Package size)" >> .delta.packageSize
       - name: Run Delta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Install core dependencies
-        run: npm ci
+        run: npm ci --no-audit
       - name: Install site dependencies
         run: npm run site:build:install
       - name: Linting

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '*'
           check-latest: true
       - name: Install core dependencies
-        run: npm ci
+        run: npm ci --no-audit
       - name: Install site dependencies
         run: npm run site:build:install
       - name: Generate docs

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/netlify/cli/issues"
   },
   "scripts": {
-    "prepublishOnly": "npm ci && run-s test",
+    "prepublishOnly": "npm ci --no-audit && run-s test",
     "start": "node ./bin/run",
     "test": "run-s format test:dev",
     "format": "run-s format:check-fix:*",
@@ -57,8 +57,8 @@
     "test:ci": "run-s test:init:* test:ci:*",
     "test:init:cli-version": "npm run start -- --version",
     "test:init:cli-help": "npm run start -- --help",
-    "test:init:eleventy-deps": "npm ci --prefix tests/eleventy-site",
-    "test:init:hugo-deps": "npm ci --prefix tests/hugo-site",
+    "test:init:eleventy-deps": "npm ci --prefix tests/eleventy-site --no-audit",
+    "test:init:hugo-deps": "npm ci --prefix tests/hugo-site --no-audit",
     "test:dev:ava": "ava --verbose",
     "test:ci:ava": "nyc -r json ava",
     "docs": "node ./site/scripts/docs.js",
@@ -66,7 +66,7 @@
     "prepack": "oclif-dev manifest && npm prune --prod",
     "postpack": "rm -f oclif.manifest.json && npm i",
     "site:build": "run-s site:build:*",
-    "site:build:install": "cd site && npm ci",
+    "site:build:install": "cd site && npm ci --no-audit",
     "site:build:assets": "cd site && npm run build",
     "postinstall": "node ./scripts/postinstall.js"
   },


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2209

Adds the `--no-audit` flag to `npm ci` and `npm install` commands. It's not really useful for GitHub workflows/CI.
Since npm v7 `npm ci` also runs the audit which adds a few seconds to each installation process.
See https://github.com/npm/cli/issues/2703.

Also we use renovate to update dependencies and GitHub alerts us when there are security vulnerabilities, so I don't think there's much benefit to it. 

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
🦒 

> On a side note we can consider adding this to all our repos workflows