### PR TITLE
fix: update minimum required version of commander to 9.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,7 +30,7 @@
         "chokidar": "^3.0.2",
         "ci-info": "^3.0.0",
         "clean-deep": "^3.0.2",
-        "commander": "^9.0.0",
+        "commander": "^9.2.0",
         "concordance": "^5.0.0",
         "configstore": "^5.0.0",
         "content-type": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "chokidar": "^3.0.2",
     "ci-info": "^3.0.0",
     "clean-deep": "^3.0.2",
-    "commander": "^9.0.0",
+    "commander": "^9.2.0",
     "concordance": "^5.0.0",
     "configstore": "^5.0.0",
     "content-type": "^1.0.4",


### PR DESCRIPTION
#### Summary

In #4615 the `commander.js` function `conflicts()` is used. This functionality was added in `9.1.0` but our package json is set to `^9.0.0`

This pr updates the minimum `commander.js` version to 9.2.0, because this also includes a fix for `conflicts()`

https://github.com/tj/commander.js/blob/master/CHANGELOG.md#920-2022-04-15

Fixes #4747 
