### PR TITLE
chore: remove `safe-join` dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -106,7 +106,6 @@
         "pump": "^3.0.0",
         "raw-body": "^2.4.1",
         "resolve": "^1.12.0",
-        "safe-join": "^0.1.3",
         "semver": "^7.3.4",
         "source-map-support": "^0.5.19",
         "static-server": "^2.2.1",
@@ -18284,11 +18283,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/safe-join": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/safe-join/-/safe-join-0.1.3.tgz",
-      "integrity": "sha512-Ylh1EWn4pmL57HRV/oi4Ye7ws5AxKkdGpyDdWsvZob5VLH8xnQpG8tqmHD5v4SdKlN7hyrBjYt7Jm3faeC+uJg=="
-    },
     "node_modules/safe-json-stringify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
@@ -34845,11 +34839,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safe-join": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/safe-join/-/safe-join-0.1.3.tgz",
-      "integrity": "sha512-Ylh1EWn4pmL57HRV/oi4Ye7ws5AxKkdGpyDdWsvZob5VLH8xnQpG8tqmHD5v4SdKlN7hyrBjYt7Jm3faeC+uJg=="
     },
     "safe-json-stringify": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "pump": "^3.0.0",
     "raw-body": "^2.4.1",
     "resolve": "^1.12.0",
-    "safe-join": "^0.1.3",
     "semver": "^7.3.4",
     "source-map-support": "^0.5.19",
     "static-server": "^2.2.1",

--- a/src/utils/read-repo-url.js
+++ b/src/utils/read-repo-url.js
@@ -1,7 +1,6 @@
 const url = require('url')
 
 const fetch = require('node-fetch')
-const { safeJoin } = require('safe-join')
 
 // supported repo host types
 const GITHUB = Symbol('GITHUB')
@@ -27,7 +26,7 @@ const getRepoURLContents = async function (repoHost, ownerAndRepo, contentsPath)
   // naive joining strategy for now
   if (repoHost === GITHUB) {
     // https://developer.github.com/v3/repos/contents/#get-contents
-    const APIURL = safeJoin('https://api.github.com/repos', ownerAndRepo, 'contents', contentsPath)
+    const APIURL = `https://api.github.com/repos/${ownerAndRepo}/contents/${contentsPath}`
     try {
       const res = await fetch(APIURL)
       return await res.json()
@@ -51,7 +50,7 @@ const parseRepoURL = function (repoHost, URL) {
   if (repoHost === GITHUB) {
     // https://developer.github.com/v3/repos/contents/#get-contents
     // what if it's not master? note that our contents retrieval may assume it is master
-    const [ownerAndRepo, contentsPath] = URL.path.split('/tree/master')
+    const [ownerAndRepo, contentsPath] = URL.path.slice(1).split('/tree/master/')
     return [ownerAndRepo, contentsPath]
   }
   throw new Error('unsupported host ', repoHost)

--- a/src/utils/read-repo-url.js
+++ b/src/utils/read-repo-url.js
@@ -3,9 +3,7 @@ const url = require('url')
 const fetch = require('node-fetch')
 
 // supported repo host types
-const GITHUB = Symbol('GITHUB')
-// const BITBUCKET = Symbol('BITBUCKET')
-// const GITLAB = Symbol('GITLAB')
+const GITHUB = 'GitHub'
 
 /**
  * Takes a url like https://github.com/netlify-labs/all-the-functions/tree/master/functions/9-using-middleware
@@ -53,10 +51,11 @@ const parseRepoURL = function (repoHost, URL) {
     const [ownerAndRepo, contentsPath] = URL.path.slice(1).split('/tree/master/')
     return [ownerAndRepo, contentsPath]
   }
-  throw new Error('unsupported host ', repoHost)
+  throw new Error(`Unsupported host ${repoHost}`)
 }
 
 module.exports = {
+  parseRepoURL,
   readRepoURL,
   validateRepoURL,
 }

--- a/src/utils/read-repo-url.test.js
+++ b/src/utils/read-repo-url.test.js
@@ -1,0 +1,17 @@
+const test = require('ava')
+
+const { parseRepoURL } = require('./read-repo-url')
+
+test('parseRepoURL: should parse GitHub URL', (t) => {
+  const url = new URL('https://github.com/netlify-labs/all-the-functions/tree/master/functions/9-using-middleware')
+  // parseRepoURL expects the result of url.parse
+  const [repo, contentPath] = parseRepoURL('GitHub', { path: url.pathname })
+
+  t.is(repo, 'netlify-labs/all-the-functions')
+  t.is(contentPath, 'functions/9-using-middleware')
+})
+
+test('parseRepoURL: should fail on GitLab URL', (t) => {
+  const url = new URL('https://gitlab.com/netlify-labs/all-the-functions/-/blob/master/functions/9-using-middleware')
+  t.throws(() => parseRepoURL('GitLab', { path: url.pathname }), { message: 'Unsupported host GitLab' })
+})


### PR DESCRIPTION
Closes #2896 

**- Summary**
 - Removes the unlicensed `safe-join` dependency
 - Instead, we remove the leading and trailing slashes from the path

**- Test plan**
:eyes: 

**- A picture of a cute animal (not mandatory but encouraged)**
:eyes: :eyes: 
