### PR TITLE
fix(command-dev): pass full lambda-local result functions server

### DIFF
--- a/src/lib/functions/runtimes/js/index.js
+++ b/src/lib/functions/runtimes/js/index.js
@@ -54,7 +54,7 @@ const invokeFunction = async ({ context, event, func, timeout }) => {
   // If a function builder has defined a `buildPath` property, we use it.
   // Otherwise, we'll invoke the function's main file.
   const lambdaPath = (func.buildData && func.buildData.buildPath) || func.mainFile
-  const { body, statusCode } = await lambdaLocal.execute({
+  const result = await lambdaLocal.execute({
     clientContext: context,
     event,
     lambdaPath,
@@ -62,7 +62,7 @@ const invokeFunction = async ({ context, event, func, timeout }) => {
     verboseLevel: 3,
   })
 
-  return { body, statusCode }
+  return result
 }
 
 const onDirectoryScan = async () => {

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1780,5 +1780,28 @@ export const handler = async function () {
       })
     })
   })
+
+  test(testName(`returns headers set by function`, args), async (t) => {
+    await withSiteBuilder('site-with-function-with-custom-headers', async (builder) => {
+      await builder
+        .withFunction({
+          pathPrefix: 'netlify/functions',
+          path: 'custom-headers.js',
+          handler: async () => ({
+            statusCode: 200,
+            body: '',
+            headers: { 'single-value-header': 'custom-value' },
+            multiValueHeaders: { 'multi-value-header': ['custom-value1', 'custom-value2'] },
+          }),
+        })
+        .buildAsync()
+
+      await withDevServer({ cwd: builder.directory, args }, async (server) => {
+        const response = await got(`${server.url}/.netlify/functions/custom-headers`)
+        t.is(response.headers['single-value-header'], 'custom-value')
+        t.is(response.headers['multi-value-header'], 'custom-value1, custom-value2')
+      })
+    })
+  })
 })
 /* eslint-enable require-await */


### PR DESCRIPTION
**- Summary**

Follow up on https://github.com/netlify/cli/pull/2826
Fixes an issue where functions headers from `lambda-local` are not passed down to the functions server.
Found it while reviewing https://github.com/netlify/cli/pull/2852

**- Test plan**

Added a test case for it

**- A picture of a cute animal (not mandatory but encouraged)**
🐪 