### PR TITLE
fix(command-dev): improve initialization time

### DIFF
--- a/src/utils/detect-server.js
+++ b/src/utils/detect-server.js
@@ -5,8 +5,6 @@ const process = require('process')
 const chalk = require('chalk')
 const fuzzy = require('fuzzy')
 const getPort = require('get-port')
-const inquirer = require('inquirer')
-const inquirerAutocompletePrompt = require('inquirer-autocomplete-prompt')
 const isPlainObject = require('is-plain-obj')
 
 const { readFileAsyncCatchError } = require('../lib/fs')
@@ -78,6 +76,12 @@ const serverSettings = async (devConfig, flags, projectDir, log) => {
       settings = firstSettings
       settings.args = chooseDefaultArgs(settings.possibleArgsArrs)
     } else if (settingsArr.length > 1) {
+      // performance optimization, load inquirer on demand
+      // eslint-disable-next-line node/global-require
+      const inquirer = require('inquirer')
+      // eslint-disable-next-line node/global-require
+      const inquirerAutocompletePrompt = require('inquirer-autocomplete-prompt')
+
       /** multiple matching detectors, make the user choose */
       inquirer.registerPrompt('autocomplete', inquirerAutocompletePrompt)
       const scriptInquirerOptions = formatSettingsArrForInquirer(settingsArr)

--- a/src/utils/get-functions.js
+++ b/src/utils/get-functions.js
@@ -1,5 +1,3 @@
-const { listFunctions } = require('@netlify/zip-it-and-ship-it')
-
 const { fileExistsAsync } = require('../lib/fs')
 
 const getUrlPath = (functionName) => `/.netlify/functions/${functionName}`
@@ -19,6 +17,9 @@ const getFunctions = async (functionsSrcDir) => {
     return []
   }
 
+  // performance optimization, load '@netlify/zip-it-and-ship-it' on demand
+  // eslint-disable-next-line node/global-require
+  const { listFunctions } = require('@netlify/zip-it-and-ship-it')
   const functions = await listFunctions(functionsSrcDir)
   const functionsWithProps = functions.filter(({ runtime }) => runtime === JS).map((func) => addFunctionProps(func))
   return functionsWithProps
@@ -28,6 +29,10 @@ const getFunctionsAndWatchDirs = async (functionsSrcDir) => {
   if (!(await fileExistsAsync(functionsSrcDir))) {
     return { functions: [], watchDirs: [functionsSrcDir] }
   }
+
+  // performance optimization, load '@netlify/zip-it-and-ship-it' on demand
+  // eslint-disable-next-line node/global-require
+  const { listFunctions } = require('@netlify/zip-it-and-ship-it')
 
   // get all functions files so we know which directories to watch
   const functions = await listFunctions(functionsSrcDir)

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -9,8 +9,6 @@ const bodyParser = require('body-parser')
 const chalk = require('chalk')
 const chokidar = require('chokidar')
 const { parse: parseContentType } = require('content-type')
-const express = require('express')
-const expressLogging = require('express-logging')
 const jwtDecode = require('jwt-decode')
 const lambdaLocal = require('lambda-local')
 const debounce = require('lodash/debounce')
@@ -440,6 +438,11 @@ const createFormSubmissionHandler = function ({ siteUrl, warn }) {
 }
 
 const getFunctionsServer = async function ({ getFunctionByName, siteUrl, warn, timeouts, prefix }) {
+  // performance optimization, load express on demand
+  // eslint-disable-next-line node/global-require
+  const express = require('express')
+  // eslint-disable-next-line node/global-require
+  const expressLogging = require('express-logging')
   const app = express()
   app.set('query parser', 'simple')
 


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/2209.

Improves the `netlify dev` command initialization time, from when the user runs `netlify dev` until the first log line is printed here:
https://github.com/netlify/cli/blob/1590158bc72f18daa9e908a2409e5a9e48ee9393/src/commands/dev/index.js#L201

For projects that don't have a functions directory the execution time is also improved as we don't require related dependencies.

Based on running an analysis with https://github.com/davidmarkclements/0x

**- Test plan**

Before

```
BROWSER=none ntl dev --silent  3.03s user 0.55s system 158% cpu 2.261 total
BROWSER=none ntl dev --silent  2.74s user 0.49s system 158% cpu 2.037 total
BROWSER=none ntl dev --silent  2.77s user 0.50s system 161% cpu 2.030 total
BROWSER=none ntl dev --silent  2.78s user 0.50s system 154% cpu 2.124 total
BROWSER=none ntl dev --silent  2.77s user 0.49s system 161% cpu 2.019 total
BROWSER=none ntl dev --silent  2.77s user 0.49s system 156% cpu 2.080 total
BROWSER=none ntl dev --silent  2.77s user 0.49s system 159% cpu 2.046 total
BROWSER=none ntl dev --silent  2.77s user 0.49s system 136% cpu 2.389 total
BROWSER=none ntl dev --silent  2.78s user 0.50s system 157% cpu 2.082 total
BROWSER=none ntl dev --silent  2.84s user 0.50s system 157% cpu 2.119 total
```

After:
```
BROWSER=none ntl dev --silent  1.76s user 0.31s system 167% cpu 1.235 total
BROWSER=none ntl dev --silent  1.79s user 0.30s system 169% cpu 1.235 total
BROWSER=none ntl dev --silent  1.85s user 0.30s system 166% cpu 1.292 total
BROWSER=none ntl dev --silent  1.83s user 0.29s system 168% cpu 1.258 total
BROWSER=none ntl dev --silent  1.84s user 0.29s system 170% cpu 1.249 total
BROWSER=none ntl dev --silent  1.83s user 0.29s system 164% cpu 1.285 total
BROWSER=none ntl dev --silent  1.83s user 0.29s system 176% cpu 1.199 total
BROWSER=none ntl dev --silent  1.82s user 0.28s system 149% cpu 1.401 total
BROWSER=none ntl dev --silent  1.83s user 0.29s system 167% cpu 1.268 total
BROWSER=none ntl dev --silent  1.90s user 0.30s system 175% cpu 1.249 total
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐈 