### PR TITLE
fix: correctly create edge function directory when running in custom cwd

### DIFF
--- a/src/lib/edge-functions/deploy.js
+++ b/src/lib/edge-functions/deploy.js
@@ -1,5 +1,6 @@
 // @ts-check
 const { stat } = require('fs').promises
+const { join } = require('path')
 
 const { getPathInProject } = require('../settings')
 
@@ -7,8 +8,9 @@ const { EDGE_FUNCTIONS_FOLDER, PUBLIC_URL_PATH } = require('./consts')
 
 const distPath = getPathInProject([EDGE_FUNCTIONS_FOLDER])
 
-const deployFileNormalizer = (file) => {
-  const isEdgeFunction = file.root === distPath
+const deployFileNormalizer = (rootDir, file) => {
+  const absoluteDistPath = join(rootDir, distPath)
+  const isEdgeFunction = file.root === absoluteDistPath
   const normalizedPath = isEdgeFunction ? `${PUBLIC_URL_PATH}/${file.normalizedPath}` : file.normalizedPath
 
   return {
@@ -17,15 +19,16 @@ const deployFileNormalizer = (file) => {
   }
 }
 
-const getDistPathIfExists = async () => {
+const getDistPathIfExists = async ({ rootDir }) => {
   try {
-    const stats = await stat(distPath)
+    const absoluteDistPath = join(rootDir, distPath)
+    const stats = await stat(absoluteDistPath)
 
     if (!stats.isDirectory()) {
-      throw new Error(`Path ${distPath} must be a directory.`)
+      throw new Error(`Path ${absoluteDistPath} must be a directory.`)
     }
 
-    return distPath
+    return absoluteDistPath
   } catch {
     // no-op
   }

--- a/src/utils/deploy/deploy-site.js
+++ b/src/utils/deploy/deploy-site.js
@@ -54,7 +54,7 @@ const deploySite = async (
     phase: 'start',
   })
 
-  const edgeFunctionsDistPath = await edgeFunctions.getDistPathIfExists()
+  const edgeFunctionsDistPath = await edgeFunctions.getDistPathIfExists({ rootDir })
   const [{ files, filesShaMap }, { fnShaMap, functionSchedules, functions, functionsWithNativeModules }] =
     await Promise.all([
       hashFiles({
@@ -63,7 +63,7 @@ const deploySite = async (
         directories: [configPath, dir, edgeFunctionsDistPath].filter(Boolean),
         filter,
         hashAlgorithm,
-        normalizer: edgeFunctions.deployFileNormalizer,
+        normalizer: edgeFunctions.deployFileNormalizer.bind(null, rootDir),
         statusCb,
       }),
       hashFns(fnDir, {

--- a/tests/integration/210.command.deploy.test.js
+++ b/tests/integration/210.command.deploy.test.js
@@ -28,12 +28,12 @@ const validateContent = async ({ content, path, siteUrl, t }) => {
   }
 }
 
-const validateDeploy = async ({ content, deploy, siteName, t }) => {
+const validateDeploy = async ({ content, contentMessage, deploy, siteName, t }) => {
   t.truthy(deploy.site_name)
   t.truthy(deploy.deploy_url)
   t.truthy(deploy.deploy_id)
   t.truthy(deploy.logs)
-  t.is(deploy.site_name, siteName)
+  t.is(deploy.site_name, siteName, contentMessage)
 
   await validateContent({ siteUrl: deploy.deploy_url, path: '', content, t })
 }
@@ -115,7 +115,7 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
 
   test.serial('should deploy Edge Functions when directory exists', async (t) => {
     await withSiteBuilder('site-with-public-folder', async (builder) => {
-      const content = '<h1>loud</h1>'
+      const content = 'Edge Function works NOT'
       builder
         .withContentFile({
           path: 'public/index.html',
@@ -124,17 +124,12 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
         .withNetlifyToml({
           config: {
             build: { publish: 'public', command: 'echo "no op"' },
-            edge_functions: [{ function: 'yell', path: '/*' }],
+            edge_functions: [{ function: 'edge', path: '/*' }],
           },
         })
         .withEdgeFunction({
-          handler: async (_, context) => {
-            const resp = await context.next()
-            const text = await resp.text()
-
-            return new Response(text.toUpperCase(), resp)
-          },
-          name: 'yell',
+          handler: async () => new Response('Edge Function works'),
+          name: 'edge',
         })
 
       await builder.buildAsync()
@@ -147,7 +142,57 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
       await callCli(['build'], options)
       const deploy = await callCli(['deploy', '--json'], options).then((output) => JSON.parse(output))
 
-      await validateDeploy({ deploy, siteName: SITE_NAME, content: content.toUpperCase(), t })
+      await validateDeploy({
+        deploy,
+        siteName: SITE_NAME,
+        content: 'Edge Function works',
+        contentMessage: 'Edge function did not execute correctly or was not deployed correctly',
+        t,
+      })
+    })
+  })
+
+  test.serial('should deploy Edge Functions with custom cwd when directory exists', async (t) => {
+    await withSiteBuilder('site-with-public-folder', async (builder) => {
+      const content = 'Edge Function works NOT'
+      const pathPrefix = 'app/cool'
+      builder
+        .withContentFile({
+          path: 'app/cool/public/index.html',
+          content,
+        })
+        .withNetlifyToml({
+          config: {
+            build: { publish: 'public', command: 'echo "no op"' },
+            edge_functions: [{ function: 'edge', path: '/*' }],
+          },
+          pathPrefix,
+        })
+        .withEdgeFunction({
+          handler: async () => new Response('Edge Function works'),
+          name: 'edge',
+          pathPrefix,
+        })
+
+      await builder.buildAsync()
+
+      const options = {
+        cwd: builder.directory,
+        env: { NETLIFY_SITE_ID: t.context.siteId },
+      }
+
+      await callCli(['build', '--cwd', pathPrefix], options)
+      const deploy = await callCli(['deploy', '--json', '--cwd', pathPrefix], options).then((output) =>
+        JSON.parse(output),
+      )
+
+      await validateDeploy({
+        deploy,
+        siteName: SITE_NAME,
+        content: 'Edge Function works',
+        contentMessage: 'Edge function did not execute correctly or was not deployed correctly',
+        t,
+      })
     })
   })
 

--- a/tests/integration/utils/site-builder.js
+++ b/tests/integration/utils/site-builder.js
@@ -66,8 +66,8 @@ const createSiteBuilder = ({ siteName }) => {
       })
       return builder
     },
-    withEdgeFunction: ({ handler, name = 'function' }) => {
-      const dest = path.join(directory, 'netlify/edge-functions', `${name}.js`)
+    withEdgeFunction: ({ handler, name = 'function', pathPrefix = '' }) => {
+      const dest = path.join(directory, pathPrefix, 'netlify/edge-functions', `${name}.js`)
       tasks.push(async () => {
         const content = `export default ${handler.toString()}`
         await ensureDir(path.dirname(dest))


### PR DESCRIPTION
#### Summary

Fixes netlify/netlify-plugin-nextjs#1400
Fixes netlify/pod-compute#150

The edge function dist path was incorrect when a custom working directory `--cwd` was supplied through the cli options. We were looking at `/repo/path/.netlify/...` instead of `/repo/path/cwd/.netlify/...`

Added a new test (which failed without the fix) and adjusted the other test to be more clear what failed. Just getting the uppercase/lowercase error, usually made me think this is some unimportant server/proxy conversation, but it actually means the edge function is not being loaded. Should be clearer now.

![download](https://user-images.githubusercontent.com/231804/180794982-1409dbff-3ad0-43ff-b727-5d2a693d3a02.jpeg)

