### PR TITLE
fix: docs update and required status checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,8 @@ name: Testing for CLI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
When docs are being updated, our CI setup does not run automated tests since those are not needed then.
However, we also enforce automated tests in PRs as part of our required status checks using branch protection rules.
Unfortunately, branch protection rules do not allow for conditions such as "if only docs are being updated". Since we do want to keep those rules, then this PR makes our CI setup run automated tests even when only docs are being updated.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅