### PR TITLE
feat: add retry count parameter to function uploads

### DIFF
--- a/src/utils/deploy/upload-files.js
+++ b/src/utils/deploy/upload-files.js
@@ -75,7 +75,6 @@ const uploadFiles = async (api, deployId, uploadList, { concurrentUpload, maxRet
 const retryUpload = (uploadFn, maxRetry) =>
   new Promise((resolve, reject) => {
     let lastError
-    let retryCount = 0
 
     const fibonacciBackoff = backoff.fibonacci({
       randomisationFactor: UPLOAD_RANDOM_FACTOR,
@@ -83,14 +82,13 @@ const retryUpload = (uploadFn, maxRetry) =>
       maxDelay: UPLOAD_MAX_DELAY,
     })
 
-    const tryUpload = async () => {
+    const tryUpload = async (retryIndex = -1) => {
       try {
-        const results = await uploadFn(retryCount)
+        const results = await uploadFn(retryIndex + 1)
 
         return resolve(results)
       } catch (error) {
         lastError = error
-        retryCount += 1
 
         // observed errors: 408, 401 (4** swallowed), 502
         if (error.status >= 400 || error.name === 'FetchError') {

--- a/src/utils/deploy/upload-files.js
+++ b/src/utils/deploy/upload-files.js
@@ -86,6 +86,7 @@ const retryUpload = (uploadFn, maxRetry) =>
     const tryUpload = async () => {
       try {
         const results = await uploadFn(retryCount)
+
         return resolve(results)
       } catch (error) {
         lastError = error

--- a/tests/unit/utils/deploy/upload-files.test.js
+++ b/tests/unit/utils/deploy/upload-files.test.js
@@ -1,0 +1,41 @@
+const test = require('ava')
+const sinon = require('sinon')
+const { v4: generateUUID } = require('uuid')
+
+const { uploadFiles } = require('../../../../src/utils/deploy/upload-files')
+
+test('Adds a retry count to function upload requests', async (t) => {
+  const uploadDeployFunction = sinon.stub()
+  const mockError = new Error('Uh-oh')
+
+  mockError.status = 500
+
+  uploadDeployFunction.onCall(0).throws(mockError)
+  uploadDeployFunction.onCall(1).throws(mockError)
+  uploadDeployFunction.onCall(2).resolves()
+
+  const mockApi = {
+    uploadDeployFunction,
+  }
+  const deployId = generateUUID()
+  const files = [
+    {
+      assetType: 'function',
+      filepath: '/some/path/func1.zip',
+      normalizedPath: 'func1.zip',
+      runtime: 'js',
+    },
+  ]
+  const options = {
+    concurrentUpload: 1,
+    maxRetry: 3,
+    statusCb: sinon.stub(),
+  }
+
+  await uploadFiles(mockApi, deployId, files, options)
+
+  t.is(uploadDeployFunction.callCount, 3)
+  t.is(uploadDeployFunction.firstCall.args[0].xNfRetryCount, undefined)
+  t.is(uploadDeployFunction.secondCall.args[0].xNfRetryCount, 1)
+  t.is(uploadDeployFunction.thirdCall.args[0].xNfRetryCount, 2)
+})


### PR DESCRIPTION
#### Summary

Adds a retry count parameter to the `uploadDeployFunction` API call on retries.

Part of https://github.com/netlify/pod-compute/issues/140.