### PR TITLE
fix: update dep and remove @netlify directive SDL definition in output

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -82,7 +82,7 @@
         "multiparty": "^4.2.1",
         "netlify": "^11.0.0",
         "netlify-headers-parser": "^6.0.1",
-        "netlify-onegraph-internal": "0.0.37",
+        "netlify-onegraph-internal": "0.0.39",
         "netlify-redirect-parser": "^13.0.2",
         "netlify-redirector": "^0.2.1",
         "node-fetch": "^2.6.0",
@@ -16484,9 +16484,9 @@
       }
     },
     "node_modules/netlify-onegraph-internal": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.37.tgz",
-      "integrity": "sha512-EjcLO4jafn2mKVval6hns7wdqT28c7rHJyOzYTUa5ViU+L4eF6CweA4jjH36rmsFxNJchQBpzR2zl/KY4auOKg==",
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.39.tgz",
+      "integrity": "sha512-ekx1INpJGTU2t6TkvlnzFXuaFGrf5PM9we13Oq4mFbynhfuwN3NmnDRSIGl2g6ae9ZpvzTCVSIr13u/HMWjxpA==",
       "dependencies": {
         "graphql": "16.0.0",
         "node-fetch": "^2.6.0",
@@ -35806,9 +35806,9 @@
       }
     },
     "netlify-onegraph-internal": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.37.tgz",
-      "integrity": "sha512-EjcLO4jafn2mKVval6hns7wdqT28c7rHJyOzYTUa5ViU+L4eF6CweA4jjH36rmsFxNJchQBpzR2zl/KY4auOKg==",
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.0.39.tgz",
+      "integrity": "sha512-ekx1INpJGTU2t6TkvlnzFXuaFGrf5PM9we13Oq4mFbynhfuwN3NmnDRSIGl2g6ae9ZpvzTCVSIr13u/HMWjxpA==",
       "requires": {
         "graphql": "16.0.0",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "multiparty": "^4.2.1",
     "netlify": "^11.0.0",
     "netlify-headers-parser": "^6.0.1",
-    "netlify-onegraph-internal": "0.0.37",
+    "netlify-onegraph-internal": "0.0.39",
     "netlify-redirect-parser": "^13.0.2",
     "netlify-redirector": "^0.2.1",
     "node-fetch": "^2.6.0",

--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -478,7 +478,7 @@ const { buildSchema, parse } = GraphQL
 const getGraphEditUrlBySiteName = ({ oneGraphSessionId, siteName }) => {
   const host = process.env.NETLIFY_APP_HOST || 'app.netlify.com'
   // http because app.netlify.com will redirect to https, and localhost will still work for development
-  const url = `http://${host}/sites/${siteName}/graph/explorer?cliSessionId=${oneGraphSessionId}`
+  const url = `http://${host}/sites/app/${siteName}/graph/explorer/${oneGraphSessionId}`
 
   return url
 }
@@ -493,7 +493,7 @@ const getGraphEditUrlBySiteName = ({ oneGraphSessionId, siteName }) => {
 const getGraphEditUrlBySiteId = ({ oneGraphSessionId, siteId }) => {
   const host = process.env.NETLIFY_APP_HOST || 'app.netlify.com'
   // http because app.netlify.com will redirect to https, and localhost will still work for development
-  const url = `http://${host}/site-redirect/${siteId}/graph/explorer?cliSessionId=${oneGraphSessionId}`
+  const url = `http://${host}/site-redirect/${siteId}/graph/explorer/${oneGraphSessionId}`
 
   return url
 }


### PR DESCRIPTION
#### Summary

Fixes a bug where we send a SDL directive definition for `@netlify` to OneGraph. Normally this isn't a problem, but ocaml-graphql-server doesn't parse SDL, and declares it an invalid query. 

Also adds a quality-of-life improvement where we send you directly to the edit url for a graph session when running `graph:edit`

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅
