### PR TITLE
refactor: replace inherited log, exit utils in commands.(build|env|lm|link|unlink)

### DIFF
--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -2,7 +2,17 @@ const { flags: flagsLib } = require('@oclif/command')
 
 const { getBuildOptions, runBuild } = require('../../lib/build')
 const Command = require('../../utils/command')
-const { getToken } = require('../../utils/command-helpers')
+const { error, exit, getToken } = require('../../utils/command-helpers')
+
+const checkOptions = ({ cachedConfig: { siteInfo = {} }, token }) => {
+  if (!siteInfo.id) {
+    error('Could not find the site ID. Please run netlify link.', { exit: 1 })
+  }
+
+  if (!token) {
+    error('Could not find the access token. Please run netlify login.', { exit: 1 })
+  }
+}
 
 class BuildCommand extends Command {
   // Run Netlify Build
@@ -21,22 +31,14 @@ class BuildCommand extends Command {
     })
 
     if (!flags.offline) {
-      this.checkOptions(options)
+      checkOptions(options)
     }
 
     const { exitCode } = await runBuild(options)
-    this.exit(exitCode)
+    exit(exitCode)
   }
 
-  checkOptions({ cachedConfig: { siteInfo = {} }, token }) {
-    if (!siteInfo.id) {
-      this.error('Could not find the site ID. Please run netlify link.', { exit: 1 })
-    }
-
-    if (!token) {
-      this.error('Could not find the access token. Please run netlify login.', { exit: 1 })
-    }
-  }
+  static;
 }
 
 // Netlify Build programmatic options

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -37,8 +37,6 @@ class BuildCommand extends Command {
     const { exitCode } = await runBuild(options)
     exit(exitCode)
   }
-
-  static;
 }
 
 // Netlify Build programmatic options

--- a/src/commands/env/import.js
+++ b/src/commands/env/import.js
@@ -6,7 +6,7 @@ const dotenv = require('dotenv')
 const isEmpty = require('lodash/isEmpty')
 
 const Command = require('../../utils/command')
-const { log, logJson } = require('../../utils/command-helpers')
+const { log, logJson, exit } = require('../../utils/command-helpers')
 
 class EnvImportCommand extends Command {
   async run() {
@@ -34,7 +34,7 @@ class EnvImportCommand extends Command {
       importedEnv = dotenv.parse(envFileContents)
     } catch (error) {
       log(error.message)
-      this.exit(1)
+      exit(1)
     }
 
     if (isEmpty(importedEnv)) {

--- a/src/commands/lm/setup.js
+++ b/src/commands/lm/setup.js
@@ -3,6 +3,7 @@ const execa = require('execa')
 const Listr = require('listr')
 
 const Command = require('../../utils/command')
+const { error } = require('../../utils/command-helpers')
 const { installPlatform } = require('../../utils/lm/install')
 const { checkHelperVersion } = require('../../utils/lm/requirements')
 const { printBanner } = require('../../utils/lm/ui')
@@ -14,7 +15,7 @@ const installHelperIfMissing = async function ({ force }) {
     if (!version) {
       installHelper = true
     }
-  } catch (error) {
+  } catch {
     installHelper = true
   }
 
@@ -37,9 +38,9 @@ const provisionService = async function (siteId, api) {
       addon: addonName,
       body: {},
     })
-  } catch (error) {
+  } catch (error_) {
     // error is JSONHTTPError
-    throw new Error(error.json.error)
+    throw new Error(error_.json.error)
   }
 }
 
@@ -62,7 +63,7 @@ class LmSetupCommand extends Command {
       try {
         helperInstalled = await installHelperIfMissing({ force: flags['force-install'] })
       } catch (error_) {
-        this.error(error_)
+        error(error_)
       }
     }
 

--- a/src/commands/unlink.js
+++ b/src/commands/unlink.js
@@ -1,5 +1,5 @@
 const Command = require('../utils/command')
-const { log } = require('../utils/command-helpers')
+const { log, exit } = require('../utils/command-helpers')
 const { track } = require('../utils/telemetry')
 
 class UnlinkCommand extends Command {
@@ -9,7 +9,7 @@ class UnlinkCommand extends Command {
 
     if (!siteId) {
       log(`Folder is not linked to a Netlify site. Run 'netlify link' to link it`)
-      return this.exit()
+      return exit()
     }
 
     let siteData = {}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

#3028 was too large for review and is being broken down.

This PR is a follow-up on #3247 and uses the separate logging and process control utilities created in it to remove the inherited ones.

This PR focuses specifically on the `build`, `env`, `lm` , `link`, `unlink` commands in `src`.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npx ava --verbose --serial`
