### PR TITLE
feat(command-dev): add framework flag

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -21,6 +21,7 @@ netlify dev
 - `command` (*string*) - command to run
 - `port` (*string*) - port of netlify dev
 - `targetPort` (*string*) - port of target app server
+- `framework` (*string*) - framework to use. Defaults to #auto which automatically detects a framework
 - `dir` (*string*) - dir with static files
 - `functions` (*string*) - specify a functions folder to serve
 - `offline` (*boolean*) - disables any features that require network access

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -288,6 +288,9 @@ DevCommand.flags = {
   targetPort: flagsLib.integer({
     description: 'port of target app server',
   }),
+  framework: flagsLib.string({
+    description: 'framework to use. Defaults to #auto which automatically detects a framework',
+  }),
   staticServerPort: flagsLib.integer({
     description: 'port of the static app server used when no framework is detected',
     hidden: true,


### PR DESCRIPTION
Part of #1704

This PR adds a `--framework` flag to the `ntl dev` command.

This allows running `ntl dev --command "echo hello" --targetPort 3000 --framework "#custom"` to configure a custom framework.

Before this change `framework` had to be configured in the `netlify.toml` `dev` block.