### PR TITLE
fix: correctly watch function files specified in the config option `included_files`

### DIFF
--- a/src/lib/functions/netlify-function.js
+++ b/src/lib/functions/netlify-function.js
@@ -87,7 +87,7 @@ class NetlifyFunction {
     this.buildQueue = buildFunction({ cache })
 
     try {
-      const { schedule, srcFiles, ...buildData } = await this.buildQueue
+      const { includedFiles = [], schedule, srcFiles, ...buildData } = await this.buildQueue
       const srcFilesSet = new Set(srcFiles)
       const srcFilesDiff = this.getSrcFilesDiff(srcFilesSet)
 
@@ -95,7 +95,7 @@ class NetlifyFunction {
       this.srcFiles = srcFilesSet
       this.schedule = schedule || this.schedule
 
-      return { srcFilesDiff }
+      return { includedFiles, srcFilesDiff }
     } catch (error) {
       return { error }
     }

--- a/src/lib/functions/registry.js
+++ b/src/lib/functions/registry.js
@@ -76,7 +76,7 @@ class FunctionsRegistry {
       log(`${NETLIFYDEVLOG} ${chalk.magenta('Reloading')} function ${chalk.yellow(func.name)}...`)
     }
 
-    const { error_, srcFilesDiff } = await func.build({ cache: this.buildCache })
+    const { error_, includedFiles, srcFilesDiff } = await func.build({ cache: this.buildCache })
 
     if (error_) {
       log(
@@ -113,7 +113,9 @@ class FunctionsRegistry {
     // If there is no watcher for this function but the build produced files,
     // we create a new watcher and watch them.
     if (srcFilesDiff.added.size !== 0) {
-      const newWatcher = await watchDebounced([...srcFilesDiff.added], {
+      const filesToWatch = [...srcFilesDiff.added, ...includedFiles]
+
+      const newWatcher = await watchDebounced(filesToWatch, {
         onChange: () => {
           this.buildFunctionAndWatchFiles(func, { verbose: true })
         },

--- a/src/lib/functions/runtimes/js/builders/zisi.js
+++ b/src/lib/functions/runtimes/js/builders/zisi.js
@@ -36,6 +36,7 @@ const buildFunction = async ({ cache, config, directory, func, hasTypeModule, pr
   // this case, we use `mainFile` as the function path of `zipFunction`.
   const entryPath = functionDirectory === directory ? func.mainFile : functionDirectory
   const {
+    includedFiles,
     inputs,
     path: functionPath,
     schedule,
@@ -60,7 +61,7 @@ const buildFunction = async ({ cache, config, directory, func, hasTypeModule, pr
 
   clearFunctionsCache(targetDirectory)
 
-  return { buildPath, srcFiles, schedule }
+  return { buildPath, includedFiles, srcFiles, schedule }
 }
 
 /**

--- a/tests/integration/330.serving-functions.test.js
+++ b/tests/integration/330.serving-functions.test.js
@@ -951,7 +951,8 @@ test('Ensures watcher watches included files', async (t) => {
         .buildAsync()
 
       // wait for the watcher to rebuild the function
-      await pause(500)
+      const delay = 1000
+      await pause(delay)
 
       t.true(outputBuffer.some((buffer) => /.*Reloaded function hello.*/.test(buffer.toString())))
       await tryAndLogOutput(async () => {

--- a/tests/integration/330.serving-functions.test.js
+++ b/tests/integration/330.serving-functions.test.js
@@ -891,4 +891,73 @@ test('Populates the `event` argument', async (t) => {
     })
   })
 })
+
+test('Ensures watcher watches included files', async (t) => {
+  await withSiteBuilder('function-with-included-files-watch', async (builder) => {
+    await builder
+      .withContentFiles([
+        {
+          path: 'files/one.json',
+          content: `{"data": "one"}`,
+        },
+        {
+          path: 'files/two.json',
+          content: `{"data": "two"}`,
+        },
+      ])
+      .withFunction({
+        path: 'hello.js',
+        handler: async (event) => {
+          // eslint-disable-next-line n/global-require
+          const { readFileSync } = require('fs')
+          const { name } = event.queryStringParameters
+          const { data } = JSON.parse(readFileSync(`${__dirname}/../files/${name}.json`, 'utf-8'))
+
+          return {
+            statusCode: 200,
+            body: data,
+          }
+        },
+      })
+      .withNetlifyToml({
+        config: {
+          build: { publish: 'public' },
+          functions: {
+            directory: 'functions',
+            included_files: ['files/*'],
+            node_bundler: 'esbuild',
+          },
+        },
+      })
+      .buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async ({ outputBuffer, port }) => {
+      await tryAndLogOutput(async () => {
+        t.is(await got(`http://localhost:${port}/.netlify/functions/hello?name=one`).text(), 'one')
+        t.is(await got(`http://localhost:${port}/.netlify/functions/hello?name=two`).text(), 'two')
+      }, outputBuffer)
+
+      await builder
+        .withContentFiles([
+          {
+            path: 'files/one.json',
+            content: `{"data": "three"}`,
+          },
+          {
+            path: 'files/two.json',
+            content: `{"data": "four"}`,
+          },
+        ])
+        .buildAsync()
+
+      // wait for the watcher to rebuild the function
+      const timeout = 500
+      await new Promise((resolve) => {
+        setTimeout(resolve, timeout)
+      })
+
+      t.true(outputBuffer.some((buffer) => /.*Reloaded function hello.*/.test(buffer.toString())))
+    })
+  })
+})
 /* eslint-enable require-await */

--- a/tests/integration/330.serving-functions.test.js
+++ b/tests/integration/330.serving-functions.test.js
@@ -951,12 +951,13 @@ test('Ensures watcher watches included files', async (t) => {
         .buildAsync()
 
       // wait for the watcher to rebuild the function
-      const timeout = 500
-      await new Promise((resolve) => {
-        setTimeout(resolve, timeout)
-      })
+      await pause(500)
 
       t.true(outputBuffer.some((buffer) => /.*Reloaded function hello.*/.test(buffer.toString())))
+      await tryAndLogOutput(async () => {
+        t.is(await got(`http://localhost:${port}/.netlify/functions/hello?name=one`).text(), 'three')
+        t.is(await got(`http://localhost:${port}/.netlify/functions/hello?name=two`).text(), 'four')
+      }, outputBuffer)
     })
   })
 })

--- a/tests/unit/utils/functions/registry.test.js
+++ b/tests/unit/utils/functions/registry.test.js
@@ -1,0 +1,29 @@
+const test = require('ava')
+const sinon = require('sinon')
+
+const { rewiremock } = require('../../../integration/utils/rewiremock')
+
+const watchDebouncedSpy = sinon.stub()
+// eslint-disable-next-line n/global-require
+const { FunctionsRegistry } = rewiremock.proxy(() => require('../../../../src/lib/functions/registry'), {
+  '../../../../src/utils/index': {
+    watchDebounced: watchDebouncedSpy,
+  },
+})
+
+test('should add included_files to watcher', async (t) => {
+  watchDebouncedSpy.resolves({})
+
+  const registry = new FunctionsRegistry({})
+  const func = {
+    name: '',
+    config: { functions: { '*': { included_files: ['include/*', '!include/a.txt'] } } },
+    build() {
+      return { srcFilesDiff: { added: ['myfile'] }, includedFiles: ['include/*'] }
+    },
+  }
+
+  await registry.buildFunctionAndWatchFiles(func)
+
+  t.deepEqual(watchDebouncedSpy.args.at(0)[0], ['myfile', 'include/*'])
+})


### PR DESCRIPTION
#### Summary

Fixes #4454

Adds the files/globs from the `included_files` config option to the watcher.

This requires a new version of zisi with netlify/zip-it-and-ship-it#1098 , which is not released yet.

