### PR TITLE
fix: fix scheduled function template to use async

### DIFF
--- a/src/functions-templates/typescript/scheduled-function/{{name}}.ts
+++ b/src/functions-templates/typescript/scheduled-function/{{name}}.ts
@@ -2,7 +2,7 @@ import { schedule } from '@netlify/functions';
 
 // To learn about scheduled functions and supported cron extensions, 
 // see: https://ntl.fyi/sched-func
-export const handler = schedule("@hourly", (event) => {
+export const handler = schedule("@hourly", async (event) => {
     const eventBody = JSON.parse(event.body);
     console.log(`Next function run at ${eventBody.next_run}.`);
 


### PR DESCRIPTION
#### Summary

Without the async keyword, typescript instantly errors as the handler (according to the types
of `schedule()` ) needs to return a Promise.

I also tried deploying a function that is not async and lambda throws an error.
