### PR TITLE
feat: pass `zipGo` property to ZISI

### DIFF
--- a/src/lib/functions/config.js
+++ b/src/lib/functions/config.js
@@ -13,6 +13,7 @@ const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot }) =>
         nodeBundler: config.node_bundler === 'esbuild' ? 'esbuild_zisi' : config.node_bundler,
         processDynamicNodeImports: true,
         schedule: config.schedule,
+        zipGo: true,
       },
     }),
     {},


### PR DESCRIPTION
#### Summary

Passes the `zipGo` configuration property to zip-it-and-ship-it during the `deploy` command.

Follow up to https://github.com/netlify/zip-it-and-ship-it/pull/955 and https://github.com/netlify/build/pull/4058.