### PR TITLE
fix(telemetry): add the correct content-type header to the request

### DIFF
--- a/src/utils/telemetry/request.js
+++ b/src/utils/telemetry/request.js
@@ -17,6 +17,7 @@ const makeRequest = async function () {
     await fetch(API_URL, {
       method: 'POST',
       headers: {
+        'Content-Type': 'application/json',
         'X-Netlify-Client': CLIENT_ID,
       },
       body: JSON.stringify(options.data),

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -15,11 +15,7 @@ const startMockApi = ({ routes }) => {
   const requests = []
   const app = express()
   app.use(bodyParser.urlencoded({ extended: true }))
-  app.use(
-    bodyParser.json({
-      type: () => true,
-    }),
-  )
+  app.use(bodyParser.json())
   app.use(bodyParser.raw())
 
   routes.forEach(({ method = 'get', path, response = {}, status = 200, requestBody }) => {


### PR DESCRIPTION
**- Summary**

Sets the correct `content-type` header for the telemetry requests.

**- Test plan**

Automatted tests but I've also run it locally. The resulting lambda execution shows the header was set 👍 :
 ```bash
 1:10:17 PM: {"level":30,"time":1622203817056,"pid":9,"hostname":"169.254.11.189","httpMethod":"POST","path":"/track","headers":{"accept":"*/*","accept-encoding":"gzip","client-ip":"100.64.0.79","content-length":"150","content-type":"application/json","forwarded":"for=94.63.204.136;proto=https","host":"cli-telemetry.netlify.engineering","user-agent":"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)","via":"http/1.1 Netlify[87e6d7c6-478f-436c-8a38-93295836ce5d] (Netlify Edge Server), https/1.1 Netlify[33025fc6-25ae-4c95-818f-5f3496865ae1] (Netlify Edge Server)","x-bb-ab":"0.495002","x-bb-client-request-uuid":"33025fc6-25ae-4c95-818f-5f3496865ae1-21609337","x-bb-ip":"94.63.204.136, 94.63.204.136","x-bb-loop":"2","x-cdn-domain":"www.bitballoon.com","x-country":"PT, PT","x-datadog-parent-id":"2835856699474980615","x-datadog-trace-id":"11714716607053049179","x-forwarded-for":"94.63.204.136, 100.64.0.79, 54.242.44.193","x-forwarded-proto":"https","x-netlify-client":"NETLIFY_CLI","x-nf-cache-gen":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9Cg.eyJnZW4iOiI2MGFmYzc0YTc0Yjg4NjAwMDc4NTkyNDg6MTYyMjIwMjg1MDMzMSJ9Cg.uIXlwDIj1dMMsvz7EQZ4vD8guRWjE-GNUmBfxAA7vXE","x-nf-client-connection-ip":"54.242.44.193","x-nf-client-request-loop-chain":"ce48d35b-3d92-404f-ab5f-e8b8c103bb59","x-nf-connection-proto":"https","x-nf-request-id":"33025fc6-25ae-4c95-818f-5f3496865ae1-21609337"},"requestId":"5e66115a-9352-4119-8ace-88c8ef045971","msg":"Incoming Request"}
1:10:17 PM: {"level":30,"time":1622203817322,"pid":9,"hostname":"169.254.11.189","httpMethod":"POST","path":"/track","statusCode":200,"headers":{"content-type":"application/json"},"requestId":"5e66115a-9352-4119-8ace-88c8ef045971","msg":"Outgoing Response"}
```

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![cat](https://http.cat/422) 
