### PR TITLE
fixes the netlify lm:install tests for different shells (like zsh)

### DIFF
--- a/tests/command.lm.test.js
+++ b/tests/command.lm.test.js
@@ -71,8 +71,16 @@ test.serial('netlify lm:install', async (t) => {
     t.true(stdout.startsWith('git-credential-netlify'))
   } else {
     t.true(cliResponse.includes('Run this command to use Netlify Large Media in your current shell'))
-    const [source] = cliResponse.match(/source.+inc/)
-    const { stdout } = await execa.command(`${source} && git-credential-netlify version`, {
+    // The source path is always an absolute path so we can match for starting with `/`.
+    // The reasoning behind this regular expression is, that on different shells the border of the box inside the command output
+    // can infer with line breaks and split the source with the path.
+    // https://regex101.com/r/2d5BUn/1
+    //                                       /source[\s\S]+?(\/.+inc)/
+    //                                       /      [\s\S]           / \s matches any whitespace character and \S any non whitespace character
+    //                                       /            +?         / matches at least one character but until the next group
+    //                                       /              (\/.+inc)/ matches any character until `inc` (the path starting with a `\`)
+    const [, sourcePath] = cliResponse.match(/source[\s\S]+?(\/.+inc)/)
+    const { stdout } = await execa.command(`source ${sourcePath} && git-credential-netlify version`, {
       shell: t.context.execOptions.env.SHELL,
     })
     t.true(stdout.startsWith('git-credential-netlify'))

--- a/tests/utils/call-cli.js
+++ b/tests/utils/call-cli.js
@@ -1,9 +1,18 @@
+// @ts-check
 const execa = require('execa')
 
 const cliPath = require('./cli-path')
 
 const CLI_TIMEOUT = 3e5
 
+/**
+ * Calls the Cli with a max timeout.
+ * If the `parseJson` argument is specified then the result will be converted into an object.
+ * @param {readonly string[]} args
+ * @param {execa.Options<string>} execOptions
+ * @param {boolean} parseJson
+ * @returns {Promise<string|object>}
+ */
 const callCli = async function (args, execOptions, parseJson = false) {
   const { stdout } = await execa(cliPath, args, {
     timeout: CLI_TIMEOUT,


### PR DESCRIPTION
#### Summary

Fixes #3573 

When executing the test with a `zsh` shell the formatting of the box was off, so that the regex matched a wrong string. Therefore the further execution of the test was not working. 

Updated the regular expression to match exactly the path regardless of what is between the word source and the absolute path.

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/11156362/140042306-a746ca67-198c-4d79-8d96-ad1084b602ad.png)

