### PR TITLE
chore: skip main workflow on push event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: Testing for CLI
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
**- Summary**

I think we can skip the main workflow on the `push` event, since on this event we run `release-please` which will trigger its own run of the test suite as part of `npm publish`. Running the test suite again feels redundant?