### PR TITLE
chore: Downgrade release-please to make it work for now

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
           app-id: ${{ secrets.TOKENS_APP_ID }}
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v3.1.4
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "Cole Bosmann",
     "Dan Croak (https://twitter.com/croaky)",
     "Dan Loewenherz <dan@lionheartsw.com> (https://twitter.com/dwlz)",
+    "Daniel Tschinder (https://twitter.com/TschinderDaniel)",
     "Daniel Woelfel <dwwoelfel@gmail.com> (https://twitter.com/danielwoelfel)",
     "Dave Ackerman <dmackerman@gmail.com>",
     "David Calavera <david@netlify.com> (https://twitter.com/calavera)",


### PR DESCRIPTION
#### Summary

Newer versions cannot parse versions/tags with major versions higher than 9.
googleapis/release-please#1451

It will take a little bit until this is solved, as after the linked PR, there has to be another PR updating release-please in the github action. That is why I think it is best to downgrade for now.

---

![pirate-cat](https://user-images.githubusercontent.com/231804/170374701-2fad9528-c60a-470b-88cb-ea39a757cabe.gif)

