### PR TITLE
feat: send CLI version in all API requests

### DIFF
--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -34,7 +34,9 @@ class BaseCommand extends TrackedCommand {
     // Get site id & build state
     const state = new StateConfig(cwd)
 
-    const apiUrlOpts = {}
+    const apiUrlOpts = {
+      userAgent: this.config.userAgent,
+    }
 
     if (NETLIFY_API_URL) {
       const apiUrl = new URL(NETLIFY_API_URL)

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -52,9 +52,6 @@ test.serial('should send netlify-cli/<version> user-agent', async (t) => {
     t.is(requests.length, 2)
     // example: netlify-cli/6.14.25 darwin-x64 node-v16.13.0
     const userAgent = requests[1].headers['user-agent']
-    const [agent, os, node] = userAgent.split(' ')
-    t.is(agent, `${name}/${version}`)
-    t.truthy(os)
-    t.truthy(node)
+    t.assert(userAgent.startsWith(`${name}/${version}`))
   })
 })

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -41,3 +41,11 @@ test.serial('should track --telemetry-enable', async (t) => {
     t.deepEqual(requests[0].body.properties, {})
   })
 })
+
+test.serial('should send netlify-cli/<version> user-agent', async (t) => {
+  await withMockApi(routes, async ({ apiUrl, requests }) => {
+    await callCli(['api', "listSites"], getCLIOptions(apiUrl))
+    t.is(requests.length, 1)
+    t.is(requests[0].headers['user-agent'], `${name}/${version}`)
+  })
+})


### PR DESCRIPTION
#### Summary

At the moment, we send the [default `netlify/js-client`](https://github.com/netlify/js-client/blob/46becd9e829c60cac83828c7905674027d66d88d/src/index.js#L14) user-agent for every API request that's made from the CLI. This PR updates it so that the user-agent discloses both that it's a request from the CLI, what version it's on, what operating system and what version of Node.js. On my machine, this would be `netlify-cli/6.14.25 darwin-x64 node-v16.13.0`.

cc @netlify/data 

Closes #2804

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
