### PR TITLE
feat: deprecate `netlify:edge` in function templates

### DIFF
--- a/src/functions-templates/typescript/abtest/{{name}}.ts
+++ b/src/functions-templates/typescript/abtest/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   // look for existing "test_bucket" cookie

--- a/src/functions-templates/typescript/geolocation/{{name}}.ts
+++ b/src/functions-templates/typescript/geolocation/{{name}}.ts
@@ -1,4 +1,4 @@
-import { Context } from "netlify:edge";
+import { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   // Here's what's available on context.geo

--- a/src/functions-templates/typescript/json/{{name}}.ts
+++ b/src/functions-templates/typescript/json/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   return context.json({ hello: "world" });

--- a/src/functions-templates/typescript/log/{{name}}.ts
+++ b/src/functions-templates/typescript/log/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   context.log("Hello from the logging service");

--- a/src/functions-templates/typescript/set-cookies/{{name}}.ts
+++ b/src/functions-templates/typescript/set-cookies/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);

--- a/src/functions-templates/typescript/set-req-header/{{name}}.ts
+++ b/src/functions-templates/typescript/set-req-header/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   request.headers.set("X-Your-Custom-Header", "Your custom header value");

--- a/src/functions-templates/typescript/set-res-header/{{name}}.ts
+++ b/src/functions-templates/typescript/set-res-header/{{name}}.ts
@@ -1,4 +1,4 @@
-import type { Context } from "netlify:edge";
+import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   const response = await context.next();

--- a/src/functions-templates/typescript/transform-response/{{name}}.ts
+++ b/src/functions-templates/typescript/transform-response/{{name}}.ts
@@ -1,4 +1,4 @@
-import { Context } from "netlify:edge";
+import { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
   const url = new URL(request.url);


### PR DESCRIPTION
#### Summary

Replaces `netlify:edge` with `https://edge.netlify.com` in Edge Functions templates.

Part of https://github.com/netlify/pillar-runtime/issues/322.