### PR TITLE
fix(fish): stop git lm utility script path clutter

### DIFF
--- a/src/utils/lm/scripts/fish.sh
+++ b/src/utils/lm/scripts/fish.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env fish
 
-set -U fish_user_paths (dirname (status --current-filename))/bin $fish_user_paths
+# Only append to PATH if it isn't already part of the list
+# `fish_add_path` - https://fishshell.com/docs/current/cmds/fish_add_path.html?highlight=fish_add_path would be a more
+# suited alternative but it's only supported in fish 3.3.x
+if not contains (dirname (status --current-filename))/bin $fish_user_paths
+  set -U fish_user_paths (dirname (status --current-filename))/bin $fish_user_paths
+end


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Whenever a new fish shell is spawned, the current git lm utility script appends the binary to the user `$fish_user_paths`, leading to the following:

```sh
> echo $fish_user_paths
/Users/jgantunes/.fzf/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin /Users/jgantunes/Library/Preferences/netlify/helper/bin
```

This leads to problems like #2934.

**- Test plan**

Tested locally.

**- A picture of a cute animal (not mandatory but encouraged)**
 🦜 