### PR TITLE
refactor: replace inherited logging, exit utils in commands.functions…

### DIFF
--- a/src/commands/functions/build.js
+++ b/src/commands/functions/build.js
@@ -4,7 +4,7 @@ const { zipFunctions } = require('@netlify/zip-it-and-ship-it')
 const { flags: flagsLib } = require('@oclif/command')
 
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, exit } = require('../../utils/command-helpers')
 const { getFunctionsDir } = require('../../utils/functions')
 const { NETLIFYDEVLOG, NETLIFYDEVERR } = require('../../utils/logo')
 
@@ -19,7 +19,7 @@ class FunctionsBuildCommand extends Command {
 
     if (src === dst) {
       log(`${NETLIFYDEVERR} Source and destination for function build can't be the same`)
-      this.exit(1)
+      exit(1)
     }
 
     if (!src || !dst) {
@@ -31,7 +31,7 @@ class FunctionsBuildCommand extends Command {
         log(
           `${NETLIFYDEVERR} Error: You must specify a destination functions folder with a --functions flag or a functions field in your config`,
         )
-      this.exit(1)
+      exit(1)
     }
 
     fs.mkdirSync(dst, { recursive: true })

--- a/src/commands/functions/invoke.js
+++ b/src/commands/functions/invoke.js
@@ -8,6 +8,7 @@ const inquirer = require('inquirer')
 const fetch = require('node-fetch')
 
 const Command = require('../../utils/command')
+const { error } = require('../../utils/command-helpers')
 const { getFunctions, BACKGROUND } = require('../../utils/get-functions')
 const { NETLIFYDEVWARN } = require('../../utils/logo')
 
@@ -38,7 +39,7 @@ class FunctionsInvokeCommand extends Command {
 
     const functionsDir = flags.functions || (config.dev && config.dev.functions) || config.functionsDirectory
     if (typeof functionsDir === 'undefined') {
-      this.error('functions directory is undefined, did you forget to set it in netlify.toml?')
+      error('functions directory is undefined, did you forget to set it in netlify.toml?')
     }
 
     if (!flags.port)
@@ -126,8 +127,8 @@ class FunctionsInvokeCommand extends Command {
       )
       const data = await response.text()
       console.log(data)
-    } catch (error) {
-      this.error(`Ran into an error invoking your function: ${error.message}`)
+    } catch (error_) {
+      error(`Ran into an error invoking your function: ${error_.message}`)
     }
   }
 }
@@ -154,8 +155,8 @@ const processPayloadFromFlag = function (payloadString) {
         // eslint-disable-next-line node/global-require, import/no-dynamic-require
         payload = require(payloadpath)
         return payload
-      } catch (error) {
-        console.error(error)
+      } catch (error_) {
+        console.error(error_)
       }
     }
     // case 3: invalid string, invalid path
@@ -270,7 +271,7 @@ const tryParseJSON = function (jsonString) {
     if (parsedValue && typeof parsedValue === 'object') {
       return parsedValue
     }
-  } catch (error) {}
+  } catch (_) {}
 
   return false
 }

--- a/src/commands/functions/list.js
+++ b/src/commands/functions/list.js
@@ -4,7 +4,7 @@ const { flags: flagsLib } = require('@oclif/command')
 const AsciiTable = require('ascii-table')
 
 const Command = require('../../utils/command')
-const { log, logJson } = require('../../utils/command-helpers')
+const { log, logJson, warn, error, exit } = require('../../utils/command-helpers')
 const { getFunctionsDir } = require('../../utils/functions')
 const { getFunctions } = require('../../utils/get-functions')
 
@@ -18,23 +18,23 @@ class FunctionsListCommand extends Command {
     // copied from `netlify status`
     const siteId = site.id
     if (!siteId) {
-      this.warn('Did you run `netlify link` yet?')
-      this.error(`You don't appear to be in a folder that is linked to a site`)
+      warn('Did you run `netlify link` yet?')
+      error(`You don't appear to be in a folder that is linked to a site`)
     }
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (error) {
+    } catch (error_) {
       // unauthorized
-      if (error.status === 401) {
-        this.warn(`Log in with a different account or re-link to a site you have permission for`)
-        this.error(`Not authorized to view the currently linked site (${siteId})`)
+      if (error_.status === 401) {
+        warn(`Log in with a different account or re-link to a site you have permission for`)
+        error(`Not authorized to view the currently linked site (${siteId})`)
       }
       // missing
-      if (error.status === 404) {
-        this.error(`The site this folder is linked to can't be found`)
+      if (error_.status === 404) {
+        error(`The site this folder is linked to can't be found`)
       }
-      this.error(error)
+      error(error_)
     }
     const deploy = siteData.published_deploy || {}
     const deployedFunctions = deploy.available_functions || []
@@ -53,12 +53,12 @@ class FunctionsListCommand extends Command {
 
     if (normalizedFunctions.length === 0) {
       log(`No functions found in ${functionsDir}`)
-      this.exit()
+      exit()
     }
 
     if (flags.json) {
       logJson(normalizedFunctions)
-      this.exit()
+      exit()
     }
 
     // Make table

--- a/src/commands/functions/serve.js
+++ b/src/commands/functions/serve.js
@@ -13,18 +13,17 @@ class FunctionsServeCommand extends Command {
   async run() {
     const { flags } = this.parse(FunctionsServeCommand)
 
-    const { error: errorExit, warn, netlify } = this
+    const { error: errorExit, netlify } = this
     const { api, site, config, siteInfo } = netlify
 
     const functionsDir = getFunctionsDir({ flags, config }, join('netlify', 'functions'))
 
-    await injectEnvVariables({ env: this.netlify.cachedConfig.env, site, warn })
+    await injectEnvVariables({ env: this.netlify.cachedConfig.env, site })
 
     const { siteUrl, capabilities, timeouts } = await getSiteInformation({
       flags,
       api,
       site,
-      warn,
       error: errorExit,
       siteInfo,
     })
@@ -39,7 +38,6 @@ class FunctionsServeCommand extends Command {
       config,
       settings: { functions: functionsDir, functionsPort },
       site,
-      warn,
       errorExit,
       siteUrl,
       capabilities,

--- a/src/lib/functions/server.js
+++ b/src/lib/functions/server.js
@@ -1,7 +1,7 @@
 const bodyParser = require('body-parser')
 const jwtDecode = require('jwt-decode')
 
-const { log } = require('../../utils/command-helpers')
+const { log, warn } = require('../../utils/command-helpers')
 const { getInternalFunctionsDir } = require('../../utils/functions')
 const { NETLIFYDEVERR, NETLIFYDEVLOG } = require('../../utils/logo')
 
@@ -108,7 +108,7 @@ const createHandler = function ({ functionsRegistry }) {
   }
 }
 
-const getFunctionsServer = async function ({ functionsRegistry, siteUrl, warn, prefix }) {
+const getFunctionsServer = async function ({ functionsRegistry, siteUrl, prefix }) {
   // performance optimization, load express on demand
   // eslint-disable-next-line node/global-require
   const express = require('express')
@@ -144,7 +144,6 @@ const startFunctionsServer = async ({
   config,
   settings,
   site,
-  warn,
   errorExit,
   siteUrl,
   capabilities,

--- a/src/utils/addons/prepare.js
+++ b/src/utils/addons/prepare.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk')
 
-const { log } = require('../command-helpers')
+const { log, error } = require('../command-helpers')
 
 const ADDON_VALIDATION = {
   EXISTS: 'EXISTS',
@@ -47,7 +47,7 @@ const validateCurrentAddon = ({ addon, validation, addonName, siteData, warn, ex
   }
 }
 
-const getAddonManifest = async ({ api, addonName, error }) => {
+const getAddonManifest = async ({ api, addonName }) => {
   let manifest
   try {
     manifest = await api.showServiceManifest({ addonName })
@@ -61,7 +61,7 @@ const getAddonManifest = async ({ api, addonName, error }) => {
   return manifest
 }
 
-const getSiteData = async ({ api, siteId, error }) => {
+const getSiteData = async ({ api, siteId }) => {
   let siteData
   try {
     siteData = await api.getSite({ siteId })
@@ -71,7 +71,7 @@ const getSiteData = async ({ api, siteId, error }) => {
   return siteData
 }
 
-const getAddons = async ({ api, siteId, error }) => {
+const getAddons = async ({ api, siteId }) => {
   let addons
   try {
     addons = await api.listServiceInstancesForSite({ siteId })
@@ -82,7 +82,7 @@ const getAddons = async ({ api, siteId, error }) => {
 }
 
 const prepareAddonCommand = async ({ context, addonName, validation }) => {
-  const { netlify, warn, error, exit } = context
+  const { netlify, warn, exit } = context
   const { api, site } = netlify
   const siteId = site.id
   if (!siteId) {
@@ -93,8 +93,8 @@ const prepareAddonCommand = async ({ context, addonName, validation }) => {
 
   const [manifest, siteData, addons] = await Promise.all([
     addonName ? getAddonManifest({ api, addonName, error }) : Promise.resolve(),
-    getSiteData({ api, siteId, error }),
-    getAddons({ api, siteId, error }),
+    getSiteData({ api, siteId }),
+    getAddons({ api, siteId }),
   ])
 
   let addon

--- a/src/utils/dev.js
+++ b/src/utils/dev.js
@@ -8,7 +8,7 @@ const isEmpty = require('lodash/isEmpty')
 
 const { supportsBackgroundFunctions } = require('../lib/account')
 
-const { log } = require('./command-helpers')
+const { log, warn } = require('./command-helpers')
 const { loadDotEnvFiles } = require('./dot-env')
 const { NETLIFYDEVLOG } = require('./logo')
 
@@ -73,7 +73,7 @@ const getAddonsInformation = ({ siteInfo, addons }) => {
   return { urls, env }
 }
 
-const getSiteAccount = ({ siteInfo, accounts, warn }) => {
+const getSiteAccount = ({ siteInfo, accounts }) => {
   const siteAccount = accounts.find((account) => account.slug === siteInfo.account_slug)
   if (!siteAccount) {
     warn(`Could not find account for site '${siteInfo.name}' with account slug '${siteInfo.account_slug}'`)
@@ -88,7 +88,7 @@ const SYNCHRONOUS_FUNCTION_TIMEOUT = 10
 // default 15 minutes for background functions
 const BACKGROUND_FUNCTION_TIMEOUT = 900
 
-const getSiteInformation = async ({ flags = {}, api, site, warn, error: failAndExit, siteInfo }) => {
+const getSiteInformation = async ({ flags = {}, api, site, error: failAndExit, siteInfo }) => {
   if (site.id && !flags.offline) {
     validateSiteInfo({ site, siteInfo, failAndExit })
     const [accounts, addons] = await Promise.all([
@@ -97,7 +97,7 @@ const getSiteInformation = async ({ flags = {}, api, site, warn, error: failAndE
     ])
 
     const { urls: addonsUrls } = getAddonsInformation({ siteInfo, addons })
-    const account = getSiteAccount({ siteInfo, accounts, warn })
+    const account = getSiteAccount({ siteInfo, accounts })
 
     return {
       addonsUrls,
@@ -132,9 +132,9 @@ const getEnvSourceName = (source) => {
 
 // Takes a set of environment variables in the format provided by @netlify/config, augments it with variables from both
 // dot-env files and the process itself, and injects into `process.env`.
-const injectEnvVariables = async ({ env, site, warn }) => {
+const injectEnvVariables = async ({ env, site }) => {
   const environment = new Map(Object.entries(env))
-  const dotEnvFiles = await loadDotEnvFiles({ projectDir: site.root, warn })
+  const dotEnvFiles = await loadDotEnvFiles({ projectDir: site.root })
 
   dotEnvFiles.forEach(({ file, env: fileEnv }) => {
     Object.keys(fileEnv).forEach((key) => {

--- a/src/utils/dot-env.js
+++ b/src/utils/dot-env.js
@@ -4,7 +4,11 @@ const dotenv = require('dotenv')
 
 const { isFileAsync, readFileAsync } = require('../lib/fs')
 
-const loadDotEnvFiles = async function ({ projectDir, warn }) {
+const { warn: warn_ } = require('./command-helpers')
+
+const loadDotEnvFiles = async function ({ projectDir, warnLog }) {
+  // a stub utility is used in tests
+  const warn = warnLog || warn_
   const dotenvFiles = ['.env', '.env.development']
   const results = await Promise.all(
     dotenvFiles.map(async (file) => {


### PR DESCRIPTION
… and adjacent utils

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

#3028  was too large for review and is being broken down.

This PR is a follow-up on #3247 and uses the separate logging and process control utilities created in it to remove the inherited ones.

This PR focuses specifically on the src/commands/functions folder. Utilities outside this folder have been changed as less as possible to avoid growing the diff size in a single PR.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava --verbose --serial` ran without any failing tests.
