### PR TITLE
chore: split package size workflow to make it work for PRs from forks

### DIFF
--- a/.github/workflows/benchmark-post.yml
+++ b/.github/workflows/benchmark-post.yml
@@ -1,0 +1,27 @@
+name: Post package size
+
+on:
+  workflow_run:
+    workflows: [Calculate package size]
+    types:
+      - completed
+
+jobs:
+  post-package-size:
+    runs-on: ubuntu-latest
+    steps:
+      # This posts the status to the PR/commit
+      - uses: haya14busa/action-workflow_run-status@v1
+      - name: Download deltas
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          # This is the workflow that triggered this run
+          workflow: ${{ github.event.workflow.id }}
+          workflow_conclusion: success
+          name: delta-action-deltas
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post deltas to GitHub
+        uses: netlify/delta-action@v4
+        with:
+          title: '📊 Benchmark results'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-name: Package size
+name: Calculate package size
 
 on:
   push:
@@ -23,8 +23,10 @@ jobs:
         run: npm ci --no-audit && npm prune --production
       - name: Get size
         run: du -sk node_modules | cut -f1 > .delta.packageSize && echo "kb (Package size)" >> .delta.packageSize
-      - name: Run Delta
-        uses: netlify/delta-action@v3
+      - name: Upload deltas
+        uses: actions/upload-artifact@v3
         with:
-          title: '📊 Benchmark results'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          name: delta-action-deltas
+          retention-days: 7
+          path: |
+            .delta.*


### PR DESCRIPTION
This enables the package-size to work also from forks. Currently
it does not work because the workflow gets only a readonly token
if started from a fork, hence the workflow cannot post the comment.

https://github.com/netlify/cli/runs/7194403058?check_suite_focus=true#step:6:27

By splitting the workflow, we run the calculation in a secure environment with
only the readonly token and then run the second workflow after the first
one is finished. The second workflow then has write access and can
post the comment

taken from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

This upload of a workflow artifact will not count against the storage limit of the netlify github-account, because this is a public repository. https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-billing-for-github-actions


There is no way to test this in a PR: 🤞

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run