### PR TITLE
test(command-dev): pass offline flag by default

### DIFF
--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1710,11 +1710,11 @@ export const handler = async function () {
           await withDevServer(
             {
               cwd: builder.directory,
-              // we need to pass a token so the CLI tries to retrieve site information from the mock API
-              args: [...args, '--auth', 'fake-token'],
+              offline: false,
               env: {
                 NETLIFY_API_URL: apiUrl,
                 NETLIFY_SITE_ID: 'site_id',
+                NETLIFY_AUTH_TOKEN: 'fake-token',
               },
             },
             async ({ url }) => {

--- a/tests/utils/dev-server.js
+++ b/tests/utils/dev-server.js
@@ -22,23 +22,22 @@ const FRAMEWORK_PORT_SHIFT = 1e3
 
 let currentPort = getRandomPortStart()
 
-const startServer = async ({ cwd, env = {}, args = [] }) => {
+const startServer = async ({ cwd, offline = true, env = {}, args = [] }) => {
   const tryPort = currentPort
   currentPort += 1
   const port = await getPort({ port: tryPort })
   const host = 'localhost'
   const url = `http://${host}:${port}`
   console.log(`Starting dev server on port: ${port} in directory ${path.basename(cwd)}`)
-  // In CI we set a NETLIFY_AUTH_TOKEN which means the CLI will hit the live API in some cases
-  // as we don't need it for dev tests we can omit it
-  // eslint-disable-next-line no-unused-vars
-  const { NETLIFY_AUTH_TOKEN, ...processEnv } = process.env
-  const ps = execa(cliPath, ['dev', '-p', port, '--staticServerPort', port + FRAMEWORK_PORT_SHIFT, ...args], {
-    cwd,
-    extendEnv: false,
-    env: { ...processEnv, BROWSER: 'none', ...env },
-    encoding: 'utf8',
-  })
+  const ps = execa(
+    cliPath,
+    ['dev', offline ? '--offline' : '', '-p', port, '--staticServerPort', port + FRAMEWORK_PORT_SHIFT, ...args],
+    {
+      cwd,
+      env: { BROWSER: 'none', ...env },
+      encoding: 'utf8',
+    },
+  )
   let output = ''
   const serverPromise = new Promise((resolve, reject) => {
     let selfKilled = false


### PR DESCRIPTION
Part of https://github.com/netlify/cli/pull/1704/

This passes the `--offline` flag for `ntl dev` in our tests instead of removing the `NETLIFY_AUTH_TOKEN` env variable.
Both are valid ways to prevent `ntl dev` sending API requests, `--offline` is more clear.

There is only a single tests that needs to hit the API so I updated it accordingly.