### PR TITLE
test: move site info header creation to function and write unit test for function

### DIFF
--- a/src/lib/edge-functions/proxy.js
+++ b/src/lib/edge-functions/proxy.js
@@ -46,6 +46,13 @@ const handleProxyRequest = (req, proxyReq) => {
   })
 }
 
+const createSiteInfoHeader = (siteInfo = {}) => {
+  const { id, name, url } = siteInfo
+  const site = { id, name, url }
+  const siteString = JSON.stringify(site)
+  return Buffer.from(siteString).toString('base64')
+}
+
 const initializeProxy = async ({
   config,
   configPath,
@@ -95,9 +102,7 @@ const initializeProxy = async ({
 
     // Setting header with geolocation and site info.
     req.headers[headers.Geo] = JSON.stringify(geoLocation)
-    req.headers[headers.Site] = Buffer.from(
-      JSON.stringify({ id: siteInfo.id, name: siteInfo.name, url: siteInfo.url }),
-    ).toString('base64')
+    req.headers[headers.Site] = createSiteInfoHeader(siteInfo)
 
     await registry.initialize()
 
@@ -187,4 +192,4 @@ const prepareServer = async ({
   }
 }
 
-module.exports = { handleProxyRequest, initializeProxy, isEdgeFunctionsRequest }
+module.exports = { handleProxyRequest, initializeProxy, isEdgeFunctionsRequest, createSiteInfoHeader }

--- a/tests/unit/lib/edge-functions/create-site-info-header.test.js
+++ b/tests/unit/lib/edge-functions/create-site-info-header.test.js
@@ -1,0 +1,21 @@
+const { Buffer } = require('buffer')
+
+const test = require('ava')
+
+const { createSiteInfoHeader } = require('../../../../src/lib/edge-functions/proxy')
+
+test('createSiteInfoHeader builds a base64 string', (t) => {
+  const siteInfo = { id: 'site_id', name: 'site_name', url: 'site_url' }
+  const output = createSiteInfoHeader(siteInfo)
+  const parsedOutput = JSON.parse(Buffer.from(output, 'base64').toString('utf-8'))
+
+  t.deepEqual(parsedOutput, siteInfo)
+})
+
+test('createSiteInfoHeader builds a base64 string if there is no siteInfo passed', (t) => {
+  const siteInfo = {}
+  const output = createSiteInfoHeader(siteInfo)
+  const parsedOutput = JSON.parse(Buffer.from(output, 'base64').toString('utf-8'))
+
+  t.deepEqual(parsedOutput, {})
+})


### PR DESCRIPTION
#### Summary

As per request, I moved some logic to its own function and added a unit test.

I'd love to get input! Also on the style that I did it in. For example, would it have been better in its own file? (if so, how do we want to structure it? 🤔) and what do we think of the naming. (is it creating a header? or would it be better to name it `createSiteInfoBase64`?

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
