### PR TITLE
feat: add warning for missing aws-sdk dependency

### DIFF
--- a/src/lib/functions/server.js
+++ b/src/lib/functions/server.js
@@ -38,7 +38,7 @@ const buildClientContext = function (headers) {
   }
 }
 
-const createHandler = function ({ getFunctionByName, timeouts }) {
+const createHandler = function ({ getFunctionByName, timeouts, warn }) {
   const logger = winston.createLogger({
     levels: winston.config.npm.levels,
     transports: [new winston.transports.Console({ level: 'warn' })],
@@ -106,6 +106,7 @@ const createHandler = function ({ getFunctionByName, timeouts }) {
         clientContext,
         response,
         functionName,
+        warn,
       })
     }
 
@@ -115,6 +116,7 @@ const createHandler = function ({ getFunctionByName, timeouts }) {
       timeout: timeouts.syncFunctions,
       clientContext,
       response,
+      warn,
     })
   }
 }
@@ -146,7 +148,7 @@ const getFunctionsServer = async function ({ getFunctionByName, siteUrl, warn, t
     res.status(204).end()
   })
 
-  app.all(`${prefix}*`, await createHandler({ getFunctionByName, timeouts }))
+  app.all(`${prefix}*`, await createHandler({ getFunctionByName, timeouts, warn }))
 
   return app
 }

--- a/src/lib/functions/utils.js
+++ b/src/lib/functions/utils.js
@@ -11,6 +11,14 @@ const DEFAULT_LAMBDA_OPTIONS = {
 
 const SECONDS_TO_MILLISECONDS = 1000
 
+const detectAwsSdkError = ({ error, warn }) => {
+  const isAwsSdkError = error.errorMessage && error.errorMessage.includes("Cannot find module 'aws-sdk'")
+
+  if (isAwsSdkError) {
+    warn(getLogMessage('functions.missingAwsSdk'))
+  }
+}
+
 const formatLambdaError = (err) => chalk.red(`${err.errorType}: ${err.errorMessage}`)
 
 const logAfterAction = ({ path, action }) => {
@@ -34,6 +42,7 @@ const validateFunctions = function ({ functions, capabilities, warn }) {
 }
 
 module.exports = {
+  detectAwsSdkError,
   DEFAULT_LAMBDA_OPTIONS,
   formatLambdaError,
   logAfterAction,

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -9,10 +9,17 @@ To be able to deploy this function successfully either:
   - change the function name to remove \`${RED_BACKGROUND}\` and execute it synchronously
   - upgrade your team plan to a level that supports Background Functions (${PRO}, ${BUSINESS}, or ${ENTERPRISE})
 `
+const MISSING_AWS_SDK_WARNING = `A function has thrown an error due to a missing dependency: ${chalk.yellow('aws-sdk')}.
+You should add this module to the project's dependencies, using your package manager of choice:
+
+${chalk.yellow('npm install aws-sdk --save')} or ${chalk.yellow('yarn add aws-sdk')}
+
+For more information, see https://ntl.fyi/cli-aws-sdk.`
 
 const messages = {
   functions: {
     backgroundNotSupported: BACKGROUND_FUNCTIONS_WARNING,
+    missingAwsSdk: MISSING_AWS_SDK_WARNING,
   },
 }
 


### PR DESCRIPTION
**- Summary**

Adds a warning message whenever a runtime error occurs due to `aws-sdk` being missing. This must accompany https://github.com/netlify/cli/pull/2713, since `lambda-local@2.0.0` no longer includes `aws-sdk` as a dependency.

**- Test plan**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐦 