### PR TITLE
fix: show Background Function plan warning only if site is connected

### DIFF
--- a/src/lib/functions/registry.js
+++ b/src/lib/functions/registry.js
@@ -12,9 +12,10 @@ const runtimes = require('./runtimes')
 const { watchDebounced } = require('./watcher')
 
 class FunctionsRegistry {
-  constructor({ capabilities, config, projectRoot, timeouts }) {
+  constructor({ capabilities, config, isConnected = false, projectRoot, timeouts }) {
     this.capabilities = capabilities
     this.config = config
+    this.isConnected = isConnected
     this.projectRoot = projectRoot
     this.timeouts = timeouts
 
@@ -128,7 +129,7 @@ class FunctionsRegistry {
       return
     }
 
-    if (func.isBackground && !this.capabilities.backgroundFunctions) {
+    if (func.isBackground && this.isConnected && !this.capabilities.backgroundFunctions) {
       warn(getLogMessage('functions.backgroundNotSupported'))
     }
 

--- a/src/lib/functions/server.js
+++ b/src/lib/functions/server.js
@@ -178,6 +178,7 @@ const startFunctionsServer = async ({
     const functionsRegistry = new FunctionsRegistry({
       capabilities,
       config,
+      isConnected: Boolean(siteUrl),
       projectRoot: site.root,
       timeouts,
     })


### PR DESCRIPTION
#### Summary

The `netlify dev` command is showing a warning message when a Background Function is used and the `capabilities` object shows that the current plan doesn't support that feature. However, it's possible that the `capabilities` object is not populated due to the user being signed out or running the command using the `--offline` flag.

This PR addresses that by passing an `isConnected` flag to the functions registry, which infers whether the site is connected by looking at the `siteUrl` property. If that property is falsy, CLI won't show the warning because it can't know whether the user has a plan with access to the feature or not.

Closes https://github.com/netlify/pod-serverless/issues/31.