### PR TITLE
fix: simplify scheduled functions template in go

### DIFF
--- a/src/commands/functions/functions-create.js
+++ b/src/commands/functions/functions-create.js
@@ -422,9 +422,9 @@ const scaffoldFromTemplate = async function (command, options, argumentName, fun
 
     const createdFiles = moveWatchedFilesIntoCurrentWorkingDirectory({
       copiedFiles: await copy(pathToTemplate, functionPath, vars),
-      watchedFiles: FILES_TO_COPY_TO_WORKING_DIR
+      watchedFiles: FILES_TO_COPY_TO_WORKING_DIR,
     })
-    
+
     createdFiles.forEach((filePath) => {
       const filename = path.basename(filePath)
 
@@ -577,17 +577,16 @@ const moveWatchedFilesIntoCurrentWorkingDirectory = ({ copiedFiles, watchedFiles
   watchedFiles.forEach((watchedFileName) => {
     const index = copiedFiles.findIndex((copiedFilePath) => copiedFilePath.endsWith(watchedFileName))
 
-    if (index === -1) 
-      return
-    
+    if (index === -1) return
+
     const cwdFilePath = path.join(process.cwd(), watchedFileName)
     const copiedFilePath = copiedFiles[index]
 
-     // we move the copied file to the current working directory
+    // we move the copied file to the current working directory
     fs.renameSync(copiedFilePath, cwdFilePath)
 
     // update the copiedFiles array to reflect the new path
-    copiedFiles[index] = cwdFilePath 
+    copiedFiles[index] = cwdFilePath
   })
 
   return copiedFiles

--- a/src/functions-templates/go/scheduled-function/main.go
+++ b/src/functions-templates/go/scheduled-function/main.go
@@ -15,7 +15,7 @@ type requestBody struct {
 	NextRun time.Time `json:"next_run"`
 }
 
-// The schedule for this function is defined inside the netlify.toml file. To learn about scheduled functions 
+// The schedule for this function is defined inside the netlify.toml file. To learn about scheduled functions
 // and supported cron extensions, visit https://ntl.fyi/sched-func.
 func handler(ctx context.Context, request events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
 	requestBody := requestBody{}

--- a/src/functions-templates/go/scheduled-function/netlify.toml
+++ b/src/functions-templates/go/scheduled-function/netlify.toml
@@ -1,11 +1,2 @@
-[build]
-functions = "functions"
-
-[build.environment]
-GO_VERSION = "1.17"
-
-[functions]
-directory = "src/"
-
-[functions.hourly-schedule]
+[functions.{{name}}]
 schedule = "@hourly"


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Related to https://github.com/netlify/pillar-runtime/issues/253

This PR aims to address the following issues when working with Go function templates:

1. The current scheduled functions template for Go isn't consistent with the one for regular functions
2. When generating Go scheduled functions from the template using the `functions:create` command, `netlify.toml` isn't placed in the current working directory.