### PR TITLE
fix: correctly support `multiValueHeaders` in go functions during development

### DIFF
--- a/src/lib/functions/runtimes/go/index.js
+++ b/src/lib/functions/runtimes/go/index.js
@@ -55,11 +55,12 @@ const invokeFunction = async ({ context, event, func, timeout }) => {
   })
 
   try {
-    const { body, headers, statusCode } = JSON.parse(stdout)
+    const { body, headers, multiValueHeaders, statusCode } = JSON.parse(stdout)
 
     return {
       body,
       headers,
+      multiValueHeaders,
       statusCode,
     }
   } catch {

--- a/tests/unit/lib/functions/runtimes/go/index.test.js
+++ b/tests/unit/lib/functions/runtimes/go/index.test.js
@@ -1,0 +1,29 @@
+const test = require('ava')
+const sinon = require('sinon')
+
+const { rewiremock } = require('../../../../../integration/utils/rewiremock')
+
+const runFunctionsProxySpy = sinon.stub()
+// eslint-disable-next-line n/global-require
+const { invokeFunction } = rewiremock.proxy(() => require('../../../../../../src/lib/functions/runtimes/go/index'), {
+  '../../../../../../src/lib/functions/local-proxy': {
+    runFunctionsProxy: runFunctionsProxySpy,
+  },
+})
+
+const invokeFunctionMacro = test.macro({
+  async exec(t, prop, expected) {
+    runFunctionsProxySpy.returns(Promise.resolve({ stdout: JSON.stringify({ [prop]: expected }) }))
+
+    const match = await invokeFunction({ func: { mainFile: '', buildData: {} } })
+    t.deepEqual(match[prop], expected)
+  },
+  title(providedTitle, prop) {
+    return `should return ${prop}`
+  },
+})
+
+test(invokeFunctionMacro, 'body', 'thebody')
+test(invokeFunctionMacro, 'headers', { 'X-Single': 'A' })
+test(invokeFunctionMacro, 'multiValueHeaders', { 'X-Multi': ['B', 'C'] })
+test(invokeFunctionMacro, 'statusCode', 200)


### PR DESCRIPTION
#### Summary

Fixes #4575 

`multiValueHeaders` was simply not forwarded from the response of the go function

Side note: `rust` functions have the same problem, but I did not want to fix this in one PR. 
---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅


![cat_hat_and_sunglasses_large_2c5d1dfe-fe71-4cb9-a5fc-d5e7a658e10c_large](https://user-images.githubusercontent.com/231804/169360661-b03ef2fc-59be-4194-89d0-47ae3a178734.jpg)


