### PR TITLE
chore(deps): remove read-pkg-up

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -95,7 +95,6 @@
         "prettyjson": "^1.2.1",
         "pump": "^3.0.0",
         "raw-body": "^2.4.1",
-        "read-pkg-up": "^7.0.1",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.19",
         "static-server": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "prettyjson": "^1.2.1",
     "pump": "^3.0.0",
     "raw-body": "^2.4.1",
-    "read-pkg-up": "^7.0.1",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.19",
     "static-server": "^2.2.1",


### PR DESCRIPTION
Refs #3941.

Note:

Opening this for feedback. I have tried to make this foolproof, but it might not be 100% the same, for example you might not want to throw an error if `JSON.parse` fails here, so, I'll let you decide. :)

PS. I haven't checked if there's similar code in other parts of the codebase. If so, it's probably best abstracting this, using it everywhere and testing it properly.

---

If this lands, the same should be made in the remaining 2 production packages that depend on `read-pkg-up`:

```
C:\Users\xmr\Desktop\cli>npm ls read-pkg-up
netlify-cli@8.9.0 C:\Users\xmr\Desktop\cli
+-- @netlify/build@26.1.3
| `-- read-pkg-up@7.0.1
`-- @netlify/framework-info@8.0.1
  `-- read-pkg-up@7.0.1
```

---

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
