### PR TITLE
fix: omit deleted files from log message

### DIFF
--- a/src/commands/functions/create.js
+++ b/src/commands/functions/create.js
@@ -410,10 +410,17 @@ const scaffoldFromTemplate = async function (context, flags, args, functionsDir)
     const vars = { name }
     let functionPackageJson
 
+    // These files will not be part of the log message because they'll likely
+    // be removed before the command finishes.
+    const omittedFromOutput = new Set(['.netlify-function-template.js', 'package.json', 'package-lock.json'])
     const createdFiles = await copy(pathToTemplate, functionPath, vars)
     createdFiles.forEach((filePath) => {
-      if (filePath.endsWith('.netlify-function-template.js')) return
-      context.log(`${NETLIFYDEVLOG} ${chalk.greenBright('Created')} ${filePath}`)
+      const filename = path.basename(filePath)
+
+      if (!omittedFromOutput.has(filename)) {
+        context.log(`${NETLIFYDEVLOG} ${chalk.greenBright('Created')} ${filePath}`)
+      }
+
       fs.chmodSync(path.resolve(filePath), TEMPLATE_PERMISSIONS)
       if (filePath.includes('package.json')) {
         functionPackageJson = path.resolve(filePath)


### PR DESCRIPTION
**- Summary**

The `functions:create` command will print a log message for each file that was copied from the template. Some files will be deleted later in the process, like `package.json` and `package-lock.json`. This PR adjusts the log messages so that those files aren't logged in the first place.