### PR TITLE
fix: Update getTemplatesFromGitHub to retrieve more repositories

### DIFF
--- a/src/commands/sites/sites-create-template.js
+++ b/src/commands/sites/sites-create-template.js
@@ -16,7 +16,7 @@ const fetchTemplates = async (token) => {
   const templatesFromGithubOrg = await getTemplatesFromGitHub(token)
 
   return templatesFromGithubOrg
-    .filter((repo) => !repo.archived && !repo.private && !repo.disabled)
+    .filter((repo) => !repo.archived && !repo.disabled)
     .map((template) => ({
       name: template.name,
       sourceCodeUrl: template.html_url,

--- a/src/utils/sites/utils.js
+++ b/src/utils/sites/utils.js
@@ -1,7 +1,16 @@
 const fetch = require('node-fetch')
 
 const getTemplatesFromGitHub = async (token) => {
-  const templates = await fetch(`https://api.github.com/orgs/netlify-templates/repos`, {
+  const getPublicGitHubReposFromOrg = new URL(`https://api.github.com/orgs/netlify-templates/repos`)
+  // GitHub returns 30 by default and we want to avoid our limit
+  // due to our archived repositories at any given time
+  const REPOS_PER_PAGE = 70
+
+  getPublicGitHubReposFromOrg.searchParams.set('type', 'public')
+  getPublicGitHubReposFromOrg.searchParams.set('sort', 'full_name')
+  getPublicGitHubReposFromOrg.searchParams.set('per_page', REPOS_PER_PAGE)
+
+  const templates = await fetch(getPublicGitHubReposFromOrg, {
     method: 'GET',
     headers: {
       Authorization: `token ${token}`,

--- a/tests/integration/140.command.sites.test.js
+++ b/tests/integration/140.command.sites.test.js
@@ -22,6 +22,12 @@ const getTemplatesStub = sinon.stub(templatesUtils, 'getTemplatesFromGitHub').ca
     html_url: 'http://github.com/netlify-templates/next-starter',
     full_name: 'netlify-templates/next-starter',
   },
+  {
+    name: 'archived-starter',
+    html_url: 'https://github.com/netlify-templates/fake-repo',
+    full_name: 'netlify-templates/fake-repo',
+    archived: true,
+  },
 ])
 
 const createRepoStub = sinon.stub(templatesUtils, 'createRepo').callsFake(() => ({


### PR DESCRIPTION
#### Summary

Fixes #4777 

When a user uses the CLI for generating a site with a template, we want to make sure only the appropriate repos show up for us. Right now that's all public, non-archived projects. The default limit is 30, so we also doubled the site request for now.

---

I wasn't quite sure if I should make a separate test for validating that the other repository do not show up but I modified the example at least so it should still pass other tests.

**A picture of a cute animal (not mandatory, but encouraged)**
![cute little hedgehog peering into your heart](https://user-images.githubusercontent.com/8431042/178266213-88836534-2eeb-45cb-b327-d9cefa68b180.png)
