### PR TITLE
fix(performance): load envinfo on demand, disable ts-node

### DIFF
--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -1,7 +1,5 @@
 const process = require('process')
 
-const envinfo = require('envinfo')
-
 const getGlobalConfig = require('../utils/get-global-config')
 const header = require('../utils/header')
 const { track } = require('../utils/telemetry')
@@ -31,6 +29,10 @@ module.exports = async function initHooks(context) {
     console.log(`────────────────────┐
  Environment Info   │
 ────────────────────┘`)
+
+    // performance optimization - load envinfo on demand
+    // eslint-disable-next-line node/global-require
+    const envinfo = require('envinfo')
     const data = await envinfo.run({
       System: ['OS', 'CPU'],
       Binaries: ['Node', 'Yarn', 'npm'],

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,16 @@
+const process = require('process')
+
 const updateNotifier = require('update-notifier')
 
 const pkg = require('../package.json')
 
 // 12 hours
 const UPDATE_CHECK_INTERVAL = 432e5
+
+// performance optimization to disable built in oclif TypeScript support
+// see https://github.com/oclif/config/blob/1066a42a61a71b9a0708a2beff498d2cbbb9a3fd/src/ts-node.ts#L51
+// oclif registers ts-node which can be quite slow
+process.env.OCLIF_TS_NODE = '0'
 
 try {
   updateNotifier({


### PR DESCRIPTION
**- Summary**

This is a result of going over results generated from https://github.com/davidmarkclements/0x.

See example for the `status` command [here](https://netlify-cli-performance.netlify.app/status).

Related to https://github.com/netlify/cli/issues/2209

This lazy loads `envinfo` and disables `registerTSNode` (see huge chunk due to it in above link).

**- Test plan**

Before see 20 invocations of the `status` command (my local machine on a linked sites):
```
ntl status --silent  0.88s user 0.33s system 31% cpu 3.807 total
ntl status --silent  0.80s user 0.27s system 51% cpu 2.109 total
ntl status --silent  0.81s user 0.28s system 53% cpu 2.033 total
ntl status --silent  0.84s user 0.28s system 55% cpu 2.014 total
ntl status --silent  0.79s user 0.25s system 50% cpu 2.077 total
ntl status --silent  0.80s user 0.26s system 54% cpu 1.936 total
ntl status --silent  0.78s user 0.26s system 50% cpu 2.051 total
ntl status --silent  0.80s user 0.28s system 54% cpu 1.987 total
ntl status --silent  0.83s user 0.27s system 53% cpu 2.052 total
ntl status --silent  0.83s user 0.28s system 53% cpu 2.081 total
ntl status --silent  0.84s user 0.29s system 55% cpu 2.038 total
ntl status --silent  0.84s user 0.29s system 52% cpu 2.142 total
ntl status --silent  0.81s user 0.28s system 34% cpu 3.130 total
ntl status --silent  0.83s user 0.29s system 54% cpu 2.062 total
ntl status --silent  0.87s user 0.29s system 53% cpu 2.165 total
ntl status --silent  0.88s user 0.31s system 57% cpu 2.075 total
ntl status --silent  0.91s user 0.33s system 58% cpu 2.148 total
ntl status --silent  0.98s user 0.33s system 56% cpu 2.316 total
ntl status --silent  0.91s user 0.31s system 54% cpu 2.236 total
ntl status --silent  0.91s user 0.30s system 55% cpu 2.176 total
```

After:
```
ntl status --silent  0.53s user 0.23s system 34% cpu 2.205 total
ntl status --silent  0.56s user 0.23s system 47% cpu 1.670 total
ntl status --silent  0.54s user 0.22s system 41% cpu 1.825 total
ntl status --silent  0.55s user 0.22s system 47% cpu 1.625 total
ntl status --silent  0.57s user 0.24s system 46% cpu 1.722 total
ntl status --silent  0.54s user 0.23s system 44% cpu 1.722 total
ntl status --silent  0.55s user 0.22s system 46% cpu 1.644 total
ntl status --silent  0.55s user 0.22s system 44% cpu 1.725 total
ntl status --silent  0.54s user 0.22s system 43% cpu 1.759 total
ntl status --silent  0.54s user 0.21s system 40% cpu 1.850 total
ntl status --silent  0.54s user 0.22s system 44% cpu 1.710 total
ntl status --silent  0.54s user 0.21s system 45% cpu 1.660 total
ntl status --silent  0.55s user 0.22s system 43% cpu 1.790 total
ntl status --silent  0.52s user 0.21s system 36% cpu 2.009 total
ntl status --silent  0.54s user 0.21s system 46% cpu 1.601 total
ntl status --silent  0.55s user 0.22s system 47% cpu 1.627 total
ntl status --silent  0.52s user 0.21s system 45% cpu 1.604 total
ntl status --silent  0.53s user 0.22s system 44% cpu 1.697 total
ntl status --silent  0.52s user 0.21s system 47% cpu 1.562 total
ntl status --silent  0.52s user 0.22s system 44% cpu 1.690 total
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐩 