### PR TITLE
refactor: replace inherited error and exit utils in command.addons

### DIFF
--- a/src/commands/addons/auth.js
+++ b/src/commands/addons/auth.js
@@ -1,6 +1,6 @@
 const { prepareAddonCommand, ADDON_VALIDATION } = require('../../utils/addons/prepare')
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, exit } = require('../../utils/command-helpers')
 const openBrowser = require('../../utils/open-browser')
 
 class AddonsAuthCommand extends Command {
@@ -25,7 +25,7 @@ class AddonsAuthCommand extends Command {
     log(addon.auth_url)
     log()
     await openBrowser({ url: addon.auth_url })
-    this.exit()
+    exit()
   }
 }
 AddonsAuthCommand.aliases = ['addon:auth']

--- a/src/commands/addons/config.js
+++ b/src/commands/addons/config.js
@@ -9,7 +9,7 @@ const generatePrompts = require('../../utils/addons/prompts')
 const render = require('../../utils/addons/render')
 const { requiredConfigValues, missingConfigValues, updateConfigValues } = require('../../utils/addons/validation')
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, error } = require('../../utils/command-helpers')
 const { parseRawFlags } = require('../../utils/parse-raw-flags')
 
 class AddonsConfigCommand extends Command {
@@ -132,13 +132,12 @@ class AddonsConfigCommand extends Command {
         siteId,
         instanceId: addon.id,
         api,
-        error: this.error,
       })
     }
   }
 }
 
-const update = async function ({ addonName, currentConfig, newConfig, siteId, instanceId, api, error }) {
+const update = async function ({ addonName, currentConfig, newConfig, siteId, instanceId, api }) {
   const codeDiff = diffValues(currentConfig, newConfig)
   if (!codeDiff) {
     log('No changes, exiting early')

--- a/src/commands/addons/create.js
+++ b/src/commands/addons/create.js
@@ -7,10 +7,10 @@ const generatePrompts = require('../../utils/addons/prompts')
 const render = require('../../utils/addons/render')
 const { requiredConfigValues, missingConfigValues, updateConfigValues } = require('../../utils/addons/validation')
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, error } = require('../../utils/command-helpers')
 const { parseRawFlags } = require('../../utils/parse-raw-flags')
 
-const createAddon = async ({ api, siteId, addonName, config, siteData, error }) => {
+const createAddon = async ({ api, siteId, addonName, config, siteData }) => {
   try {
     const response = await api.createServiceInstance({
       siteId,
@@ -38,7 +38,7 @@ class AddonsCreateCommand extends Command {
       validation: ADDON_VALIDATION.NOT_EXISTS,
     })
 
-    const { error, netlify } = this
+    const { netlify } = this
     const { api, site } = netlify
     const siteId = site.id
 
@@ -71,7 +71,7 @@ class AddonsCreateCommand extends Command {
           return false
         }
 
-        await createAddon({ api, siteId, addonName, config: newConfig, siteData, error })
+        await createAddon({ api, siteId, addonName, config: newConfig, siteData })
 
         return false
       }
@@ -104,7 +104,7 @@ class AddonsCreateCommand extends Command {
       }
     }
 
-    await createAddon({ api, siteId, addonName, config: configValues, siteData, error })
+    await createAddon({ api, siteId, addonName, config: configValues, siteData })
   }
 }
 

--- a/src/commands/addons/delete.js
+++ b/src/commands/addons/delete.js
@@ -3,7 +3,7 @@ const inquirer = require('inquirer')
 
 const { prepareAddonCommand, ADDON_VALIDATION } = require('../../utils/addons/prepare')
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, exit, error } = require('../../utils/command-helpers')
 const { parseRawFlags } = require('../../utils/parse-raw-flags')
 
 class AddonsDeleteCommand extends Command {
@@ -26,7 +26,7 @@ class AddonsDeleteCommand extends Command {
         default: false,
       })
       if (!wantsToDelete) {
-        this.exit()
+        exit()
       }
     }
 
@@ -37,8 +37,8 @@ class AddonsDeleteCommand extends Command {
         instanceId: addon.id,
       })
       log(`Addon "${addonName}" deleted`)
-    } catch (error) {
-      this.error(error.message)
+    } catch (error_) {
+      error(error_.message)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

#3028 was too large for review and is being broken down.

This PR is a follow-up on #3247 and uses the separate logging and process control utilities created in it to remove the inherited ones.
This PR focuses specifically on the `src/commands/addons` folder.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava --verbose --serial` ran without any failing tests.
