### PR TITLE
fix: support `netlify.toml` headers with `netlify dev`

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -23,8 +23,12 @@ const getHeaderValues = function ({ values }) {
   return values
 }
 
-const parseHeaders = async function ({ headersFiles }) {
-  const { headers, errors } = await parseAllHeaders({ headersFiles, minimal: false })
+const parseHeaders = async function ({ headersFiles, configPath }) {
+  const { headers, errors } = await parseAllHeaders({
+    headersFiles,
+    netlifyConfigPath: configPath,
+    minimal: false,
+  })
   handleHeadersErrors(errors)
   return headers
 }

--- a/src/utils/rules-proxy.js
+++ b/src/utils/rules-proxy.js
@@ -1,10 +1,12 @@
-const fs = require('fs')
 const path = require('path')
 const url = require('url')
 
 const chokidar = require('chokidar')
 const cookie = require('cookie')
 const redirector = require('netlify-redirector')
+const pFilter = require('p-filter')
+
+const { fileExistsAsync } = require('../lib/fs')
 
 const { NETLIFYDEVLOG } = require('./logo')
 const { parseRedirects } = require('./redirects')
@@ -37,7 +39,9 @@ const createRewriter = async function ({ distDir, projectDir, jwtSecret, jwtRole
   onChanges(watchedRedirectFiles, async () => {
     console.log(
       `${NETLIFYDEVLOG} Reloading redirect rules from`,
-      watchedRedirectFiles.filter(fs.existsSync).map((configFile) => path.relative(projectDir, configFile)),
+      (await pFilter(watchedRedirectFiles, fileExistsAsync)).map((redirectFile) =>
+        path.relative(projectDir, redirectFile),
+      ),
     )
     redirects = await parseRedirects({ redirectsFiles, configPath })
     matcher = null


### PR DESCRIPTION
Fixes #1198

This adds support for headers set in `netlify.toml` in `netlify dev`.