### PR TITLE
fix: decache all modules

### DIFF
--- a/src/lib/functions/watcher.js
+++ b/src/lib/functions/watcher.js
@@ -5,34 +5,28 @@ const pEvent = require('p-event')
 
 const DEBOUNCE_WAIT = 100
 
-const watchDebounced = async (target, { depth, onAdd, onChange, onUnlink }) => {
+const watchDebounced = async (target, { depth, onAdd = () => {}, onChange = () => {}, onUnlink = () => {} }) => {
   const watcher = chokidar.watch(target, { depth, ignored: /node_modules/, ignoreInitial: true })
 
   await pEvent(watcher, 'ready')
 
-  const debouncedOnChange = debounce((path) => {
-    decache(path)
+  const debouncedOnChange = debounce(onChange, DEBOUNCE_WAIT)
+  const debouncedOnUnlink = debounce(onUnlink, DEBOUNCE_WAIT)
+  const debouncedOnAdd = debounce(onAdd, DEBOUNCE_WAIT)
 
-    if (typeof onChange === 'function') {
-      onChange(path)
-    }
-  }, DEBOUNCE_WAIT)
-  const debouncedOnUnlink = debounce((path) => {
-    decache(path)
-
-    if (typeof onUnlink === 'function') {
-      onUnlink(path)
-    }
-  }, DEBOUNCE_WAIT)
-  const debouncedOnAdd = debounce((path) => {
-    decache(path)
-
-    if (typeof onAdd === 'function') {
-      onAdd(path)
-    }
-  }, DEBOUNCE_WAIT)
-
-  watcher.on('change', debouncedOnChange).on('unlink', debouncedOnUnlink).on('add', debouncedOnAdd)
+  watcher
+    .on('change', (path) => {
+      decache(path)
+      debouncedOnChange(path)
+    })
+    .on('unlink', (path) => {
+      decache(path)
+      debouncedOnUnlink(path)
+    })
+    .on('add', (path) => {
+      decache(path)
+      debouncedOnAdd(path)
+    })
 
   return watcher
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Closes #3374 

In 3374, the bundler rapidly emits `index.js.map` and then `index.js`. Because we debounce the `uncache` call, only the `.map` file is uncached - but we *really* wanted to uncache `index.js`!

This PR makes sure that `uncache` is called for *every* updated file.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

@mcansh comment wether this works, if you update to `<prerelease version will be inserted here>`?

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![animal watchers](http://www.theshiznit.co.uk/media/2012/May/animals-dogs.jpg)
