### PR TITLE
fix: supply NETLIFY_DEV to Deno

### DIFF
--- a/src/lib/edge-functions/registry.js
+++ b/src/lib/edge-functions/registry.js
@@ -24,6 +24,7 @@ class EdgeFunctionsRegistry {
    * @param {object} opts.config
    * @param {string} opts.configPath
    * @param {string[]} opts.directories
+   * @param {Record<string, string>} opts.env
    * @param {() => Promise<object>} opts.getUpdatedConfig
    * @param {EdgeFunction[]} opts.internalFunctions
    * @param {string} opts.projectDir
@@ -197,6 +198,7 @@ class EdgeFunctionsRegistry {
     })
 
     env.DENO_REGION = 'local'
+    env.NETLIFY_DEV = 'true'
     // We use it in the bootstrap layer to detect whether we're running in production or not
     // (see https://github.com/netlify/edge-functions-bootstrap/blob/main/src/bootstrap/environment.ts#L2)
     // env.DENO_DEPLOYMENT_ID = 'xxx='

--- a/tests/integration/100.command.dev.test.js
+++ b/tests/integration/100.command.dev.test.js
@@ -603,11 +603,12 @@ test('should have only allowed environment variables set', async (t) => {
           // t.is(response.DENO_DEPLOYMENT_ID, 'xxx=')
           t.true(envKeys.includes('DENO_REGION'))
           t.is(response.DENO_REGION, 'local')
+          t.true(envKeys.includes('NETLIFY_DEV'))
+          t.is(response.NETLIFY_DEV, 'true')
           t.true(envKeys.includes('SECRET_ENV'))
           t.is(response.SECRET_ENV, 'true')
 
           t.false(envKeys.includes('NODE_ENV'))
-          t.false(envKeys.includes('NETLIFY_DEV'))
           t.false(envKeys.includes('DEPLOY_URL'))
           t.false(envKeys.includes('URL'))
         },


### PR DESCRIPTION
#### Summary

As discussed in Slack, this environment variable is used in plugins to differentiate between dev and prod.