### PR TITLE
fix(command-dev): ensure no orphaned child process on Windows

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -61,7 +61,13 @@ const startFrameworkServer = async function ({ settings, exit }) {
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.framework || 'custom config'}`)
 
   // we use reject=false to avoid rejecting synchronously when the command doesn't exist
-  const frameworkProcess = execa.command(settings.command, { preferLocal: true, reject: false, env: settings.env })
+  const frameworkProcess = execa.command(settings.command, {
+    preferLocal: true,
+    reject: false,
+    env: settings.env,
+    // windowsHide needs to be false for child process to terminate properly on Windows
+    windowsHide: false,
+  })
   frameworkProcess.stdout.pipe(stripAnsiCc.stream()).pipe(process.stdout)
   frameworkProcess.stderr.pipe(stripAnsiCc.stream()).pipe(process.stderr)
   process.stdin.pipe(frameworkProcess.stdin)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Fixes #3251.

On Windows, the `dev` command does not properly terminate the framework process on exit, and leaves them running even though `netlify-cli` has exited.

This is because `execa` defaults to `windowsHide: true`, which seems to interfere with terminating child processes: sindresorhus/execa#433.

Other projects have also encountered this issue with execa's defaults and Windows: snowpackjs/snowpack#1022, lerna/lerna#2946.

Let's set `windowsHide: false` so that the framework process will terminate properly on exit. 

**- Test plan**

Run `netlify dev` with this PR and attempt to exit on Windows (e.g. via Ctrl-C). No framework processes should be left running after exit.

**- A picture of a cute animal (not mandatory but encouraged)**
🦓 