### PR TITLE
refactor: enable and fix unicorn/prefer-spread

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     'fp/no-this': 0,
     'import/max-dependencies': 0,
     'node/no-sync': 0,
-    'unicorn/prefer-spread': 0,
     'unicorn/consistent-destructuring': 0,
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase' }],

--- a/src/commands/dev/trace.js
+++ b/src/commands/dev/trace.js
@@ -12,7 +12,7 @@ class TraceCommand extends Command {
   async run() {
     this.parse(TraceCommand)
 
-    const args = ['trace'].concat(this.argv)
+    const args = ['trace', ...this.argv]
     const { subprocess } = runProcess({ log: this.log, args })
     await subprocess
   }

--- a/src/utils/addons/compare.js
+++ b/src/utils/addons/compare.js
@@ -12,14 +12,14 @@ module.exports = function compare(oldValues, newValues) {
 
   const oldKeys = Object.keys(oldValues)
   const newKeys = Object.keys(newValues)
-  const set = new Set(newKeys.concat(oldKeys))
+  const set = new Set([...newKeys, ...oldKeys])
 
   return [...set].reduce((acc, current) => {
     // if values not deep equal. There are changes
     if (!isEqual(newValues[current], oldValues[current])) {
       return {
         isEqual: false,
-        keys: acc.keys.concat(current),
+        keys: [...acc.keys, current],
         diffs: {
           ...acc.diffs,
           [`${current}`]: {

--- a/src/utils/deploy/util.js
+++ b/src/utils/deploy/util.js
@@ -96,6 +96,7 @@ const waitForDeploy = async (api, deployId, siteId, timeout) => {
 const getUploadList = (required, shaMap) => {
   if (!required || !shaMap) return []
   // TODO: use `Array.flatMap()` instead once we remove support for Node <11.0.0
+  // eslint-disable-next-line unicorn/prefer-spread
   return [].concat(...required.map((sha) => shaMap[sha]))
 }
 

--- a/src/utils/detect-server-settings.js
+++ b/src/utils/detect-server-settings.js
@@ -310,15 +310,16 @@ const filterSettings = function (scriptInquirerOptions, input) {
 }
 
 const formatSettingsArrForInquirer = function (frameworks) {
-  return [].concat(
-    ...frameworks.map((framework) =>
-      framework.dev.commands.map((command) => ({
-        name: `[${chalk.yellow(framework.name)}] '${command}'`,
-        value: { ...framework, commands: [command] },
-        short: `${framework.name}-${command}`,
-      })),
-    ),
+  const formattedArr = frameworks.map((framework) =>
+    framework.dev.commands.map((command) => ({
+      name: `[${chalk.yellow(framework.name)}] '${command}'`,
+      value: { ...framework, commands: [command] },
+      short: `${framework.name}-${command}`,
+    })),
   )
+  // Replace by .flatMap() when Node.js support >= 11.0.0
+  // eslint-disable-next-line unicorn/prefer-spread
+  return [].concat(...formattedArr)
 }
 
 module.exports = {

--- a/src/utils/proxy.js
+++ b/src/utils/proxy.js
@@ -201,7 +201,7 @@ const serveRedirect = async function ({ req, res, proxy, match, options }) {
     // We pass through request params in one of the following cases:
     // 1. The redirect rule doesn't have any query params
     // 2. This is a function redirect https://github.com/netlify/cli/issues/1605
-    if (Array.from(dest.searchParams).length === 0 || isFunction(options.functionsPort, stripOrigin(dest))) {
+    if ([...dest.searchParams].length === 0 || isFunction(options.functionsPort, stripOrigin(dest))) {
       dest.searchParams.forEach((_, key) => {
         dest.searchParams.delete(key)
       })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

See #1891 

Enables the [unicorn/prefer-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md) rule for ESLint.

There were 2 instances (with the pattern `[].concat(...nestedArray)`) that have been ignored since Node.js 10 doesn't support the array methods: `.flat()` or `.flatMap()`. Alternatives would be more verbose and confusing.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava -v -s` ran without errors.
