### PR TITLE
chore: fix country command + docs typo

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -18,7 +18,7 @@ netlify dev
 **Flags**
 
 - `command` (*string*) - command to run
-- `country` (*string*) - Two-letter country code (ISO 3166-1 alpha-2, https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) to use as mock geolocation (enables --geo=mock autmatically)
+- `country` (*string*) - Two-letter country code (ISO 3166-1 alpha-2, https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) to use as mock geolocation (enables --geo=mock automatically)
 - `dir` (*string*) - dir with static files
 - `edgeInspect` (*string*) - enable the V8 Inspector Protocol for Edge Functions, with an optional address in the host:port format
 - `edgeInspectBrk` (*string*) - enable the V8 Inspector Protocol for Edge Functions and pause execution on the first line of code, with an optional address in the host:port format

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "Liran Tal <liran.tal@gmail.com> (https://twitter.com/liran_tal)",
     "Louis DeScioli (https://twitter.com/descioli)",
     "Lukas Holzer <lukas.holzer@netlify.com> (https://twitter.com/luka5c0m)",
-    "Marc Littlemore (https://twitter.com/marclittlemore)",
     "Marcus Weiner",
     "Mark Bello <mark@markbello.dev> (https://markbello.dev)",
     "Mathias Biilmann <matt@netlify.com> (https://twitter.com/biilmann)",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "Liran Tal <liran.tal@gmail.com> (https://twitter.com/liran_tal)",
     "Louis DeScioli (https://twitter.com/descioli)",
     "Lukas Holzer <lukas.holzer@netlify.com> (https://twitter.com/luka5c0m)",
+    "Marc Littlemore (https://twitter.com/marclittlemore)",
     "Marcus Weiner",
     "Mark Bello <mark@markbello.dev> (https://markbello.dev)",
     "Mathias Biilmann <matt@netlify.com> (https://twitter.com/biilmann)",

--- a/src/commands/dev/dev.js
+++ b/src/commands/dev/dev.js
@@ -619,7 +619,7 @@ const createDevCommand = (program) => {
     .addOption(
       new Option(
         '--country <geoCountry>',
-        'Two-letter country code (ISO 3166-1 alpha-2, https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) to use as mock geolocation (enables --geo=mock autmatically)',
+        'Two-letter country code (ISO 3166-1 alpha-2, https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) to use as mock geolocation (enables --geo=mock automatically)',
       ).argParser(validateGeoCountryCode),
     )
     .addOption(


### PR DESCRIPTION
#### Summary

In raising issue #4819, @eduardoboucas noticed there's a typo in both the documentation and CLI command help. This PR fixes this.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://user-images.githubusercontent.com/1965510/179504462-b859c243-d791-40b1-a645-f3dd21404c0c.png)
