### PR TITLE
chore: remove execa mock after dev server closed

### DIFF
--- a/tests/integration/620.serving-functions-rust.test.js
+++ b/tests/integration/620.serving-functions-rust.test.js
@@ -13,26 +13,6 @@ const WAIT_WRITE = 1000
 
 test('Updates a Rust function when a file is modified', async (t) => {
   await withSiteBuilder('rust-function-update', async (builder) => {
-    await builder
-      .withNetlifyToml({
-        config: {
-          build: { publish: 'public' },
-          functions: { directory: 'functions' },
-        },
-      })
-      .withContentFiles([
-        {
-          path: 'functions/rust-func/Cargo.toml',
-          content: `[package]
-          name = "rust-func"`,
-        },
-        {
-          path: 'functions/rust-func/src/main.rs',
-          content: `<mock main.rs>`,
-        },
-      ])
-      .buildAsync()
-
     const originalBody = 'Netlify likes Rust'
     const updatedBody = 'Netlify *loves* Rust'
 
@@ -46,7 +26,7 @@ test('Updates a Rust function when a file is modified', async (t) => {
             stdout: ''
           }
         }
-        
+
         if (args[0].includes('local-functions-proxy')) {
           proxyCallCount++
 
@@ -68,13 +48,33 @@ test('Updates a Rust function when a file is modified', async (t) => {
       })
     `)
 
-    await withDevServer(
-      {
-        cwd: builder.directory,
-        env: { ...execaMock, NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE: 'true' },
-      },
-      async ({ outputBuffer, port }) => {
-        try {
+    try {
+      await builder
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public' },
+            functions: { directory: 'functions' },
+          },
+        })
+        .withContentFiles([
+          {
+            path: 'functions/rust-func/Cargo.toml',
+            content: `[package]
+          name = "rust-func"`,
+          },
+          {
+            path: 'functions/rust-func/src/main.rs',
+            content: `<mock main.rs>`,
+          },
+        ])
+        .buildAsync()
+
+      await withDevServer(
+        {
+          cwd: builder.directory,
+          env: { ...execaMock, NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE: 'true' },
+        },
+        async ({ outputBuffer, port }) => {
           await tryAndLogOutput(async () => {
             t.is(await got(`http://localhost:${port}/.netlify/functions/rust-func`).text(), originalBody)
           }, outputBuffer)
@@ -97,10 +97,10 @@ test('Updates a Rust function when a file is modified', async (t) => {
               ),
             outputBuffer,
           )
-        } finally {
-          await removeExecaMock()
-        }
-      },
-    )
+        },
+      )
+    } finally {
+      await removeExecaMock()
+    }
   })
 })


### PR DESCRIPTION
#### Summary

Refs #4625

This changes one test to delete the mocks after the dev server is closed. Before it was the other way around. This should hopefully fix some EBUSY errors in ci.