### PR TITLE
chore: fix pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,6 +18,8 @@ jobs:
       # See https://github.com/npm/cli/issues/2755.
       - name: Upgrade npm
         run: npm install -g npm@latest
+      - name: Install core dependencies
+        run: npm ci --no-audit
       - name: Extract tag and version
         id: extract
         run: |-
@@ -37,7 +39,7 @@ jobs:
       - name: Setup git email
         run: git config --global user.email github-actions@github.com
       - name: Run npm version
-        run: npm version ${{ steps.extract.outputs.version }}-${{ steps.extract.outputs.tag }}
+        run: npm version ${{ steps.extract.outputs.version }}-${{ steps.extract.outputs.tag }} --allow-same-version
       - name: Push changes
         run: git push --follow-tags
       - name: Run npm publish


### PR DESCRIPTION
**- Summary**

This PR fixes the pre-release workflow by:

- Installing the core dependencies so that the `prepack` script can run
- Use `--allow-same-version` in `npm publish` in case the workflow is running for a second time after an issue in one of the steps (if the version has already been published, the workflow will fail in the `npm publish` step anyway).

It can be seen working at https://github.com/netlify/cli/runs/3103864820?check_suite_focus=true.