### PR TITLE
fix(graph): don't attach codegen to session metadata, and don't die when missing toml config

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -81,7 +81,7 @@
         "multiparty": "^4.2.1",
         "netlify": "^12.0.0",
         "netlify-headers-parser": "^6.0.2",
-        "netlify-onegraph-internal": "0.8.6",
+        "netlify-onegraph-internal": "0.8.7",
         "netlify-redirect-parser": "^13.0.5",
         "netlify-redirector": "^0.2.1",
         "node-fetch": "^2.6.0",
@@ -15996,9 +15996,9 @@
       }
     },
     "node_modules/netlify-onegraph-internal": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.8.6.tgz",
-      "integrity": "sha512-B8xP8eonSNDe9ytJwQVND0eJYDd2JDwedwknJqtiANe11Hw4DHlw/eWZ7CdaTLiRXjD0WbMlW088NZrUZY2rtw==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.8.7.tgz",
+      "integrity": "sha512-FDHQes/GP7UjlzAwJ+qwKfhESBo9NQDN9Ed6U+9a5CW5o2j8Lr23P9Ac1MKp7jDP5h0uAq73r9P86J9Kl1yzLQ==",
       "dependencies": {
         "graphql": "16.5.0",
         "node-fetch": "^2.6.0",
@@ -34229,9 +34229,9 @@
       }
     },
     "netlify-onegraph-internal": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.8.6.tgz",
-      "integrity": "sha512-B8xP8eonSNDe9ytJwQVND0eJYDd2JDwedwknJqtiANe11Hw4DHlw/eWZ7CdaTLiRXjD0WbMlW088NZrUZY2rtw==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/netlify-onegraph-internal/-/netlify-onegraph-internal-0.8.7.tgz",
+      "integrity": "sha512-FDHQes/GP7UjlzAwJ+qwKfhESBo9NQDN9Ed6U+9a5CW5o2j8Lr23P9Ac1MKp7jDP5h0uAq73r9P86J9Kl1yzLQ==",
       "requires": {
         "graphql": "16.5.0",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
     "multiparty": "^4.2.1",
     "netlify": "^12.0.0",
     "netlify-headers-parser": "^6.0.2",
-    "netlify-onegraph-internal": "0.8.6",
+    "netlify-onegraph-internal": "0.8.7",
     "netlify-redirect-parser": "^13.0.5",
     "netlify-redirector": "^0.2.1",
     "node-fetch": "^2.6.0",

--- a/src/lib/one-graph/cli-client.js
+++ b/src/lib/one-graph/cli-client.js
@@ -806,25 +806,6 @@ const detectLocalCLISessionMetadata = async ({ config, siteRoot }) => {
 
   const editor = process.env.EDITOR || null
 
-  /** @type {CodegenHelpers.CodegenModuleMeta | null} */
-  let codegen = null
-
-  const codegenModule = await getCodegenModule({ config })
-
-  if (codegenModule) {
-    codegen = {
-      id: codegenModule.id,
-      version: codegenModule.id,
-      generators: codegenModule.generators.map((generator) => ({
-        id: generator.id,
-        name: generator.name,
-        options: generator.generateHandlerOptions || null,
-        supportedDefinitionTypes: generator.supportedDefinitionTypes,
-        version: generator.version,
-      })),
-    }
-  }
-
   const detectedMetadata = {
     gitBranch: branch,
     hostname,
@@ -835,7 +816,6 @@ const detectLocalCLISessionMetadata = async ({ config, siteRoot }) => {
     platform,
     arch,
     nodeVersion: process.version,
-    codegen,
     framework,
   }
 
@@ -992,7 +972,13 @@ const persistNewOperationsDocForSession = async ({
   })
 
   if (!result || result.errors) {
-    warn(`Unable to update session metadata with updated operations doc ${JSON.stringify(result.errors, null, 2)}`)
+    warn(
+      `Unable to update session metadata with updated operations docId="${persistedDoc.id}": ${JSON.stringify(
+        result && result.errors,
+        null,
+        2,
+      )}`,
+    )
   } else if (lockfile != null) {
     // Now that we've persisted the document, lock it in the lockfile
     const currentOperationsDoc = readGraphQLOperationsSourceFile(netlifyGraphConfig)

--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -459,7 +459,7 @@ const generateFunctionsFile = async ({ config, netlifyGraphConfig, operationsDoc
 
   const codegenModule = await getCodegenModule({ config })
   if (!codegenModule) {
-    error(
+    warn(
       `No Netlify Graph codegen module specified in netlify.toml under the [graph] header. Please specify 'codeGenerator' field and try again.`,
     )
     return


### PR DESCRIPTION
#### Summary

Fixes an issue where session metadata would get too big and would fail to update.

Also warns when trying to generate code for Graph when missing config rather than exiting.


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Make sure the status checks below are successful ✅
