### PR TITLE
chore!: drop support for Node `13`, `14.0.0-14.13.1` and `15`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Bret Comnes <bcomnes@gmail.com> (https://bret.io)"
   ],
   "engines": {
-    "node": ">=12.20.0"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "files": [
     "/bin",


### PR DESCRIPTION
From the discussion at https://github.com/netlify/netlify-headers-parser/pull/80#discussion_r755356450

Discussing with @lukasholzer and @JGAntunes we decided to drop support for Node 13, 15 and 14 below 14.14.0.

This will require a major release and editing our previous announcement.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅