### PR TITLE
fix: graph language

### DIFF
--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -217,8 +217,7 @@ const getNetlifyGraphConfig = async ({ command, options, settings }) => {
   const moduleType =
     (userSpecifiedConfig.moduleType && userSpecifiedConfig.moduleType.split(path.sep)) ||
     defaultFrameworkConfig.moduleType
-  const language =
-    (userSpecifiedConfig.language && userSpecifiedConfig.language) || autodetectedLanguage
+  const language = (userSpecifiedConfig.language && userSpecifiedConfig.language) || autodetectedLanguage
   const webhookBasePath =
     (userSpecifiedConfig.webhookBasePath && userSpecifiedConfig.webhookBasePath.split(path.sep)) ||
     defaultFrameworkConfig.webhookBasePath

--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -218,7 +218,7 @@ const getNetlifyGraphConfig = async ({ command, options, settings }) => {
     (userSpecifiedConfig.moduleType && userSpecifiedConfig.moduleType.split(path.sep)) ||
     defaultFrameworkConfig.moduleType
   const language =
-    (userSpecifiedConfig.language && userSpecifiedConfig.language.split(path.sep)) || autodetectedLanguage
+    (userSpecifiedConfig.language && userSpecifiedConfig.language) || autodetectedLanguage
   const webhookBasePath =
     (userSpecifiedConfig.webhookBasePath && userSpecifiedConfig.webhookBasePath.split(path.sep)) ||
     defaultFrameworkConfig.webhookBasePath

--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -217,7 +217,7 @@ const getNetlifyGraphConfig = async ({ command, options, settings }) => {
   const moduleType =
     (userSpecifiedConfig.moduleType && userSpecifiedConfig.moduleType.split(path.sep)) ||
     defaultFrameworkConfig.moduleType
-  const language = (userSpecifiedConfig.language && userSpecifiedConfig.language) || autodetectedLanguage
+  const language = userSpecifiedConfig.language || autodetectedLanguage
   const webhookBasePath =
     (userSpecifiedConfig.webhookBasePath && userSpecifiedConfig.webhookBasePath.split(path.sep)) ||
     defaultFrameworkConfig.webhookBasePath


### PR DESCRIPTION
#### Summary

Fixes `language` in `netlify.toml/graph` to be a scalar and not an array, which was causing the wrong language to be emitted for graph handlers


---

- [ ] Make sure the status checks below are successful ✅
