### PR TITLE
fix: pass correct protocol to functions server

### DIFF
--- a/src/lib/functions/server.js
+++ b/src/lib/functions/server.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { get } = require('dot-prop')
 const jwtDecode = require('jwt-decode')
 
 const {
@@ -89,7 +90,7 @@ const createHandler = function (options) {
       {},
     )
     const rawQuery = new URLSearchParams(request.query).toString()
-    const protocol = options.config.dev.https ? 'https' : 'http'
+    const protocol = get(options, 'config.dev.https') ? 'https' : 'http'
     const url = new URL(requestPath, `${protocol}://${request.get('host') || 'localhost'}`)
     url.search = rawQuery
     const rawUrl = url.toString()

--- a/src/lib/functions/server.js
+++ b/src/lib/functions/server.js
@@ -89,7 +89,8 @@ const createHandler = function (options) {
       {},
     )
     const rawQuery = new URLSearchParams(request.query).toString()
-    const url = new URL(requestPath, `${request.protocol}://${request.get('host') || 'localhost'}`)
+    const protocol = options.config.dev.https ? 'https' : 'http'
+    const url = new URL(requestPath, `${protocol}://${request.get('host') || 'localhost'}`)
     url.search = rawQuery
     const rawUrl = url.toString()
     const event = {

--- a/tests/integration/200.command.dev.test.js
+++ b/tests/integration/200.command.dev.test.js
@@ -213,9 +213,9 @@ export const handler = async function () {
         })
         .withFunction({
           path: 'hello.js',
-          handler: async () => ({
+          handler: async (event) => ({
             statusCode: 200,
-            body: 'Hello World',
+            body: JSON.stringify({ rawUrl: event.rawUrl }),
           }),
         })
         .withEdgeFunction({
@@ -242,7 +242,9 @@ export const handler = async function () {
         const options = { https: { rejectUnauthorized: false } }
         t.is(await got(`https://localhost:${port}`, options).text(), 'index')
         t.is(await got(`https://localhost:${port}?ef=true`, options).text(), 'INDEX')
-        t.is(await got(`https://localhost:${port}/api/hello`, options).text(), 'Hello World')
+        t.deepEqual(await got(`https://localhost:${port}/api/hello`, options).json(), {
+          rawUrl: `https://localhost:${port}/api/hello`,
+        })
       })
     })
   })

--- a/tests/integration/300.command.dev.test.js
+++ b/tests/integration/300.command.dev.test.js
@@ -131,9 +131,9 @@ test('should serve function from a subdirectory', async (t) => {
   await withSiteBuilder('site-with-from-subdirectory', async (builder) => {
     builder.withNetlifyToml({ config: { functions: { directory: 'functions' } } }).withFunction({
       path: path.join('echo', 'echo.js'),
-      handler: async () => ({
+      handler: async (event) => ({
         statusCode: 200,
-        body: 'ping',
+        body: JSON.stringify({ rawUrl: event.rawUrl }),
         metadata: { builder_function: true },
       }),
     })
@@ -141,10 +141,10 @@ test('should serve function from a subdirectory', async (t) => {
     await builder.buildAsync()
 
     await withDevServer({ cwd: builder.directory }, async (server) => {
-      const response = await got(`${server.url}/.netlify/functions/echo`).text()
-      t.is(response, 'ping')
-      const builderResponse = await got(`${server.url}/.netlify/builders/echo`).text()
-      t.is(builderResponse, 'ping')
+      const response = await got(`${server.url}/.netlify/functions/echo`).json()
+      t.deepEqual(response, { rawUrl: `${server.url}/.netlify/functions/echo` })
+      const builderResponse = await got(`${server.url}/.netlify/builders/echo`).json()
+      t.deepEqual(builderResponse, { rawUrl: `${server.url}/.netlify/builders/echo` })
     })
   })
 })


### PR DESCRIPTION
#### Summary

When using Netlify Dev with HTTPS, the `event.rawUrl` property in serverless functions incorrectly references the HTTP URL. This PR fixes that.

Closes https://github.com/netlify/pod-compute/issues/86