### PR TITLE
fix: revert "fix(deps): update dependency netlify-onegraph-internal to v0.0.18 (#4170)"

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -81,7 +81,7 @@
         "multiparty": "^4.2.1",
         "netlify": "^10.1.2",
         "netlify-headers-parser": "^6.0.1",
-        "netlify-onegraph-internal": "0.0.18",
+        "netlify-onegraph-internal": "0.0.16",
         "netlify-redirect-parser": "^13.0.1",
         "netlify-redirector": "^0.2.1",
         "node-fetch": "^2.6.0",
@@ -148,7 +148,7 @@
         "tomlify-j0.4": "^3.0.0",
         "tree-kill": "^1.2.2",
         "typescript": "^4.4.4",
-        "verdaccio": "^5.4.0"
+        "verdaccio": "^5.5.2"
       },
       "engines": {
         "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
@@ -15020,9 +15020,9 @@
       }
     },
     "node_modules/netlify-onegraph-internal": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.18.tgz",
-      "integrity": "sha512-dUODB7zQDj03gwXQZQPlxFAfB1NBAtAt0A/CvWkfieG0g3MuRFAT/TOQGWtFesN1HkRZbW7dnC3JR9S9jB66WQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.16.tgz",
+      "integrity": "sha512-reQ/C7ztbYCDMXqFLSw0rBwOi866sqdBjagUs6Ug6LXDkCIGHBTjMX0iwNhEn7+/WzV4f1lJj66NhdjF5Q4/aQ==",
       "dependencies": {
         "graphql": "16.0.0",
         "node-fetch": "^2.6.0",
@@ -32785,9 +32785,9 @@
       }
     },
     "netlify-onegraph-internal": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.18.tgz",
-      "integrity": "sha512-dUODB7zQDj03gwXQZQPlxFAfB1NBAtAt0A/CvWkfieG0g3MuRFAT/TOQGWtFesN1HkRZbW7dnC3JR9S9jB66WQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.16.tgz",
+      "integrity": "sha512-reQ/C7ztbYCDMXqFLSw0rBwOi866sqdBjagUs6Ug6LXDkCIGHBTjMX0iwNhEn7+/WzV4f1lJj66NhdjF5Q4/aQ==",
       "requires": {
         "graphql": "16.0.0",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "multiparty": "^4.2.1",
     "netlify": "^10.1.2",
     "netlify-headers-parser": "^6.0.1",
-    "netlify-onegraph-internal": "0.0.18",
+    "netlify-onegraph-internal": "0.0.16",
     "netlify-redirect-parser": "^13.0.1",
     "netlify-redirector": "^0.2.1",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
This PR broke the graphQL tests so reverting it.

It got merged since I messed up something with our branch protection.