### PR TITLE
fix: increase dev server timeout to reduce failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "dustincrogers",
     "ehmicky (https://twitter.com/ehmicky)",
     "internal tools netlibot",
+    "just toby",
     "kvn-shn",
     "netlibot (https://www.netlify.com)",
     "nikoladev",

--- a/tests/integration/utils/dev-server.js
+++ b/tests/integration/utils/dev-server.js
@@ -83,8 +83,8 @@ const startDevServer = async (options, expectFailure) => {
   }
 }
 
-// 240 seconds
-const SERVER_START_TIMEOUT = 24e4
+// 300 seconds
+const SERVER_START_TIMEOUT = 30e4
 
 const withDevServer = async (options, testHandler, expectFailure = false) => {
   let server

--- a/tests/integration/utils/dev-server.js
+++ b/tests/integration/utils/dev-server.js
@@ -83,8 +83,8 @@ const startDevServer = async (options, expectFailure) => {
   }
 }
 
-// 300 seconds
-const SERVER_START_TIMEOUT = 30e4
+// 600 seconds
+const SERVER_START_TIMEOUT = 60e4
 
 const withDevServer = async (options, testHandler, expectFailure = false) => {
   let server


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Seeing a lot of failing eleventy tests with dev server timeout on creation.  This increases the timeout from 240 seconds to 300 seconds.

