### PR TITLE
fix(site): fix wrong regex

### DIFF
--- a/site/src/_layout.js
+++ b/site/src/_layout.js
@@ -260,7 +260,7 @@ const Hits = ({ searchResults }) => {
         },
       },
     }
-    const slug = highlightedHit.url.replace(/https:\/\/cli.netlify.com/, '')
+    const slug = highlightedHit.url.replace('https://cli.netlify.com', '')
     return (
       <HitsOverlay key={index}>
         <a href={slug}>


### PR DESCRIPTION
AFAICT, this is supposed to replace only the first instance. If so, using a string is enough and this fixes the missing escape:

* <https://regex101.com/r/3XSp31/1>
