### PR TITLE
fix: shorthand notation o for the offline flag fixes #2400

### DIFF
--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -143,7 +143,7 @@ class BaseCommand extends TrackedCommand {
   }
 
   // Find and resolve the Netlify configuration
-  async getConfig({ cwd, host, offline = argv.offline, pathPrefix, scheme, state, token }) {
+  async getConfig({ cwd, host, offline = argv.offline || argv.o, pathPrefix, scheme, state, token }) {
     try {
       return await resolveConfig({
         config: argv.config,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

fixes https://github.com/netlify/cli/issues/2400

This PR makes a temporary fix for the shorthand notation (`-o`) of the offline flag not working due to parsing flags through `minimist` instead of the oclif parser. 

The fix is temporary since the ideal solution using the oclif parser might require substantial refactoring.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

- `npx ava -v -s` ran without errors.
- Tested a log statement in the `getConfig` method to see if the value for the `offline` parameter was `true` for both `--offline` and `-o` flags.
