### PR TITLE
feat: add detector for SvelteKit

### DIFF
--- a/src/detectors/svelte-kit.js
+++ b/src/detectors/svelte-kit.js
@@ -1,0 +1,26 @@
+const { hasRequiredDeps, hasRequiredFiles, getYarnOrNPMCommand, scanScripts } = require('./utils/jsdetect')
+
+const FRAMEWORK_PORT = 3000
+
+module.exports = function detector() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(['package.json'])) return false
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(['@sveltejs/kit'])) return false
+
+  // Everything below now assumes that we are within SvelteKit
+  // For more details refer to https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ['dev'],
+    preferredCommand: 'svelte-kit dev',
+  })
+
+  return {
+    framework: 'svelte-kit',
+    command: getYarnOrNPMCommand(),
+    frameworkPort: FRAMEWORK_PORT,
+    possibleArgsArrs,
+    dist: 'static',
+  }
+}

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -7,7 +7,8 @@ module.exports = function detector() {
   if (!hasRequiredFiles(['package.json'])) return false
   // REQUIRED DEPS
   if (!hasRequiredDeps(['svelte'])) return false
-  // HAS DETECTOR, IT WILL BE PICKED UP BY SAPPER DETECTOR, avoid duplication https://github.com/netlify/cli/issues/347
+  // AVOID FALSE-POSITIVES (having their own detectors and to avoid duplication https://github.com/netlify/cli/issues/347)
+  if (hasRequiredDeps(['@sveltejs/kit'])) return false
   if (hasRequiredDeps(['sapper'])) return false
 
   /** everything below now assumes that we are within svelte */


### PR DESCRIPTION
**- Summary**

Neither the [`svelte`](https://github.com/netlify/cli/blob/main/src/detectors/svelte.js) nor [`sapper`](https://github.com/netlify/cli/blob/main/src/detectors/sapper.js) detector fit to SvelteKit as discussed here https://github.com/sveltejs/kit/issues/1568 and its PR. That's why I added a new detector.

Unfortunately a small but -- in my opinion -- reasonable workaround is needed to make Netlify Dev useful together with SvelteKit: enforcing a prod build beforehand. But it looks like e.g. the [angular](https://github.com/netlify/cli/blob/main/src/detectors/angular.js) detector is doing something similar (for similar reasons?!)

**- Test plan**

I've run and tested it locally. Both the detection itself and the enforcement of a SvelteKit production build is working fine.

**- A picture of a cute animal (not mandatory but encouraged)**
🐶 🐕