### PR TITLE
fix: build .mjs functions with esbuild

### DIFF
--- a/src/lib/functions/runtimes/js/builders/zisi.js
+++ b/src/lib/functions/runtimes/js/builders/zisi.js
@@ -68,16 +68,18 @@ const getTargetDirectory = async ({ errorExit }) => {
 }
 
 module.exports = async ({ config, directory, errorExit, func, projectRoot }) => {
-  const isTSFunction = path.extname(func.mainFile) === '.ts'
   const functionsConfig = addFunctionsConfigDefaults(
     normalizeFunctionsConfig({ functionsConfig: config.functions, projectRoot }),
   )
+
+  // We must use esbuild for certain file extensions.
+  const mustUseEsbuild = ['.mjs', '.ts'].includes(path.extname(func.mainFile))
 
   // TODO: Resolve functions config globs so that we can check for the bundler
   // on a per-function basis.
   const isUsingEsbuild = functionsConfig['*'].nodeBundler === 'esbuild_zisi'
 
-  if (!isTSFunction && !isUsingEsbuild) {
+  if (!mustUseEsbuild && !isUsingEsbuild) {
     return false
   }
 


### PR DESCRIPTION
**- Summary**

Since https://github.com/netlify/zip-it-and-ship-it/pull/619, functions can have a `.mjs` entry point. With this PR, CLI will ensure that those functions are built with esbuild as part of `netlify dev`, just like TypeScript functions.

Closes #3252.

**- Test plan**

Added a new test.

**- A picture of a cute animal (not mandatory but encouraged)**

![10924656-3x2-940x627](https://user-images.githubusercontent.com/4162329/130949735-cf2517fd-5426-456a-8562-22c905198bd4.jpg)
