### PR TITLE
fix: correctly support multiValueHeaders in rust functions during development

### DIFF
--- a/src/lib/functions/runtimes/rust/index.js
+++ b/src/lib/functions/runtimes/rust/index.js
@@ -54,11 +54,12 @@ const invokeFunction = async ({ context, event, func, timeout }) => {
   })
 
   try {
-    const { body, headers, statusCode } = JSON.parse(stdout)
+    const { body, headers, multiValueHeaders, statusCode } = JSON.parse(stdout)
 
     return {
       body,
       headers,
+      multiValueHeaders,
       statusCode,
     }
   } catch {

--- a/tests/unit/lib/functions/runtimes/rust/index.test.js
+++ b/tests/unit/lib/functions/runtimes/rust/index.test.js
@@ -1,0 +1,29 @@
+const test = require('ava')
+const sinon = require('sinon')
+
+const { rewiremock } = require('../../../../../integration/utils/rewiremock')
+
+const runFunctionsProxySpy = sinon.stub()
+// eslint-disable-next-line n/global-require
+const { invokeFunction } = rewiremock.proxy(() => require('../../../../../../src/lib/functions/runtimes/rust/index'), {
+  '../../../../../../src/lib/functions/local-proxy': {
+    runFunctionsProxy: runFunctionsProxySpy,
+  },
+})
+
+const invokeFunctionMacro = test.macro({
+  async exec(t, prop, expected) {
+    runFunctionsProxySpy.resolves({ stdout: JSON.stringify({ [prop]: expected }) })
+
+    const match = await invokeFunction({ func: { mainFile: '', buildData: {} } })
+    t.deepEqual(match[prop], expected)
+  },
+  title(providedTitle, prop) {
+    return `should return ${prop}`
+  },
+})
+
+test(invokeFunctionMacro, 'body', 'thebody')
+test(invokeFunctionMacro, 'headers', { 'X-Single': 'A' })
+test(invokeFunctionMacro, 'multiValueHeaders', { 'X-Multi': ['B', 'C'] })
+test(invokeFunctionMacro, 'statusCode', 200)


### PR DESCRIPTION
#### Summary

`multiValueHeaders` was simply not forwarded from the response of the rust function

This is similar to #4618 but for rust.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![1ff935439f7e600b476a18bc2248e288--funny-pets-funny-animals](https://user-images.githubusercontent.com/231804/170673711-9931bc8e-7fc3-4b5b-aa9a-fb51af4a927c.jpeg)

