### PR TITLE
fix: fix version of `plugins.json`

### DIFF
--- a/src/utils/init/plugins.js
+++ b/src/utils/init/plugins.js
@@ -1,7 +1,7 @@
 const pluginsList = require('@netlify/plugins-list')
 const fetch = require('node-fetch')
 
-const PLUGINS_LIST_VERSION = 'v1'
+const PLUGINS_LIST_VERSION = 'list-v1'
 const PLUGINS_LIST_URL = `https://${PLUGINS_LIST_VERSION}--netlify-plugins.netlify.app/plugins.json`
 // 1 minute
 const PLUGINS_LIST_TIMEOUT = 6e4


### PR DESCRIPTION
Part of https://github.com/netlify/pod-workflow/issues/157

This updates the version of `plugins.json` to match the new URL format.