### PR TITLE
fix: pin colors to 1.4.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,7 +30,7 @@
         "chokidar": "^3.0.2",
         "ci-info": "^3.0.0",
         "clean-deep": "^3.0.2",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "commander": "^8.3.0",
         "concordance": "^5.0.0",
         "configstore": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "chokidar": "^3.0.2",
     "ci-info": "^3.0.0",
     "clean-deep": "^3.0.2",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^8.3.0",
     "concordance": "^5.0.0",
     "configstore": "^5.0.0",


### PR DESCRIPTION
Follow up to https://github.com/netlify/cli/pull/3995, which actually pins `colors`