### PR TITLE
chore(deps): downgrade googlecloudplatform/release-please-action action to v3.1.4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
           app-id: ${{ secrets.TOKENS_APP_ID }}
-      - uses: GoogleCloudPlatform/release-please-action@v3.2.5
+      - uses: GoogleCloudPlatform/release-please-action@v3.1.4
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
   dependencyDashboard: true,
   packageRules: [
     {
-      matchPackageNames: ['netlify-onegraph-internal'],
+      matchPackageNames: ['netlify-onegraph-internal', 'googlecloudplatform/release-please-action'],
       enabled: false,
     },
   ],


### PR DESCRIPTION
Reverts netlify/cli#4647

Also disable renovate for it for now.

Same as #4628, but now with renovate also disabled.