### PR TITLE
feat: Adds RedwoodJS Detector for netlify dev

### DIFF
--- a/src/detectors/redwoodjs.js
+++ b/src/detectors/redwoodjs.js
@@ -12,9 +12,11 @@ module.exports = function detector() {
 
   return {
     framework: 'redwoodjs',
-    command: 'yarn rw',
+    // yarn is a requirement for RedwoodJS:
+    // https://learn.redwoodjs.com/docs/tutorial/installation-starting-development
+    command: 'yarn',
     frameworkPort: FRAMEWORK_PORT,
-    possibleArgsArrs: ['dev'],
+    possibleArgsArrs: [['rw', 'dev']],
     dist: 'web/dist',
     disableLocalServerPolling: true,
   }

--- a/src/detectors/redwoodjs.js
+++ b/src/detectors/redwoodjs.js
@@ -1,0 +1,21 @@
+const { hasRequiredDeps, hasRequiredFiles } = require('./utils/jsdetect')
+
+const FRAMEWORK_PORT = 8910
+
+module.exports = function detector() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(['redwood.toml'])) return false
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(['@redwoodjs/core'])) return false
+
+  /** everything below now assumes that we are within redwoodjs */
+
+  return {
+    framework: 'redwoodjs',
+    command: 'yarn rw',
+    frameworkPort: FRAMEWORK_PORT,
+    possibleArgsArrs: ['dev'],
+    dist: 'web/dist',
+    disableLocalServerPolling: true,
+  }
+}


### PR DESCRIPTION
As part of adding framework detection for RedwoodJS with:

https://github.com/netlify/framework-info/blob/main/src/frameworks/redwoodjs.json

We also need to add a detector so that `netlify dev` will detect a redwoodjs-based site/app.

This PR endeavors to add this configuration such that netlify dev can be used with a `netlify.toml` file in a RedwoodJS app like:

```toml
[dev]
  # Note be sure to `netlify link` your site first
  command = "yarn rw dev"
  framework = "redwoodjs"
  targetPort = 8910 # The port for your application server, framework or site generator
  port = 8888 # The port that the netlify dev will be accessible on
```

Notes:

* we do use `yarn rw dev` as the command and `yarn rw` is set in this detector. We do know this might spawn an extra yarn, but so much of our docs use `yarn rw` and Redwood uses `yarn workspaces` so the familiarity is a benefit.
* we will still want to be able to overrive `targetPort = 8910` because people have the option to set that port in their `redwood.toml` config


