### PR TITLE
feat: add `.netlify` to `.gitignore` in Netlify Dev

### DIFF
--- a/src/commands/dev/dev.js
+++ b/src/commands/dev/dev.js
@@ -35,6 +35,7 @@ const {
   NETLIFYDEVWARN,
   chalk,
   detectServerSettings,
+  ensureNetlifyIgnore,
   error,
   exit,
   generateNetlifyGraphJWT,
@@ -507,6 +508,13 @@ const dev = async (options, command) => {
 
   if (!success) {
     error(`Could not start local development server\n\n${startDevError.message}\n\n${startDevError.stack}`)
+  }
+
+  // Try to add `.netlify` to `.gitignore`.
+  try {
+    await ensureNetlifyIgnore(repositoryRoot)
+  } catch {
+    // no-op
   }
 
   // TODO: We should consolidate this with the existing config watcher.

--- a/tests/integration/0.command.dev.test.js
+++ b/tests/integration/0.command.dev.test.js
@@ -372,9 +372,10 @@ test('should add `.netlify` to an existing `.gitignore` file', async (t) => {
       .buildAsync()
 
     await withDevServer({ cwd: builder.directory }, async () => {
-      const contents = await fs.readFile(join(builder.directory, '.gitignore'), 'utf8')
+      const gitignore = await fs.readFile(join(builder.directory, '.gitignore'), 'utf8')
+      const entries = gitignore.split('\n')
 
-      t.deepEqual(contents, [...existingGitIgnore, '# Local Netlify folder', '.netlify', ''].join('\n'))
+      t.true(entries.includes('.netlify'))
     })
   })
 })
@@ -389,9 +390,10 @@ test('should create a `.gitignore` file with `.netlify`', async (t) => {
       .buildAsync()
 
     await withDevServer({ cwd: builder.directory }, async () => {
-      const contents = await fs.readFile(join(builder.directory, '.gitignore'), 'utf8')
+      const gitignore = await fs.readFile(join(builder.directory, '.gitignore'), 'utf8')
+      const entries = gitignore.split('\n')
 
-      t.deepEqual(contents, ['# Local Netlify folder', '.netlify', ''].join('\n'))
+      t.true(entries.includes('.netlify'))
     })
   })
 })


### PR DESCRIPTION
#### Summary

We automatically add the `.netlify` directory to `.gitignore` as part of the `link` and `init` commands. This PR extends that behaviour to `dev`.