### PR TITLE
refactor: enable and fix fp/no-proxy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
     'fp/no-mutating-assign': 0,
     'fp/no-mutating-methods': 0,
     'fp/no-mutation': 0,
-    'fp/no-proxy': 0,
     'fp/no-this': 0,
     'import/max-dependencies': 0,
     'node/no-sync': 0,

--- a/src/utils/chalk.js
+++ b/src/utils/chalk.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk')
-const { Chalk } = require('chalk')
 
 /**
  * Chalk instance for CLI
@@ -8,7 +7,7 @@ const { Chalk } = require('chalk')
  */
 const safeChalk = function (noColors) {
   if (noColors) {
-    const colorlessChalk = new Chalk({ level: 0 })
+    const colorlessChalk = new chalk.Instance({ level: 0 })
     return colorlessChalk
   }
   return chalk

--- a/src/utils/chalk.js
+++ b/src/utils/chalk.js
@@ -1,50 +1,17 @@
 const chalk = require('chalk')
+const { Chalk } = require('chalk')
 
 /**
  * Chalk instance for CLI
  * @param  {boolean} noColors - disable chalk colors
- * @return {object} - chalk instance or proxy noOp
+ * @return {object} - default or custom chalk instance
  */
 const safeChalk = function (noColors) {
-  /* if no colors return proxy to chalk API */
   if (noColors) {
-    return neverNull(chalk)
+    const colorlessChalk = new Chalk({ level: 0 })
+    return colorlessChalk
   }
   return chalk
-}
-
-const noop = function () {}
-
-const neverNull = function (obj) {
-  const match = function (some, none = noop) {
-    return obj == null ? none() : some(obj)
-  }
-  return new Proxy(
-    (some, none) => {
-      if (some) {
-        // has value return it with no chalk wrapper
-        return some
-      }
-      if (!some && !none) return obj
-      return match(some, none)
-    },
-    {
-      get: (target, key) => {
-        const targetObj = target()
-        if (targetObj !== null && typeof targetObj === 'object') {
-          return neverNull(targetObj[key])
-        }
-        return neverNull()
-      },
-      set: (target, key, val) => {
-        const targetObj = target()
-        if (targetObj !== null && typeof targetObj === 'object') {
-          targetObj[key] = val
-        }
-        return true
-      },
-    },
-  )
 }
 
 module.exports = safeChalk


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
See #1891 

Enables the fp/no-proxy  for `eslint-plugin-fp`.

There was only a single instance of Proxy being used to disable colors for the [chalk](https://www.npmjs.com/package/chalk) package. The package now has a `level` option that can be used to disable the coloring as documented here: https://github.com/chalk/chalk#chalklevel.

The file: `src/utils/command.js` was using this custom chalk instance.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava -v -s` ran without errors. I tried out the `sites:list` command normally and with the `--json` flag. As expected `--json` produced discolored output.


