### PR TITLE
chore: remove pause() calls

### DIFF
--- a/tests/serving-functions.test.js
+++ b/tests/serving-functions.test.js
@@ -523,13 +523,13 @@ exports.handler = () => ({
         await tryAndLogOutput(
           () =>
             pWaitFor(
-              async () => {                        
+              async () => {
                 const resp2 = await got.get(`${server.url}/.netlify/functions/hello`)
                 return resp2.body === 'bar'
               },
               { interval: WAIT_INTERVAL, timeout: WAIT_TIMEOUT },
             ),
-            server.outputBuffer,
+          server.outputBuffer,
         )
       })
     })


### PR DESCRIPTION
None of the `pause()` calls in serving-functions.test.js do something in the context of their individual test. This commit removes them. Locally, all tests ran through fine without them - let's see if that still holds true on CI :)

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cli/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- A picture of a cute animal (not mandatory but encouraged)**
