### PR TITLE
feat: use ZISI v2 handler

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -274,6 +274,7 @@ const runDeploy = async ({
       deployId,
       filter: getDeployFilesFilter({ site, deployFolder }),
       warn,
+      rootDir: site.root,
     })
   } catch (error_) {
     if (deployId) {

--- a/src/function-builder-detectors/zisi.js
+++ b/src/function-builder-detectors/zisi.js
@@ -116,6 +116,7 @@ const bundleFunctions = async ({
   config,
   eventType,
   fileTree,
+  projectRoot,
   sourceDirectory,
   targetDirectory,
   updatedPath,
@@ -123,6 +124,7 @@ const bundleFunctions = async ({
 }) => {
   const zipOptions = {
     archiveFormat: 'none',
+    basePath: projectRoot,
     config,
   }
 
@@ -240,6 +242,7 @@ const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot }) =>
       ...result,
       [pattern]: {
         externalNodeModules: config.external_node_modules,
+        experimentalHandlerV2: true,
         includedFiles: config.included_files,
         includedFilesBasePath: projectRoot,
         ignoredNodeModules: config.ignored_node_modules,
@@ -290,6 +293,7 @@ module.exports = async function handler({ config, errorExit, functionsDirectory:
         config: functionsConfig,
         eventType,
         fileTree,
+        projectRoot,
         sourceDirectory,
         targetDirectory,
         updatedPath,

--- a/src/utils/deploy/deploy-site.js
+++ b/src/utils/deploy/deploy-site.js
@@ -41,6 +41,7 @@ const deploySite = async (
     syncFileLimit = DEFAULT_SYNC_LIMIT,
     tmpDir = tempy.directory(),
     warn,
+    rootDir,
   } = {},
 ) => {
   statusCb({
@@ -51,7 +52,7 @@ const deploySite = async (
 
   const [{ files, filesShaMap }, { functions, functionsWithNativeModules, fnShaMap }] = await Promise.all([
     hashFiles(dir, configPath, { concurrentHash, hashAlgorithm, assetType, statusCb, filter }),
-    hashFns(fnDir, { functionsConfig, tmpDir, concurrentHash, hashAlgorithm, statusCb, assetType }),
+    hashFns(fnDir, { functionsConfig, tmpDir, concurrentHash, hashAlgorithm, statusCb, assetType, rootDir }),
   ])
 
   const filesCount = Object.keys(files).length

--- a/src/utils/deploy/hash-fns.js
+++ b/src/utils/deploy/hash-fns.js
@@ -9,13 +9,13 @@ const { hasherCtor, manifestCollectorCtor } = require('./hasher-segments')
 
 const hashFns = async (
   dir,
-  { tmpDir, concurrentHash, functionsConfig, hashAlgorithm = 'sha256', assetType = 'function', statusCb },
+  { tmpDir, concurrentHash, functionsConfig, hashAlgorithm = 'sha256', assetType = 'function', statusCb, rootDir },
 ) => {
   // early out if the functions dir is omitted
   if (!dir) return { functions: {}, functionsWithNativeModules: [], shaMap: {} }
   if (!tmpDir) throw new Error('Missing tmpDir directory for zipping files')
 
-  const functionZips = await zipIt.zipFunctions(dir, tmpDir, { config: functionsConfig })
+  const functionZips = await zipIt.zipFunctions(dir, tmpDir, { basePath: rootDir, config: functionsConfig })
   const fileObjs = functionZips.map(({ path: functionPath, runtime }) => ({
     filepath: functionPath,
     root: tmpDir,


### PR DESCRIPTION
**- Summary**

Passes the `basePath` and `experimentalHandlerV2` parameters to `zip-it-and-ship-it`, as introduced by https://github.com/netlify/zip-it-and-ship-it/pull/474.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🦒 