### PR TITLE
fix: prevent promptEditorHelper to run if running tests in vscode

### DIFF
--- a/src/lib/edge-functions/editor-helper.js
+++ b/src/lib/edge-functions/editor-helper.js
@@ -10,7 +10,7 @@ const promptEditorHelper = async ({ NETLIFYDEVLOG, chalk, config, log, repositor
   // This prevents tests from hanging when running them inside the VS Code
   // terminal, as otherwise we'll show the prompt and wait for a response.
   if (env.NODE_ENV === 'test') return
-    
+
   const isVSCode = env.TERM_PROGRAM === 'vscode'
   const hasShownPrompt = Boolean(state.get(STATE_PROMPT_PROPERTY))
   const hasEdgeFunctions = Boolean(config.edge_functions && config.edge_functions.length !== 0)

--- a/src/lib/edge-functions/editor-helper.js
+++ b/src/lib/edge-functions/editor-helper.js
@@ -7,7 +7,10 @@ const { runRecipe } = require('../../commands/recipes')
 const STATE_PROMPT_PROPERTY = 'promptVSCodeSettings'
 
 const promptEditorHelper = async ({ NETLIFYDEVLOG, chalk, config, log, repositoryRoot, state }) => {
+  // This prevents tests from hanging when running them inside the VS Code
+  // terminal, as otherwise we'll show the prompt and wait for a response.
   if (env.NODE_ENV === 'test') return
+    
   const isVSCode = env.TERM_PROGRAM === 'vscode'
   const hasShownPrompt = Boolean(state.get(STATE_PROMPT_PROPERTY))
   const hasEdgeFunctions = Boolean(config.edge_functions && config.edge_functions.length !== 0)

--- a/src/lib/edge-functions/editor-helper.js
+++ b/src/lib/edge-functions/editor-helper.js
@@ -7,6 +7,7 @@ const { runRecipe } = require('../../commands/recipes')
 const STATE_PROMPT_PROPERTY = 'promptVSCodeSettings'
 
 const promptEditorHelper = async ({ NETLIFYDEVLOG, chalk, config, log, repositoryRoot, state }) => {
+  if (env.NODE_ENV === 'test') return
   const isVSCode = env.TERM_PROGRAM === 'vscode'
   const hasShownPrompt = Boolean(state.get(STATE_PROMPT_PROPERTY))
   const hasEdgeFunctions = Boolean(config.edge_functions && config.edge_functions.length !== 0)


### PR DESCRIPTION
#### Summary

Fixes #4862 

Added a check for test environment inside the `promptEditorHelper` function. This decision was made based upon the thought that we could either change the `env.TERM_PROGRAM` in all tests, or check if the `env.NODE_ENV` was `test`.


---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
