### PR TITLE
chore(ci): fix don't cache npm cache dir between workflow execs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: '*'
           cache: 'npm'
+          cache-dependency-path: 'npm-shrinkwrap.json'
           check-latest: true
       - name: Install dependencies
         run: npm install --production --no-audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: 'npm-shrinkwrap.json'
           check-latest: true
       - name: Install core dependencies
         run: npm ci --no-audit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: '*'
           cache: 'npm'
+          cache-dependency-path: 'npm-shrinkwrap.json'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: '*'
           cache: 'npm'
+          cache-dependency-path: 'npm-shrinkwrap.json'
           check-latest: true
       - name: Install core dependencies
         run: npm ci --no-audit


### PR DESCRIPTION
Reverts - https://github.com/netlify/cli/commit/9e7f41720b97a695b235b78e6a27e0a491d40a04 - ~~caching only seems to work with `package-lock.json` files and doesn't seem to support `npm-shrinkwrap` (see https://github.com/netlify/cli/runs/3471879986)~~ (EDIT: the path for the lockfile can be configured apparently - https://github.com/actions/setup-node/issues/302)
