### PR TITLE
fix: keep --build flag in deploy message suggestion

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -360,7 +360,7 @@ const printResults = ({ flags, results, deployToProduction, exit }) => {
     if (!deployToProduction) {
       log()
       log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag.')
-      log(`${chalk.cyanBright.bold('netlify deploy --prod')}`)
+      log(`${chalk.cyanBright.bold(`netlify deploy${flags.build ? ' --build' : ''} --prod`)}`)
       log()
     }
   }


### PR DESCRIPTION
**- Summary**

When running the `deploy` command without the `--prod` flag, the CLI will display a message with a command that allows the user to take the deployment to production. This PR makes it so that said command preserves the `--build` flag if it was present in the original `deploy` command.

Closes #3008.