### PR TITLE
fix: remove unneeded graphql dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -58,7 +58,6 @@
         "git-clone": "^0.2.0",
         "git-repo-info": "^2.1.0",
         "gitconfiglocal": "^2.1.0",
-        "graphql": "^16.1.0",
         "hasbin": "^1.2.3",
         "hasha": "^5.2.2",
         "http-proxy": "^1.18.0",
@@ -12389,14 +12388,6 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-    },
-    "node_modules/graphql": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.4.0.tgz",
-      "integrity": "sha512-tYDNcRvKCcfHREZYje3v33NSrSD/ZpbWWdPtBtUUuXx9NCo/2QDxYzNqCnMvfsrnbwRpEHMovVrPu/ERoLrIRg==",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
     },
     "node_modules/graphviz": {
       "version": "0.0.9",
@@ -32479,11 +32470,6 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
-    },
-    "graphql": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.4.0.tgz",
-      "integrity": "sha512-tYDNcRvKCcfHREZYje3v33NSrSD/ZpbWWdPtBtUUuXx9NCo/2QDxYzNqCnMvfsrnbwRpEHMovVrPu/ERoLrIRg=="
     },
     "graphviz": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
     "git-clone": "^0.2.0",
     "git-repo-info": "^2.1.0",
     "gitconfiglocal": "^2.1.0",
-    "graphql": "^16.1.0",
     "hasbin": "^1.2.3",
     "hasha": "^5.2.2",
     "http-proxy": "^1.18.0",


### PR DESCRIPTION
The dependency is never directly used and is also not a peer dependency of anything

This was added in #3904, but never used from the beginning afaics. It seems all Graphql stuff goes through `netlify-onegraph-internal`, which has a dependency on graphql.