### PR TITLE
fix(telemetry): add cli user-agent to the request with the cli version included

### DIFF
--- a/src/utils/telemetry/request.js
+++ b/src/utils/telemetry/request.js
@@ -3,6 +3,8 @@ const process = require('process')
 
 const fetch = require('node-fetch')
 
+const { name, version } = require('../../../package.json')
+
 const options = JSON.parse(process.argv[2])
 
 const CLIENT_ID = 'NETLIFY_CLI'
@@ -19,6 +21,7 @@ const makeRequest = async function () {
       headers: {
         'Content-Type': 'application/json',
         'X-Netlify-Client': CLIENT_ID,
+        'User-Agent': `${name}/${version}`,
       },
       body: JSON.stringify(options.data),
     })

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -3,6 +3,8 @@ const process = require('process')
 const test = require('ava')
 const { version: uuidVersion } = require('uuid')
 
+const { name, version } = require('../package.json')
+
 const callCli = require('./utils/call-cli')
 const { withMockApi } = require('./utils/mock-api')
 
@@ -33,6 +35,7 @@ test.serial('should track --telemetry-enable', async (t) => {
     t.is(requests.length, 1)
     t.is(requests[0].method, 'POST')
     t.is(requests[0].path, '/api/v1/track')
+    t.is(requests[0].headers['user-agent'], `${name}/${version}`)
     t.is(requests[0].body.event, 'cli:user_telemetryEnabled')
     t.is(uuidVersion(requests[0].body.anonymousId), UUID_VERSION)
     t.deepEqual(requests[0].body.properties, {})

--- a/tests/utils/mock-api.js
+++ b/tests/utils/mock-api.js
@@ -8,6 +8,7 @@ const addRequest = (requests, request) => {
     path: request.path,
     body: request.body,
     method: request.method,
+    headers: request.headers,
   })
 }
 


### PR DESCRIPTION
**- Summary**

Follow up on #2458 and https://github.com/netlify/cli-telemetry-service/issues/26. Updates our `uger-agent` header to fwd the app and version performing the request.

**- Test plan**

Tested locally, the lambda execution was the following (notice the `user-agent` headers):
```bash
1:37:59 PM: {"level":30,"time":1622205479733,"pid":8,"hostname":"169.254.46.221","httpMethod":"POST","path":"/track","headers":{"accept":"*/*","accept-encoding":"gzip","client-ip":"100.64.0.248","content-length":"150","content-type":"application/json","forwarded":"for=94.63.204.136;proto=https","host":"cli-telemetry.netlify.engineering","user-agent":"netlify-cli/3.31.14","via":"http/1.1 Netlify[b80cee17-b260-40c2-91ea-78b3223a8dc1] (Netlify Edge Server), https/1.1 Netlify[78d93d82-1e81-4a7e-a461-98ef9e4708ef] (Netlify Edge Server)","x-bb-ab":"0.211573","x-bb-client-request-uuid":"78d93d82-1e81-4a7e-a461-98ef9e4708ef-21800538","x-bb-ip":"94.63.204.136, 94.63.204.136","x-bb-loop":"2","x-cdn-domain":"www.bitballoon.com","x-country":"PT, PT","x-datadog-parent-id":"6556308331574884708","x-datadog-trace-id":"14023207270474156938","x-forwarded-for":"94.63.204.136, 100.64.0.248, 18.209.67.1","x-forwarded-proto":"https","x-netlify-client":"NETLIFY_CLI","x-nf-client-connection-ip":"18.209.67.1","x-nf-client-request-loop-chain":"4425b82a-31da-423f-aac4-2d0d63a2bf66","x-nf-connection-proto":"https","x-nf-request-id":"78d93d82-1e81-4a7e-a461-98ef9e4708ef-21800538"},"requestId":"cf94cfec-ffe4-48c9-9c0b-99405f34cb62","msg":"Incoming Request"}
1:38:35 PM: {"level":30,"time":1622205515111,"pid":8,"hostname":"169.254.46.221","httpMethod":"POST","path":"/track","headers":{"accept":"*/*","accept-encoding":"gzip","client-ip":"100.64.0.81","content-length":"150","content-type":"application/json","forwarded":"for=94.63.204.136;proto=https","host":"cli-telemetry.netlify.engineering","user-agent":"netlify-cli/3.31.14","via":"http/1.1 Netlify[3bbc9ece-975f-4da1-8276-305d98f21c39] (Netlify Edge Server), https/1.1 Netlify[5667936b-0fdc-4cb4-b86e-87ff9994b9a3] (Netlify Edge Server)","x-bb-ab":"0.942683","x-bb-client-request-uuid":"5667936b-0fdc-4cb4-b86e-87ff9994b9a3-14550175","x-bb-ip":"94.63.204.136, 94.63.204.136","x-bb-loop":"2","x-cdn-domain":"www.bitballoon.com","x-country":"PT, PT","x-datadog-parent-id":"6285405860525130159","x-datadog-trace-id":"10190899749090843476","x-forwarded-for":"94.63.204.136, 100.64.0.81, 18.209.67.1","x-forwarded-proto":"https","x-netlify-client":"NETLIFY_CLI","x-nf-client-connection-ip":"18.209.67.1","x-nf-client-request-loop-chain":"2ade9748-54b6-4f60-a168-6aa92e8e674e","x-nf-connection-proto":"https","x-nf-request-id":"5667936b-0fdc-4cb4-b86e-87ff9994b9a3-14550175"},"requestId":"b780a405-6ab6-4130-8cb5-4a34ed3d8d78","msg":"Incoming Request"}
```

**- A picture of a cute animal (not mandatory but encouraged)**

![turtle](https://i.giphy.com/media/MngEsCTQcZRW8/giphy.webp)
