### PR TITLE
fix(docs): clarify live site creation from tests closes #2541

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           # GitHub secrets are not available when running on PR from forks
           # We set a flag so we can skip tests that access Netlify API
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+          NETLIFY_TEST_DISABLE_LIVE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           # NETLIFY_TEST_GITHUB_TOKEN is used to avoid reaching GitHub API limits in exec-fetcher.js
           NETLIFY_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,8 @@ jobs:
         env:
           # GitHub secrets are not available when running on PR from forks
           # We set a flag so we can skip tests that access Netlify API
-          NETLIFY_TEST_DISABLE_LIVE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+          NETLIFY_TEST_DISABLE_LIVE:
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           # NETLIFY_TEST_GITHUB_TOKEN is used to avoid reaching GitHub API limits in exec-fetcher.js
           NETLIFY_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,15 @@ Tests are run with:
 npm test
 ```
 
-**NOTE:** we run some integration tests against an active Netlify account. For these tests to pass you'll need to
-provide a Netlify auth token (using the `NETLIFY_AUTH_TOKEN` environment variable) or login via `./bin/run login` before
-running the tests.
+**NOTE:**
+
+Running some integration tests will require an active Netlify account to create a live site.
+
+You can either provide a [Netlify Auth Token](https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui) (through the `NETLIFY_AUTH_TOKEN` environment variable) or login via `./bin/run login` before running the tests.
+
+Running these tests won't result in any charges towards your Netlify account because they build a site locally and then deploy it.
+
+> We don't recommend doing this, but you can disable these tests by setting the `NETLIFY_TEST_DISABLE_LIVE` environment variable to `true`.
 
 In watch mode:
 
@@ -74,7 +80,7 @@ This repo uses [ava](https://github.com/avajs/ava) for testing. Any files in the
 
 We also test for a few other things:
 
-- Dependencies (used an unused)
+- Dependencies (used and unused)
 - Linting
 - Test coverage
 - Must work with Windows + Unix environments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ To run the CLI locally:
 The CLI is written using the [oclif](https://oclif.io/) cli framework and the [netlify/js-client](https://github.com/netlify/js-client) open-api derived API client.
 
 - Commands live in the [`src/commands`](src/commands) folder.
-- The base command class which provides consistent config loading and an API client lives in [`src/base`](src/base).
+- The base command class which provides consistent config loading and an API client lives in [`src/utils/command.js`](src/utils/command.js).
 - Small utilities and other functionality live in [`src/utils`](src/utils).
 
 A good place to start is reading the base command README and looking at the commands folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,13 @@ npm test
 
 **NOTE:**
 
-Running some integration tests will require an active Netlify account to create a live site.
+Running some integration tests requires an active Netlify account to create a live site.
 
 You can either provide a [Netlify Auth Token](https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui) (through the `NETLIFY_AUTH_TOKEN` environment variable) or login via `./bin/run login` before running the tests.
 
-Running these tests won't result in any charges towards your Netlify account because they build a site locally and then deploy it.
+The tests those count towards Netlify build minutes since they build a site locally and deploy it using the API.
 
-> We don't recommend doing this, but you can disable these tests by setting the `NETLIFY_TEST_DISABLE_LIVE` environment variable to `true`.
+> You can disable these tests by setting the `NETLIFY_TEST_DISABLE_LIVE` environment variable to `true`.
 
 In watch mode:
 

--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -39,7 +39,7 @@ const validateDeploy = async ({ deploy, siteName, content, t }) => {
   await validateContent({ siteUrl: deploy.deploy_url, path: '', content, t })
 }
 
-if (process.env.IS_FORK !== 'true') {
+if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
   test.before(async (t) => {
     const { siteId, account } = await createLiveTestSite(SITE_NAME)
     t.context.siteId = siteId


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

resolves https://github.com/netlify/cli/issues/2541

This PR clarifies that the deploy test suite use a live site to run integration tests which require an active Netlify account. 

To make things simpler to configure, the `IS_FORK` environment variable (which disables these tests) has been renamed to `NETLIFY_TEST_DISABLE_LIVE`. 

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava -v -s` for https://github.com/netlify/cli/commit/a134b72409550aec4676a992d47dcca668322eb9 on Node.js 10
