### PR TITLE
fix: implement fallbacks to fix terminal-link vscode hyperlinks

### DIFF
--- a/src/commands/sites/sites-create-template.js
+++ b/src/commands/sites/sites-create-template.js
@@ -80,13 +80,20 @@ const sitesCreateTemplate = async (repository, options, command) => {
       `Could not find template ${chalk.bold(templateName)}. Please verify it exists and you can ${terminalLink(
         'access to it on GitHub',
         githubLink,
+        {
+          fallback: () => `access to it on GitHub ${githubLink}`,
+        },
       )}`,
     )
     return
   }
   if (!isTemplate) {
     const githubLink = getGitHubLink({ options, templateName })
-    error(`${terminalLink(chalk.bold(templateName), githubLink)} is not a valid GitHub template`)
+    error(
+      `${terminalLink(chalk.bold(templateName), githubLink, {
+        fallback: () => `${chalk.bold(templateName)} ${githubLink}`,
+      })} is not a valid GitHub template`,
+    )
     return
   }
 

--- a/src/lib/exec-fetcher.js
+++ b/src/lib/exec-fetcher.js
@@ -125,7 +125,9 @@ const fetchLatestVersion = async ({ destination, execName, extension, latestVers
         `${execName} is not supported on ${platform} with CPU architecture ${arch}`,
       )
 
-      const issueLink = terminalLink('Create a new CLI issue', createIssueLink.href)
+      const issueLink = terminalLink('Create a new CLI issue', createIssueLink.href, {
+        fallback: () => `Create a new CLI issue ${createIssueLink.href}`,
+      })
 
       error(`The operating system ${platform} with the CPU architecture ${arch} is currently not supported!
 

--- a/src/lib/functions/registry.js
+++ b/src/lib/functions/registry.js
@@ -152,7 +152,11 @@ class FunctionsRegistry {
     this.functions.set(name, func)
     this.buildFunctionAndWatchFiles(func)
 
-    log(`${NETLIFYDEVLOG} ${chalk.green('Loaded')} function ${terminalLink(chalk.yellow(name), func.url)}.`)
+    log(
+      `${NETLIFYDEVLOG} ${chalk.green('Loaded')} function ${terminalLink(chalk.yellow(name), func.url, {
+        fallback: () => `${chalk.yellow(name)} ${func.url}`,
+      })}.`,
+    )
   }
 
   async scan(relativeDirs) {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #4311

`netlify dev` VSCode links for loaded functions render invalid links for cmd/ctrl clicked links because the characters `%E2%80%8B` are added to the end of the URL due to a [zero width space] provision(https://github.com/sindresorhus/terminal-link/pull/12) on `terminal-link`.

This PR introduces adds a fallback function to be ran in unsupported terminals allowing us to define how those links should be rendered. e.g ```terminalLink(text, url, { fallback: () => `${text} ${url}` })```. This fixes VSCode hyperlinks while allowing us to still use terminalLink for unsupported terminals.

**_Screenshots:_**
VSCode:
<img width="824" alt="vscode-with-fallback" src="https://user-images.githubusercontent.com/16131515/158383491-37e4065c-24d0-47db-82a2-88ef957675a1.png">

PowerShell:
<img width="827" alt="pwsh-with-fallback" src="https://user-images.githubusercontent.com/16131515/158384299-9ca633fa-39c8-43b8-a177-f800e328aee2.png">


iTerm:
<img width="714" alt="iterm-with-fallback" src="https://user-images.githubusercontent.com/16131515/158383601-333f3805-4b80-44ff-be32-ee0c3638d03e.png">

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![james-watson-2joVhR1OWSc-unsplash](https://user-images.githubusercontent.com/16131515/158385227-8dd78c1d-3008-421f-ab97-50af8b0586e0.jpeg)
Photo by <a href="https://unsplash.com/@just_another_photographa?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">[James Watson](https://unsplash.com/@just_another_photographa?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)</a> on <a href="https://unsplash.com/s/photos/funny-animal?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">[Unsplash](https://unsplash.com/s/photos/funny-animal?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)</a>
