### PR TITLE
refactor: replace inherited log utils in src/command/(dev|sites|open)

### DIFF
--- a/src/commands/dev/exec.js
+++ b/src/commands/dev/exec.js
@@ -10,9 +10,9 @@ class ExecCommand extends Command {
   }
 
   async run() {
-    const { warn, netlify } = this
+    const { netlify } = this
     const { cachedConfig, site } = netlify
-    await injectEnvVariables({ env: cachedConfig.env, site, warn })
+    await injectEnvVariables({ env: cachedConfig.env, site })
 
     execa(this.argv[0], this.argv.slice(1), {
       stdio: 'inherit',

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -12,7 +12,7 @@ const waitPort = require('wait-port')
 
 const { startFunctionsServer } = require('../../lib/functions/server')
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, warn, exit } = require('../../utils/command-helpers')
 const { detectServerSettings } = require('../../utils/detect-server-settings')
 const { getSiteInformation, injectEnvVariables } = require('../../utils/dev')
 const { startLiveTunnel } = require('../../utils/live-tunnel')
@@ -53,7 +53,7 @@ const isNonExistingCommandError = ({ command, error }) => {
   )
 }
 
-const startFrameworkServer = async function ({ settings, exit }) {
+const startFrameworkServer = async function ({ settings }) {
   if (settings.useStaticServer) {
     return await startStaticServer({ settings })
   }
@@ -111,7 +111,7 @@ const startFrameworkServer = async function ({ settings, exit }) {
     if (!open) {
       throw new Error(`Timed out waiting for port '${settings.frameworkPort}' to be open`)
     }
-  } catch (error) {
+  } catch {
     log(NETLIFYDEVERR, `Netlify Dev could not connect to localhost:${settings.frameworkPort}.`)
     log(NETLIFYDEVERR, `Please make sure your framework server is running on port ${settings.frameworkPort}`)
     exit(1)
@@ -121,7 +121,7 @@ const startFrameworkServer = async function ({ settings, exit }) {
 // 10 minutes
 const FRAMEWORK_PORT_TIMEOUT = 6e5
 
-const startProxyServer = async ({ flags, settings, site, exit, addonsUrls }) => {
+const startProxyServer = async ({ flags, settings, site, addonsUrls }) => {
   let url
   if (flags.edgeHandlers || flags.trafficMesh) {
     url = await startForwardProxy({
@@ -181,7 +181,7 @@ class DevCommand extends Command {
 
   async run() {
     log(`${NETLIFYDEV}`)
-    const { error: errorExit, warn, exit } = this
+    const { error: errorExit } = this
     const { flags } = this.parse(DevCommand)
     const { api, site, config, siteInfo } = this.netlify
     config.dev = { ...config.dev }
@@ -230,9 +230,9 @@ class DevCommand extends Command {
       capabilities,
       timeouts,
     })
-    await startFrameworkServer({ settings, exit })
+    await startFrameworkServer({ settings })
 
-    let url = await startProxyServer({ flags, settings, site, exit, addonsUrls })
+    let url = await startProxyServer({ flags, settings, site, addonsUrls })
 
     const liveTunnelUrl = await handleLiveTunnel({ flags, site, api, settings })
     url = liveTunnelUrl || url

--- a/src/commands/open/admin.js
+++ b/src/commands/open/admin.js
@@ -1,5 +1,5 @@
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, warn, error, exit } = require('../../utils/command-helpers')
 const openBrowser = require('../../utils/open-browser')
 
 class OpenAdminCommand extends Command {
@@ -11,7 +11,7 @@ class OpenAdminCommand extends Command {
     const siteId = site.id
 
     if (!siteId) {
-      this.warn(`No Site ID found in current directory.
+      warn(`No Site ID found in current directory.
 Run \`netlify link\` to connect to this folder to a site`)
       return false
     }
@@ -21,26 +21,26 @@ Run \`netlify link\` to connect to this folder to a site`)
       siteData = await api.getSite({ siteId })
       log(`Opening "${siteData.name}" site admin UI:`)
       log(`> ${siteData.admin_url}`)
-    } catch (error) {
+    } catch (error_) {
       // unauthorized
-      if (error.status === 401) {
-        this.warn(`Log in with a different account or re-link to a site you have permission for`)
-        this.error(`Not authorized to view the currently linked site (${siteId})`)
+      if (error_.status === 401) {
+        warn(`Log in with a different account or re-link to a site you have permission for`)
+        error(`Not authorized to view the currently linked site (${siteId})`)
       }
       // site not found
-      if (error.status === 404) {
+      if (error_.status === 404) {
         log()
         log('Please double check this ID and verify you are logged in with the correct account')
         log()
         log('To fix this, run `netlify unlink` then `netlify link` to reconnect to the correct site ID')
         log()
-        this.error(`Site "${siteId}" not found in account`)
+        error(`Site "${siteId}" not found in account`)
       }
-      this.error(error)
+      error(error_)
     }
 
     await openBrowser({ url: siteData.admin_url })
-    this.exit()
+    exit()
   }
 }
 

--- a/src/commands/open/site.js
+++ b/src/commands/open/site.js
@@ -1,5 +1,5 @@
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, warn, error, exit } = require('../../utils/command-helpers')
 const openBrowser = require('../../utils/open-browser')
 
 class OpenAdminCommand extends Command {
@@ -10,7 +10,7 @@ class OpenAdminCommand extends Command {
     const siteId = site.id
 
     if (!siteId) {
-      this.warn(`No Site ID found in current directory.
+      warn(`No Site ID found in current directory.
 Run \`netlify link\` to connect to this folder to a site`)
       return false
     }
@@ -22,17 +22,17 @@ Run \`netlify link\` to connect to this folder to a site`)
       url = siteData.ssl_url || siteData.url
       log(`Opening "${siteData.name}" site url:`)
       log(`> ${url}`)
-    } catch (error) {
+    } catch (error_) {
       // unauthorized
-      if (error.status === 401) {
-        this.warn(`Log in with a different account or re-link to a site you have permission for`)
-        this.error(`Not authorized to view the currently linked site (${siteId})`)
+      if (error_.status === 401) {
+        warn(`Log in with a different account or re-link to a site you have permission for`)
+        error(`Not authorized to view the currently linked site (${siteId})`)
       }
-      this.error(error)
+      error(error_)
     }
 
     await openBrowser({ url })
-    this.exit()
+    exit()
   }
 }
 

--- a/src/commands/sites/create.js
+++ b/src/commands/sites/create.js
@@ -8,7 +8,7 @@ const prettyjson = require('prettyjson')
 const { v4: uuidv4 } = require('uuid')
 
 const Command = require('../../utils/command')
-const { log, logJson } = require('../../utils/command-helpers')
+const { log, logJson, warn, error } = require('../../utils/command-helpers')
 const { getRepoData } = require('../../utils/get-repo-data')
 const { configureRepo } = require('../../utils/init/config')
 const { track } = require('../../utils/telemetry')
@@ -93,12 +93,12 @@ class SitesCreateCommand extends Command {
           accountSlug,
           body,
         })
-      } catch (error) {
-        if (error.status === 422) {
-          this.warn(`${name}.netlify.app already exists. Please try a different slug.`)
+      } catch (error_) {
+        if (error_.status === 422) {
+          warn(`${name}.netlify.app already exists. Please try a different slug.`)
           await inputSiteName()
         } else {
-          this.error(`createSiteInTeam error: ${error.status}: ${error.message}`)
+          error(`createSiteInTeam error: ${error_.status}: ${error_.message}`)
         }
       }
     }

--- a/src/commands/sites/delete.js
+++ b/src/commands/sites/delete.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 const inquirer = require('inquirer')
 
 const Command = require('../../utils/command')
-const { log } = require('../../utils/command-helpers')
+const { log, error, exit } = require('../../utils/command-helpers')
 const { parseRawFlags } = require('../../utils/parse-raw-flags')
 
 class SitesDeleteCommand extends Command {
@@ -22,14 +22,14 @@ class SitesDeleteCommand extends Command {
     let siteData
     try {
       siteData = await api.getSite({ siteId })
-    } catch (error) {
-      if (error.status === 404) {
-        this.error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
+    } catch (error_) {
+      if (error_.status === 404) {
+        error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
       }
     }
 
     if (!siteData) {
-      this.error(`Unable to process site`)
+      error(`Unable to process site`)
     }
 
     const rawFlags = parseRawFlags(raw)
@@ -51,7 +51,7 @@ class SitesDeleteCommand extends Command {
       })
       log()
       if (!wantsToDelete) {
-        this.exit()
+        exit()
       }
     }
 
@@ -71,7 +71,7 @@ class SitesDeleteCommand extends Command {
         default: false,
       })
       if (!wantsToDelete) {
-        this.exit()
+        exit()
       }
     }
 
@@ -79,11 +79,11 @@ class SitesDeleteCommand extends Command {
 
     try {
       await api.deleteSite({ site_id: siteId })
-    } catch (error) {
-      if (error.status === 404) {
-        this.error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
+    } catch (error_) {
+      if (error_.status === 404) {
+        error(`No site with id ${siteId} found. Please verify the siteId & try again.`)
       } else {
-        this.error(`Delete Site error: ${error.status}: ${error.message}`)
+        error(`Delete Site error: ${error_.status}: ${error_.message}`)
       }
     }
     log(`Site "${siteId}" successfully deleted!`)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

#3028 was too large for review and is being broken down.

This PR is a follow-up on #3247 and uses the separate logging and process control utilities created in it to remove the inherited ones.

This PR focuses specifically on the `dev`,`open`,`sites` folder in `src/commands`.
Utilities outside this folder have been changed as less as possible to avoid growing the diff size in a single PR.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava --verbose --serial`
