### PR TITLE
fix: pass through cwd flag in getBuildOptions

### DIFF
--- a/src/lib/build.js
+++ b/src/lib/build.js
@@ -18,7 +18,7 @@ const netlifyBuildPromise = import('@netlify/build')
  * @param {import('commander').OptionValues} config.options
  * @returns {BuildConfig}
  */
-const getBuildOptions = ({ cachedConfig, options: { context, debug, dry, json, offline, silent }, token }) => ({
+const getBuildOptions = ({ cachedConfig, options: { context, cwd, debug, dry, json, offline, silent }, token }) => ({
   cachedConfig,
   token,
   dry,
@@ -29,6 +29,7 @@ const getBuildOptions = ({ cachedConfig, options: { context, debug, dry, json, o
   // buffer = true will not stream output
   buffer: json || silent,
   offline,
+  cwd,
   featureFlags: {
     functionsBundlingManifest: true,
   },


### PR DESCRIPTION
#### Summary

Companion PR to https://github.com/netlify/netlify-plugin-nextjs/pull/1264, fixing https://github.com/netlify/netlify-plugin-nextjs/pull/1264.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

Fixes a bug that causes an error when building a Next.js app in an Nx monorepo with the CLI and using the `cwd` option.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

I wasn't sure how/where this would be tested, would appreciate any pointers there.

**A picture of a cute animal (not mandatory, but encouraged)**

<img width="500" alt="Screen Shot 2022-03-15 at 1 23 53 AM" src="https://user-images.githubusercontent.com/2012388/158319490-0e88d3bb-57f4-4474-b3ef-3142257d4fe0.png">

