### PR TITLE
chore: fix GitHub action checking for install size

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: 'npm-shrinkwrap.json'
           check-latest: true
       - name: Install dependencies
-        run: npm ci --no-audit
+        run: npm ci --no-audit && npm prune --production
       - name: Get size
         run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "kb (Package size)" >> .delta.packageSize
       - name: Run Delta


### PR DESCRIPTION
See https://github.com/netlify/cli/pull/4041#discussion_r785051424

This fixes the GitHub action which checks for the npm package's published size, to exclude `devDependencies`.

cc @XhmikosR 

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅