### PR TITLE
fix: fallback should there be an error getting the functions error page template

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "/src/**/*.sh",
     "/src/**/*.ps1",
     "/src/functions-templates/**",
+    "/src/lib/functions/templates/**",
     "!/src/**/node_modules/**",
     "!/src/**/*.test.js"
   ],

--- a/src/lib/functions/synchronous.js
+++ b/src/lib/functions/synchronous.js
@@ -51,9 +51,14 @@ let errorTemplateFile
 
 const renderErrorTemplate = async (errString) => {
   const regexPattern = /<!--@ERROR-DETAILS-->/g
-  errorTemplateFile = errorTemplateFile || (await readFile(join(__dirname, './templates/function-error.html'), 'utf-8'))
+  const templatePath = './templates/function-error.html'
 
-  return errorTemplateFile.replace(regexPattern, errString)
+  try {
+    errorTemplateFile = errorTemplateFile || (await readFile(join(__dirname, templatePath), 'utf-8'))
+    return errorTemplateFile.replace(regexPattern, errString)
+  } catch {
+    return errString
+  }
 }
 
 const processRenderedResponse = async (err, request) => {


### PR DESCRIPTION
#### Summary

Wraps functions render error template block in try catch and returns the previous view should there be a problem getting the error template.

Part of https://github.com/netlify/pod-serverless/issues/78

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
![cute animal](https://res.cloudinary.com/cutelify/image/upload/c_fill,g_auto,q_auto:low,w_300,h_350/geran-de-klerk-bKhETeDV1WM-unsplash_sazcca.jpg)
      