### PR TITLE
fix: use correct paths when deploying edge functions on Windows

### DIFF
--- a/src/lib/edge-functions/deploy.js
+++ b/src/lib/edge-functions/deploy.js
@@ -1,6 +1,5 @@
 // @ts-check
 const { stat } = require('fs').promises
-const path = require('path')
 
 const { getPathInProject } = require('../settings')
 
@@ -10,7 +9,7 @@ const distPath = getPathInProject([EDGE_FUNCTIONS_FOLDER])
 
 const deployFileNormalizer = (file) => {
   const isEdgeFunction = file.root === distPath
-  const normalizedPath = isEdgeFunction ? path.join(PUBLIC_URL_PATH, file.normalizedPath) : file.normalizedPath
+  const normalizedPath = isEdgeFunction ? `${PUBLIC_URL_PATH}/${file.normalizedPath}` : file.normalizedPath
 
   return {
     ...file,
@@ -32,7 +31,7 @@ const getDistPathIfExists = async () => {
   }
 }
 
-const isEdgeFunctionFile = (filePath) => filePath.startsWith(`${PUBLIC_URL_PATH}${path.sep}`)
+const isEdgeFunctionFile = (filePath) => filePath.startsWith(`${PUBLIC_URL_PATH}/`)
 
 module.exports = {
   deployFileNormalizer,

--- a/tests/integration/210.command.deploy.test.js
+++ b/tests/integration/210.command.deploy.test.js
@@ -113,8 +113,7 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
     })
   })
 
-  // TODO: Re-add when feature flag is no longer needed.
-  test.serial.skip('should deploy Edge Functions when directory exists', async (t) => {
+  test.serial('should deploy Edge Functions when directory exists', async (t) => {
     await withSiteBuilder('site-with-public-folder', async (builder) => {
       const content = '<h1>loud</h1>'
       builder


### PR DESCRIPTION
#### Summary

The paths we supply to the `files` hash needs to be in the unix format.