### PR TITLE
fix: add `schedule` property to normalised config

### DIFF
--- a/src/lib/functions/config.js
+++ b/src/lib/functions/config.js
@@ -12,6 +12,7 @@ const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot }) =>
         ignoredNodeModules: config.ignored_node_modules,
         nodeBundler: config.node_bundler === 'esbuild' ? 'esbuild_zisi' : config.node_bundler,
         processDynamicNodeImports: true,
+        schedule: config.schedule,
       },
     }),
     {},


### PR DESCRIPTION
#### Summary

Include `schedule` in the list of properties that is passed to zip-it-and-ship-it. This fixes an issue where schedules defined in `netlify.toml` are not picked up.

**A picture of a cute animal (not mandatory, but encouraged)**

![should-dogs-watch-tv-1636567174](https://user-images.githubusercontent.com/4162329/149311962-b11ead6c-1839-4443-a50c-af895fd28ce1.jpg)

