### PR TITLE
test(command-deploy): improve hash files/fns tests

### DIFF
--- a/src/utils/deploy/hash-files.test.js
+++ b/src/utils/deploy/hash-files.test.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 const test = require('ava')
 
 const { withSiteBuilder } = require('../../../tests/utils/site-builder')
@@ -8,53 +6,36 @@ const { DEFAULT_CONCURRENT_HASH } = require('./constants')
 const { hashFiles } = require('./hash-files')
 
 test('Hashes files in a folder', async (t) => {
-  await withSiteBuilder('site-with-override', async (builder) => {
-    builder
-      .withNetlifyToml({ config: { functions: { directory: 'functions' } } })
+  await withSiteBuilder('site-with-content', async (builder) => {
+    await builder
+      .withNetlifyToml({ config: { build: { publish: 'public' } } })
       .withContentFile({
-        path: 'lib/util.js',
-        content: `module.exports = { one: 1 }`,
+        path: 'public/index.html',
+        content: `Root page`,
       })
-      .withContentFiles([
-        {
-          path: 'functions/function-1.js',
-          content: `
-const { one } = require('../../lib/util')
+      .buildAsync()
 
-module.exports.handler = async () => ({ statusCode: 200, body: one })
-`,
-        },
-        {
-          path: 'functions/function-2.js',
-          content: `
-const { one } = require('../../lib/util')
-
-module.exports.handler = async () => ({ statusCode: 200, body: one })
-`,
-        },
-      ])
-
-    await builder.buildAsync()
-
-    const expectedFiles = ['netlify.toml', 'functions/function-1.js', 'functions/function-2.js', 'lib/util.js']
-    const { files, filesShaMap } = await hashFiles(builder.directory, path.join(builder.directory, 'netlify.toml'), {
+    const expectedFiles = ['netlify.toml', 'public/index.html']
+    const { files, filesShaMap } = await hashFiles(builder.directory, `${builder.directory}/netlify.toml`, {
       filter: () => true,
       concurrentHash: DEFAULT_CONCURRENT_HASH,
       statusCb() {},
     })
 
-    expectedFiles.forEach((filePath) => {
-      t.truthy(files[filePath], `includes the ${filePath} file`)
-    })
+    t.is(Object.entries(files).length, expectedFiles.length)
+    t.is(Object.entries(filesShaMap).length, expectedFiles.length)
 
-    t.truthy(files['netlify.toml'], 'includes the netlify.toml file')
-    Object.keys(files).forEach((filePath) => {
-      t.truthy(filePath, 'each file has a path')
-    })
-    t.truthy(filesShaMap, 'filesShaMap is returned')
-    Object.values(filesShaMap).forEach((fileObjArray) => {
+    expectedFiles.forEach((filePath) => {
+      const sha = files[filePath]
+      t.truthy(sha, `includes the ${filePath} file`)
+
+      const fileObjArray = filesShaMap[sha]
       fileObjArray.forEach((fileObj) => {
-        t.truthy(fileObj.normalizedPath, 'fileObj have a normalizedPath field')
+        t.is(
+          fileObj.normalizedPath,
+          filePath,
+          'fileObj normalizedPath property should equal to file path from files array',
+        )
       })
     })
   })

--- a/src/utils/deploy/hash-fns.test.js
+++ b/src/utils/deploy/hash-fns.test.js
@@ -1,23 +1,49 @@
+/* eslint-disable require-await */
 const test = require('ava')
 const tempy = require('tempy')
+
+const { withSiteBuilder } = require('../../../tests/utils/site-builder')
 
 const { DEFAULT_CONCURRENT_HASH } = require('./constants')
 const { hashFns } = require('./hash-fns')
 
 test('Hashes files in a folder', async (t) => {
-  const { functions, fnShaMap } = await hashFns(__dirname, {
-    tmpDir: tempy.directory(),
-    concurrentHash: DEFAULT_CONCURRENT_HASH,
-    statusCb() {},
-  })
+  await withSiteBuilder('site-with-functions', async (builder) => {
+    await builder
+      .withNetlifyToml({ config: { functions: { directory: 'functions' } } })
+      .withFunction({
+        path: 'hello.js',
+        handler: async () => ({ statusCode: 200, body: 'Hello' }),
+      })
+      .withFunction({
+        path: 'goodbye.js',
+        handler: async () => ({ statusCode: 200, body: 'Goodbye' }),
+      })
+      .buildAsync()
 
-  Object.keys(functions).forEach((path) => {
-    t.truthy(path, 'each file has a path')
-  })
-  t.truthy(fnShaMap, 'fnShaMap is returned')
-  Object.values(fnShaMap).forEach((fileObjArray) => {
-    fileObjArray.forEach((fileObj) => {
-      t.truthy(fileObj.normalizedPath, 'fileObj have a normalizedPath field')
+    const expectedFunctions = ['hello', 'goodbye']
+    const { functions, fnShaMap } = await hashFns(`${builder.directory}/functions`, {
+      tmpDir: tempy.directory(),
+      concurrentHash: DEFAULT_CONCURRENT_HASH,
+      statusCb() {},
+    })
+
+    t.is(Object.entries(functions).length, expectedFunctions.length)
+    t.is(Object.entries(fnShaMap).length, expectedFunctions.length)
+
+    expectedFunctions.forEach((functionPath) => {
+      const sha = functions[functionPath]
+      t.truthy(sha, `includes the ${functionPath} file`)
+
+      const functionsObjArray = fnShaMap[sha]
+      functionsObjArray.forEach((fileObj) => {
+        t.is(
+          fileObj.normalizedPath,
+          functionPath,
+          'functionPath normalizedPath property should equal to function path from functions array',
+        )
+      })
     })
   })
 })
+/* eslint-enable require-await */


### PR DESCRIPTION
**- Summary**

Related to Related to https://github.com/netlify/cli/issues/2209

I'm doing some benchmarking on our tests and noticed the `hash-fns.test.js` takes about 20 seconds on my machine when executed as a single test (it's slower when running all tests in parallel).

On CI with limited compute this is even worse:
https://github.com/netlify/cli/runs/2672814438?check_suite_focus=true#step:8:289
![image](https://user-images.githubusercontent.com/26760571/119626902-58995800-be14-11eb-8ef4-51139770c5df.png)

I believe the reason is that it's using `__dirname` at the functions directory to hash which is not necessary. 

I changed it to use a dedicated site and also cleaned up both tests

**- Test plan**

Existing tests

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/119629048-5506d080-be16-11eb-95ff-8720e5fcbef2.png)