### PR TITLE
feat: pass `nodeVersion` and feature flags to zip-it-and-ship-it

### DIFF
--- a/src/commands/deploy/deploy.js
+++ b/src/commands/deploy/deploy.js
@@ -529,7 +529,12 @@ const deploy = async (options, command) => {
     deployFolder,
     functionsFolder,
   })
-  const functionsConfig = normalizeFunctionsConfig({ functionsConfig: config.functions, projectRoot: site.root })
+  const siteEnv = get(siteData, 'build_settings.env', {})
+  const functionsConfig = normalizeFunctionsConfig({
+    functionsConfig: config.functions,
+    projectRoot: site.root,
+    siteEnv,
+  })
 
   const redirectsPath = `${deployFolder}/_redirects`
   const { restoreConfig, updateConfig } = await netlifyConfigPromise

--- a/src/commands/deploy/deploy.js
+++ b/src/commands/deploy/deploy.js
@@ -529,7 +529,7 @@ const deploy = async (options, command) => {
     deployFolder,
     functionsFolder,
   })
-  const siteEnv = get(siteData, 'build_settings.env', {})
+  const siteEnv = get(siteData, 'build_settings.env')
   const functionsConfig = normalizeFunctionsConfig({
     functionsConfig: config.functions,
     projectRoot: site.root,

--- a/src/lib/functions/config.js
+++ b/src/lib/functions/config.js
@@ -1,7 +1,7 @@
 // The function configuration keys returned by @netlify/config are not an exact
 // match to the properties that @netlify/zip-it-and-ship-it expects. We do that
 // translation here.
-const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot, siteEnv }) =>
+const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot, siteEnv = {} }) =>
   Object.entries(functionsConfig).reduce(
     (result, [pattern, config]) => ({
       ...result,

--- a/src/lib/functions/config.js
+++ b/src/lib/functions/config.js
@@ -1,7 +1,7 @@
 // The function configuration keys returned by @netlify/config are not an exact
 // match to the properties that @netlify/zip-it-and-ship-it expects. We do that
 // translation here.
-const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot }) =>
+const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot, siteEnv }) =>
   Object.entries(functionsConfig).reduce(
     (result, [pattern, config]) => ({
       ...result,
@@ -11,6 +11,7 @@ const normalizeFunctionsConfig = ({ functionsConfig = {}, projectRoot }) =>
         includedFilesBasePath: projectRoot,
         ignoredNodeModules: config.ignored_node_modules,
         nodeBundler: config.node_bundler === 'esbuild' ? 'esbuild_zisi' : config.node_bundler,
+        nodeVersion: siteEnv.AWS_LAMBDA_JS_RUNTIME,
         processDynamicNodeImports: true,
         schedule: config.schedule,
         zipGo: true,

--- a/src/utils/deploy/deploy-site.js
+++ b/src/utils/deploy/deploy-site.js
@@ -37,6 +37,7 @@ const deploySite = async (
     maxRetry = DEFAULT_MAX_RETRY,
     // API calls this the 'title'
     message: title,
+    siteEnv,
     skipFunctionsCache,
     statusCb = () => {
       /* default to noop */
@@ -65,6 +66,7 @@ const deploySite = async (
         rootDir,
         manifestPath,
         skipFunctionsCache,
+        siteEnv,
       }),
     ])
   const filesCount = Object.keys(files).length

--- a/src/utils/deploy/hash-fns.js
+++ b/src/utils/deploy/hash-fns.js
@@ -61,7 +61,12 @@ const getFunctionZips = async ({
     })
   }
 
-  return await zipIt.zipFunctions(directories, tmpDir, { basePath: rootDir, config: functionsConfig })
+  const featureFlags = {
+    zisi_detect_esm: true,
+    zisi_pure_esm: true,
+  }
+
+  return await zipIt.zipFunctions(directories, tmpDir, { basePath: rootDir, config: functionsConfig, featureFlags })
 }
 
 const hashFns = async (


### PR DESCRIPTION
#### Summary

zip-it-and-ship-it uses the `nodeVersion` configuration property to make certain decisions about the bundle (e.g. whether to use an ESM entrypoint or not). This PR reads the `AWS_LAMBDA_JS_RUNTIME` environment variable from the site settings and passes that along as the `nodeVersion` value.

This PR also sends the `zisi_detect_esm` and `zisi_pure_esm` feature flags to zip-it-and-ship-it.