### PR TITLE
fix: dont show warning message for toml-defined scheduled functions

### DIFF
--- a/src/commands/functions/functions-invoke.js
+++ b/src/commands/functions/functions-invoke.js
@@ -156,7 +156,7 @@ const functionsInvoke = async (nameArgument, options, command) => {
     console.warn(`${NETLIFYDEVWARN} "port" flag was not specified. Attempting to connect to localhost:8888 by default`)
   const port = options.port || DEFAULT_PORT
 
-  const functions = await getFunctions(functionsDir)
+  const functions = await getFunctions(functionsDir, config)
   const functionToTrigger = await getNameFromArgs(functions, options, nameArgument)
   const functionObj = functions.find((func) => func.name === functionToTrigger)
 

--- a/src/utils/functions/get-functions.js
+++ b/src/utils/functions/get-functions.js
@@ -20,7 +20,7 @@ const JS = 'js'
 const extractSchedule = (functionConfigRecord) =>
   Object.fromEntries(Object.entries(functionConfigRecord).map(([name, { schedule }]) => [name, { schedule }]))
 
-const getFunctions = async (functionsSrcDir, config) => {
+const getFunctions = async (functionsSrcDir, config = {}) => {
   if (!(await fileExistsAsync(functionsSrcDir))) {
     return []
   }
@@ -29,7 +29,7 @@ const getFunctions = async (functionsSrcDir, config) => {
   // eslint-disable-next-line node/global-require
   const { listFunctions } = require('@netlify/zip-it-and-ship-it')
   const functions = await listFunctions(functionsSrcDir, {
-    config: extractSchedule(config.functions),
+    config: config.functions ? extractSchedule(config.functions) : undefined,
     parseISC: true,
   })
   const functionsWithProps = functions.filter(({ runtime }) => runtime === JS).map((func) => addFunctionProps(func))

--- a/src/utils/functions/get-functions.js
+++ b/src/utils/functions/get-functions.js
@@ -13,6 +13,13 @@ const addFunctionProps = ({ mainFile, name, runtime, schedule }) => {
 
 const JS = 'js'
 
+/**
+ * @param {Record<string, { schedule?: string }>} functionConfigRecord
+ * @returns {Record<string, { schedule?: string }>}
+ */
+const extractSchedule = (functionConfigRecord) =>
+  Object.fromEntries(Object.entries(functionConfigRecord).map(([name, { schedule }]) => [name, { schedule }]))
+
 const getFunctions = async (functionsSrcDir, config) => {
   if (!(await fileExistsAsync(functionsSrcDir))) {
     return []
@@ -22,7 +29,7 @@ const getFunctions = async (functionsSrcDir, config) => {
   // eslint-disable-next-line node/global-require
   const { listFunctions } = require('@netlify/zip-it-and-ship-it')
   const functions = await listFunctions(functionsSrcDir, {
-    config: config.functions,
+    config: extractSchedule(config.functions),
     parseISC: true,
   })
   const functionsWithProps = functions.filter(({ runtime }) => runtime === JS).map((func) => addFunctionProps(func))

--- a/src/utils/functions/get-functions.js
+++ b/src/utils/functions/get-functions.js
@@ -13,7 +13,7 @@ const addFunctionProps = ({ mainFile, name, runtime, schedule }) => {
 
 const JS = 'js'
 
-const getFunctions = async (functionsSrcDir) => {
+const getFunctions = async (functionsSrcDir, config) => {
   if (!(await fileExistsAsync(functionsSrcDir))) {
     return []
   }
@@ -22,6 +22,7 @@ const getFunctions = async (functionsSrcDir) => {
   // eslint-disable-next-line node/global-require
   const { listFunctions } = require('@netlify/zip-it-and-ship-it')
   const functions = await listFunctions(functionsSrcDir, {
+    config: config.functions,
     parseISC: true,
   })
   const functionsWithProps = functions.filter(({ runtime }) => runtime === JS).map((func) => addFunctionProps(func))

--- a/tests/command.functions.test.js
+++ b/tests/command.functions.test.js
@@ -643,6 +643,29 @@ test('should serve helpful tips and tricks', async (t) => {
   })
 })
 
+test('should detect netlify-toml defined scheduled functions', async (t) => {
+  await withSiteBuilder('site-with-netlify-toml-ping-function', async (builder) => {
+    await builder
+      .withNetlifyToml({
+        config: { functions: { directory: 'functions', 'test-1': { schedule: '@daily' } } },
+      })
+      .withFunction({
+        path: 'test-1.js',
+        handler: async () => ({
+          statusCode: 200,
+        }),
+      })
+      .buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async (server) => {
+      const stdout = await callCli(['functions:invoke', 'test-1', `--port=${server.port}`], {
+        cwd: builder.directory,
+      })
+      t.is(stdout, '')
+    })
+  })
+})
+
 test('should detect file changes to scheduled function', async (t) => {
   await withSiteBuilder('site-with-isc-ping-function', async (builder) => {
     await builder


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This PR fixes a bug discovered by @minivan, where our warning message was off when a toml-defined scheduled function was invoked with `functions:invoke`.


For us to review and ship your PR efficiently, please perform the following steps:

**A picture of a cute animal (not mandatory, but encouraged)**

![](https://img-new.cgtrader.com/items/796702/5af57706ac/large/3drt-cute-fish-3d-model-low-poly-animated-rigged-max-bip-fbx-blend-dae-ms3d-b3d.jpg)