### PR TITLE
test(edge-handlers): using new edge-handler default directory

### DIFF
--- a/tests/command.deploy.test.js
+++ b/tests/command.deploy.test.js
@@ -109,7 +109,7 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
           })
           .withNetlifyToml({
             config: {
-              build: { publish: 'public', command: 'echo "no op"' },
+              build: { publish: 'public', command: 'echo "no op"', edge_handlers: 'netlify/edge-handlers' },
             },
           })
           .withEdgeHandlers({

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1287,7 +1287,10 @@ testMatrix.forEach(({ args }) => {
         builder
           .withNetlifyToml({
             config: {
-              build: { publish: publicDir, edge_handlers: "netlify/edge-handlers" },
+              build: {
+                publish: publicDir,
+                edge_handlers: 'netlify/edge-handlers',
+              },
               'edge-handlers': [
                 {
                   handler: 'smoke',
@@ -1338,7 +1341,10 @@ testMatrix.forEach(({ args }) => {
         builder
           .withNetlifyToml({
             config: {
-              build: { publish: publicDir, edge_handlers: "netlify/edge-handlers" },
+              build: {
+                publish: publicDir,
+                edge_handlers: 'netlify/edge-handlers',
+              },
               'edge-handlers': [
                 {
                   handler: 'smoke',

--- a/tests/command.dev.test.js
+++ b/tests/command.dev.test.js
@@ -1287,7 +1287,7 @@ testMatrix.forEach(({ args }) => {
         builder
           .withNetlifyToml({
             config: {
-              build: { publish: publicDir },
+              build: { publish: publicDir, edge_handlers: "netlify/edge-handlers" },
               'edge-handlers': [
                 {
                   handler: 'smoke',
@@ -1338,7 +1338,7 @@ testMatrix.forEach(({ args }) => {
         builder
           .withNetlifyToml({
             config: {
-              build: { publish: publicDir },
+              build: { publish: publicDir, edge_handlers: "netlify/edge-handlers" },
               'edge-handlers': [
                 {
                   handler: 'smoke',

--- a/tests/utils/site-builder.js
+++ b/tests/utils/site-builder.js
@@ -64,7 +64,7 @@ const createSiteBuilder = ({ siteName }) => {
       return builder
     },
     withEdgeHandlers: ({ fileName = 'index.js', handlers }) => {
-      const dest = path.join(directory, 'edge-handlers', fileName)
+      const dest = path.join(directory, 'netlify/edge-handlers', fileName)
       tasks.push(async () => {
         const content = Object.entries(handlers)
           .map(([event, handler]) => `export const ${event} = ${handler.toString()}`)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

The current edge-handler tests make assumptions about where edge-handler code is stored (default directory). Although this is an interface (contract) worth testing, it is hampering our ability to change this default. This PR removes the reliance on a default directory by explicitly configuring one.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Since the changes are only to tests, i'm relying on CI to ensure they are passing.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/6810900/125712342-53b398a7-1884-4a7a-a5bc-baff32af5901.png)
