### PR TITLE
chore: skip flaky test

### DIFF
--- a/tests/serving-functions.test.js
+++ b/tests/serving-functions.test.js
@@ -491,7 +491,7 @@ export { handler }
     })
   })
 
-  test(testName(`should pick up new function files even through debounce`, args), async (t) => {
+  test.skip(testName(`should pick up new function files even through debounce`, args), async (t) => {
     await withSiteBuilder('function-file-updates', async (builder) => {
       await builder
         .withNetlifyToml({


### PR DESCRIPTION
#3450 introduces a test that makes the CI very flaky. This PR disables that test temporarily, until a fix is found.