### PR TITLE
fix: correct regex for binary types

### DIFF
--- a/src/lib/functions/utils.js
+++ b/src/lib/functions/utils.js
@@ -3,7 +3,8 @@ const chalk = require('chalk')
 const { warn } = require('../../utils/command-helpers')
 const { getLogMessage } = require('../log')
 
-const BASE_64_MIME_REGEXP = /image|audio|video|application\/pdf|application\/zip|applicaton\/octet-stream/i
+const BASE_64_MIME_REGEXP =
+  /image|audio|video|application\/(?!json|xml|javascript|csp-report|graphql|x-www-form-urlencoded|x-ndjson)/i
 
 const DEFAULT_LAMBDA_OPTIONS = {
   verboseLevel: 3,


### PR DESCRIPTION
#### Summary

The regex to match binary MIME types had a typo (`applicaton/octet-stream`, note the missing `i`). This PR fixes that by correcting the regex so that `application` is only spelled once. 

This PR also follows the behavior documented in [this forum answer](https://answers.netlify.com/t/changed-behavior-in-function-body-encoding/19000) where all `application/*` content types are base64 encoded except for some known text types:

>**The fix**
>
> Going forward, we will base64 encode the body if the content-type starts with application/. This will ensure that binary media types like application/octet-stream and application/pdf arrive at their final destinations intact.
>
>**Exceptions**
>
> Requests with the following content-types will not be base64 encoded, even though they start with application/:
>
>    - `application/json` or `application/*+json`
>    - `application/xml` or `application/*+xml`
>    - `application/javascript`
>    - `application/csp-report`
>    - `application/graphql`
>    - `application/x-www-form-urlencoded`
>    - `application/x-ndjson`


**A picture of a cute animal (not mandatory, but encouraged)**
🐫