### PR TITLE
fix(ci): do not build site during prerelease workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,8 +18,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install core dependencies
         run: npm ci --no-audit
-      - name: Install and build site
-        run: npm run site:build
+      - name: Install site dependencies
+        run: npm run site:build:install
       - name: Extract tag and version
         id: extract
         run: |-


### PR DESCRIPTION
#### Summary

This PR fixes the pre-release workflow in CI by installing dependencies for the site, but not building the site. A new site build isn't necessary for a prerelease version, and skipping that step allows the workflow to succeed in CI. 

[Relevant Slack thread](https://netlify.slack.com/archives/CN8S7NB29/p1660759755607129)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img width="644" alt="Screenshot 2022-08-17 at 12 45 21" src="https://user-images.githubusercontent.com/236451/185228954-5fa62eb8-c7ac-4322-936f-c666b2cca3de.png">

