### PR TITLE
feat: simplify `init` and `link` flows

### DIFF
--- a/src/commands/init/init.js
+++ b/src/commands/init/init.js
@@ -198,6 +198,8 @@ const init = async (options, command) => {
     siteInfo = await createOrLinkSiteToRepo(command)
   }
 
+  log()
+
   // Check for existing CI setup
   const remoteBuildRepo = getRepoUrl({ siteInfo })
   if (remoteBuildRepo && !options.force) {

--- a/src/commands/link/link.js
+++ b/src/commands/link/link.js
@@ -1,8 +1,4 @@
 // @ts-check
-const { join, relative } = require('path')
-const path = require('path')
-const { cwd } = require('process')
-
 const inquirer = require('inquirer')
 const isEmpty = require('lodash/isEmpty')
 
@@ -292,7 +288,7 @@ const link = async (options, command) => {
 
     // Save site ID
     state.set('siteId', siteData.id)
-    log(`Linked to ${siteData.name} in ${state.path}`)
+    log(`Linked to ${siteData.name}`)
 
     await track('sites_linked', {
       siteId: siteData.id,
@@ -323,7 +319,7 @@ const link = async (options, command) => {
     const [firstSiteData] = results
     state.set('siteId', firstSiteData.id)
 
-    log(`Linked to ${firstSiteData.name} in ${relative(join(cwd(), '..'), state.path)}`)
+    log(`Linked to ${firstSiteData.name}`)
 
     await track('sites_linked', {
       siteId: (firstSiteData && firstSiteData.id) || siteId,

--- a/src/commands/link/link.js
+++ b/src/commands/link/link.js
@@ -234,10 +234,6 @@ or run ${chalk.cyanBright('netlify sites:create')} to create a site.`)
   log(`Admin url: ${chalk.magentaBright(site.admin_url)}`)
   log(`Site url:  ${chalk.cyanBright(site.ssl_url || site.url)}`)
   log()
-
-  log(`Site id saved to ${path.join(netlify.site.root, '/.netlify/state.json')}`)
-  // log(`Local Config: .netlify/config.json`)
-  log()
   log(`You can now run other \`netlify\` cli commands in this directory`)
 
   return site

--- a/src/commands/sites/sites-create.js
+++ b/src/commands/sites/sites-create.js
@@ -39,16 +39,14 @@ const getSiteNameInput = async (name, user, api) => {
     ]
     siteSuggestion = sample(suggestions)
 
-    console.log(
-      `Choose a unique site name (e.g. ${siteSuggestion}.netlify.app) or leave it blank for a random name. You can update the site name later.`,
-    )
     const { name: nameInput } = await inquirer.prompt([
       {
         type: 'input',
         name: 'name',
-        message: 'Site name (optional):',
-        filter: (val) => (val === '' ? undefined : val),
-        validate: (input) => /^[a-zA-Z\d-]+$/.test(input) || 'Only alphanumeric characters and hyphens are allowed',
+        message: 'Site name (you can change it later):',
+        default: siteSuggestion,
+        validate: (input) =>
+          /^[a-zA-Z\d-]+$/.test(input || undefined) || 'Only alphanumeric characters and hyphens are allowed',
       },
     ])
     name = nameInput || siteSuggestion

--- a/src/utils/init/config-github.js
+++ b/src/utils/init/config-github.js
@@ -224,6 +224,8 @@ const configGithub = async ({ command, repoName, repoOwner, siteId }) => {
   })
   await saveNetlifyToml({ repositoryRoot, config, configPath, baseDir, buildCmd, buildDir, functionsDir })
 
+  log()
+
   const octokit = getGitHubClient(token)
   const [deployKey, githubRepo] = await Promise.all([
     addDeployKey({ api, octokit, repoOwner, repoName }),

--- a/src/utils/init/plugins.js
+++ b/src/utils/init/plugins.js
@@ -1,38 +1,10 @@
-const fetch = require('node-fetch')
-
-// TODO: use static `import` after migrating this repository to pure ES modules
-const netlifyPluginsList = import('@netlify/plugins-list')
-
-// 1 minute
-const PLUGINS_LIST_TIMEOUT = 6e4
-
-const getPluginsList = async () => {
-  const { pluginsList, pluginsUrl } = await netlifyPluginsList
-  try {
-    const response = await fetch(pluginsUrl, { timeout: PLUGINS_LIST_TIMEOUT })
-    return await response.json()
-  } catch {
-    return pluginsList
-  }
-}
-
-const getPluginInfo = (list, packageName) => list.find(({ package }) => package === packageName)
-
 const isPluginInstalled = (configPlugins, plugin) =>
   configPlugins.some(({ package: configPlugin }) => configPlugin === plugin)
 
 const getRecommendPlugins = (frameworkPlugins, config) =>
   frameworkPlugins.filter((plugin) => !isPluginInstalled(config.plugins, plugin))
 
-const getPluginsToInstall = ({ installSinglePlugin, plugins, recommendedPlugins }) => {
-  if (Array.isArray(plugins)) {
-    return plugins.map((plugin) => ({ package: plugin }))
-  }
-
-  return installSinglePlugin === true ? [{ package: recommendedPlugins[0] }] : []
-}
-
 const getUIPlugins = (configPlugins) =>
   configPlugins.filter(({ origin }) => origin === 'ui').map(({ package }) => ({ package }))
 
-module.exports = { getPluginsList, getPluginInfo, getRecommendPlugins, getPluginsToInstall, getUIPlugins }
+module.exports = { getRecommendPlugins, getUIPlugins }

--- a/src/utils/init/utils.js
+++ b/src/utils/init/utils.js
@@ -14,7 +14,7 @@ const { chalk, error: failAndExit, warn } = require('../command-helpers')
 
 const { getFrameworkInfo } = require('./frameworks')
 const { detectNodeVersion } = require('./node-version')
-const { getPluginInfo, getPluginsList, getPluginsToInstall, getRecommendPlugins, getUIPlugins } = require('./plugins')
+const { getRecommendPlugins, getUIPlugins } = require('./plugins')
 
 const normalizeDir = ({ baseDirectory, defaultValue, dir }) => {
   if (dir === undefined) {
@@ -55,14 +55,7 @@ const getDefaultSettings = ({
   }
 }
 
-const getPromptInputs = async ({
-  defaultBaseDir,
-  defaultBuildCmd,
-  defaultBuildDir,
-  defaultFunctionsDir,
-  frameworkName,
-  recommendedPlugins,
-}) => {
+const getPromptInputs = ({ defaultBaseDir, defaultBuildCmd, defaultBuildDir, defaultFunctionsDir }) => {
   const inputs = [
     defaultBaseDir !== undefined && {
       type: 'input',
@@ -91,42 +84,7 @@ const getPromptInputs = async ({
     },
   ].filter(Boolean)
 
-  if (recommendedPlugins.length === 0) {
-    return inputs
-  }
-
-  const pluginsList = await getPluginsList()
-
-  const prefix = `Seems like this is a ${formatTitle(frameworkName)} site.${EOL}❇️  `
-  if (recommendedPlugins.length === 1) {
-    const { name } = getPluginInfo(pluginsList, recommendedPlugins[0])
-    return [
-      ...inputs,
-      {
-        type: 'confirm',
-        name: 'installSinglePlugin',
-        message: `${prefix}We're going to install this Build Plugin: ${formatTitle(
-          `${name} plugin`,
-        )}${EOL}➡️  OK to install?`,
-        default: true,
-      },
-    ]
-  }
-
-  const infos = recommendedPlugins.map((packageName) => getPluginInfo(pluginsList, packageName))
-  return [
-    ...inputs,
-    {
-      type: 'checkbox',
-      name: 'plugins',
-      message: `${prefix}We're going to install these plugins: ${infos
-        .map(({ name }) => `${name} plugin`)
-        .map(formatTitle)
-        .join(', ')}${EOL}➡️  OK to install??`,
-      choices: infos.map((info) => ({ name: `${info.name} plugin`, value: info.package })),
-      default: infos.map((info) => info.package),
-    },
-  ]
+  return inputs.filter(Boolean)
 }
 
 // `repositoryRoot === siteRoot` means the base directory wasn't detected by @netlify/config, so we use cwd()
@@ -154,22 +112,15 @@ const getBuildSettings = async ({ config, env, repositoryRoot, siteRoot }) => {
       frameworkBuildDir,
       frameworkPlugins,
     })
-  const { baseDir, buildCmd, buildDir, functionsDir, installSinglePlugin, plugins } = await inquirer.prompt(
-    await getPromptInputs({
+  const { baseDir, buildCmd, buildDir, functionsDir } = await inquirer.prompt(
+    getPromptInputs({
+      defaultBaseDir,
       defaultBuildCmd,
       defaultBuildDir,
       defaultFunctionsDir,
-      defaultBaseDir,
-      recommendedPlugins,
-      frameworkName,
     }),
   )
-  const pluginsToInstall = getPluginsToInstall({
-    plugins,
-    installSinglePlugin,
-    recommendedPlugins,
-  })
-
+  const pluginsToInstall = recommendedPlugins.map((plugin) => ({ package: plugin }))
   const normalizedBaseDir = baseDir ? normalizeBackslash(baseDir) : undefined
 
   return { baseDir: normalizedBaseDir, buildCmd, buildDir, functionsDir, pluginsToInstall }

--- a/src/utils/init/utils.js
+++ b/src/utils/init/utils.js
@@ -55,7 +55,7 @@ const getDefaultSettings = ({
   }
 }
 
-const getPromptInputs = ({ defaultBaseDir, defaultBuildCmd, defaultBuildDir, defaultFunctionsDir }) => {
+const getPromptInputs = ({ defaultBaseDir, defaultBuildCmd, defaultBuildDir }) => {
   const inputs = [
     defaultBaseDir !== undefined && {
       type: 'input',
@@ -75,12 +75,6 @@ const getPromptInputs = ({ defaultBaseDir, defaultBuildCmd, defaultBuildDir, def
       name: 'buildDir',
       message: 'Directory to deploy (blank for current dir):',
       default: defaultBuildDir,
-    },
-    {
-      type: 'input',
-      name: 'functionsDir',
-      message: 'Netlify functions folder:',
-      default: defaultFunctionsDir,
     },
   ].filter(Boolean)
 
@@ -112,18 +106,17 @@ const getBuildSettings = async ({ config, env, repositoryRoot, siteRoot }) => {
       frameworkBuildDir,
       frameworkPlugins,
     })
-  const { baseDir, buildCmd, buildDir, functionsDir } = await inquirer.prompt(
+  const { baseDir, buildCmd, buildDir } = await inquirer.prompt(
     getPromptInputs({
       defaultBaseDir,
       defaultBuildCmd,
       defaultBuildDir,
-      defaultFunctionsDir,
     }),
   )
   const pluginsToInstall = recommendedPlugins.map((plugin) => ({ package: plugin }))
   const normalizedBaseDir = baseDir ? normalizeBackslash(baseDir) : undefined
 
-  return { baseDir: normalizedBaseDir, buildCmd, buildDir, functionsDir, pluginsToInstall }
+  return { baseDir: normalizedBaseDir, buildCmd, buildDir, functionsDir: defaultFunctionsDir, pluginsToInstall }
 }
 
 const getNetlifyToml = ({

--- a/src/utils/init/utils.js
+++ b/src/utils/init/utils.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { existsSync } = require('fs')
 const { writeFile } = require('fs').promises
-const { EOL } = require('os')
 const path = require('path')
 const process = require('process')
 
@@ -10,6 +9,7 @@ const inquirer = require('inquirer')
 const isEmpty = require('lodash/isEmpty')
 
 const { normalizeBackslash } = require('../../lib/path')
+const { log } = require('../command-helpers')
 const { chalk, error: failAndExit, warn } = require('../command-helpers')
 
 const { getFrameworkInfo } = require('./frameworks')
@@ -106,6 +106,12 @@ const getBuildSettings = async ({ config, env, repositoryRoot, siteRoot }) => {
       frameworkBuildDir,
       frameworkPlugins,
     })
+
+  if (recommendedPlugins.length !== 0) {
+    log(`Configuring ${formatTitle(frameworkName)} runtime...`)
+    log()
+  }
+
   const { baseDir, buildCmd, buildDir } = await inquirer.prompt(
     getPromptInputs({
       defaultBaseDir,
@@ -113,6 +119,7 @@ const getBuildSettings = async ({ config, env, repositoryRoot, siteRoot }) => {
       defaultBuildDir,
     }),
   )
+
   const pluginsToInstall = recommendedPlugins.map((plugin) => ({ package: plugin }))
   const normalizedBaseDir = baseDir ? normalizeBackslash(baseDir) : undefined
 

--- a/tests/integration/420.command.init.test.js
+++ b/tests/integration/420.command.init.test.js
@@ -11,6 +11,8 @@ const { CONFIRM, DOWN, answerWithValue, handleQuestions } = require('./utils/han
 const { withMockApi } = require('./utils/mock-api')
 const { withSiteBuilder } = require('./utils/site-builder')
 
+const defaultFunctionsDirectory = 'netlify/functions'
+
 // TODO: Flaky tests enable once fixed
 /**
  * As some of the tests are flaky on windows machines I will skip them for now
@@ -90,7 +92,7 @@ test('netlify init existing site', async (t) => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: 'netlify/functions',
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -112,20 +114,20 @@ test('netlify init existing site', async (t) => {
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions: 'netlify/functions', publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: defaultFunctionsDirectory, publish })
     })
   })
 })
 
 test('netlify init new site', async (t) => {
-  const [command, publish, functions] = ['custom-build-command', 'custom-publish', 'custom-functions']
+  const [command, publish] = ['custom-build-command', 'custom-publish']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Your build command (hugo build/yarn run build/etc)',
       answer: answerWithValue(command),
@@ -133,10 +135,6 @@ test('netlify init new site', async (t) => {
     {
       question: 'Directory to deploy (blank for current dir)',
       answer: answerWithValue(publish),
-    },
-    {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
     },
     {
       question: 'No netlify.toml detected',
@@ -188,7 +186,7 @@ test('netlify init new site', async (t) => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -209,20 +207,20 @@ test('netlify init new site', async (t) => {
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions, publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: defaultFunctionsDirectory, publish })
     })
   })
 })
 
 test('netlify init new Next.js site', async (t) => {
-  const [command, publish, functions] = ['custom-build-command', 'custom-publish', 'custom-functions']
+  const [command, publish] = ['custom-build-command', 'custom-publish']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Your build command (hugo build/yarn run build/etc)',
       answer: answerWithValue(command),
@@ -232,10 +230,6 @@ test('netlify init new Next.js site', async (t) => {
       answer: answerWithValue(publish),
     },
     {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
-    },
-    {
       question: 'OK to install',
       answer: CONFIRM,
     },
@@ -290,7 +284,7 @@ test('netlify init new Next.js site', async (t) => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -313,20 +307,20 @@ test('netlify init new Next.js site', async (t) => {
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions, publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: defaultFunctionsDirectory, publish })
     })
   })
 })
 
 test('netlify init new Next.js site with correct default build directory and build command', async (t) => {
-  const [command, publish, functions] = ['next build', '.next', 'custom-functions']
+  const [command, publish] = ['next build', '.next']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Your build command (hugo build/yarn run build/etc)',
       answer: CONFIRM,
@@ -336,10 +330,6 @@ test('netlify init new Next.js site with correct default build directory and bui
       answer: CONFIRM,
     },
     {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
-    },
-    {
       question: 'OK to install',
       answer: CONFIRM,
     },
@@ -394,7 +384,7 @@ test('netlify init new Next.js site with correct default build directory and bui
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -417,7 +407,7 @@ test('netlify init new Next.js site with correct default build directory and bui
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions, publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: defaultFunctionsDirectory, publish })
     })
   })
 })
@@ -512,14 +502,14 @@ test('netlify init existing Next.js site with existing plugins', async () => {
 })
 
 test('netlify init new Gatsby site with correct default build directory and build command', async (t) => {
-  const [command, publish, functions] = ['gatsby build', 'public', 'custom-functions']
+  const [command, publish] = ['gatsby build', 'public']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Your build command (hugo build/yarn run build/etc)',
       answer: CONFIRM,
@@ -527,10 +517,6 @@ test('netlify init new Gatsby site with correct default build directory and buil
     {
       question: 'Directory to deploy (blank for current dir)',
       answer: CONFIRM,
-    },
-    {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
     },
     {
       question: 'OK to install',
@@ -587,7 +573,7 @@ test('netlify init new Gatsby site with correct default build directory and buil
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -614,7 +600,7 @@ test('netlify init new Gatsby site with correct default build directory and buil
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions, publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: defaultFunctionsDirectory, publish })
     })
   })
 })
@@ -626,7 +612,7 @@ windowsSkip('netlify init monorepo root and sub directory without netlify.toml',
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Base directory (e.g. projects/frontend):',
       answer: CONFIRM,
@@ -693,7 +679,7 @@ windowsSkip('netlify init monorepo root and sub directory without netlify.toml',
           repo_branch: 'main',
           base: 'projects/project1',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: 'netlify/functions',
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -732,7 +718,7 @@ windowsSkip('netlify init monorepo root and sub directory without netlify.toml',
 
       await assertNetlifyToml(t, `${builder.directory}/projects/project1`, {
         command: '# no build command',
-        functions: 'netlify/functions',
+        functions: defaultFunctionsDirectory,
         publish: '.',
       })
     })
@@ -746,7 +732,7 @@ test('netlify init monorepo root with netlify.toml, subdirectory without netlify
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Base directory (e.g. projects/frontend):',
       answer: CONFIRM,
@@ -814,7 +800,7 @@ test('netlify init monorepo root with netlify.toml, subdirectory without netlify
           repo_branch: 'main',
           base: 'projects/project2',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: 'netlify/functions',
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },
@@ -854,7 +840,7 @@ test('netlify init monorepo root with netlify.toml, subdirectory without netlify
 
       await assertNetlifyToml(t, `${builder.directory}/projects/project2`, {
         command: '# no build command',
-        functions: 'netlify/functions',
+        functions: defaultFunctionsDirectory,
         publish: '.',
       })
     })
@@ -868,7 +854,7 @@ windowsSkip('netlify init monorepo root and sub directory with netlify.toml', as
       answer: answerWithValue(DOWN),
     },
     { question: 'Team: (Use arrow keys)', answer: CONFIRM },
-    { question: 'Site name (optional)', answer: answerWithValue('test-site-name') },
+    { question: 'Site name (you can change it later)', answer: answerWithValue('test-site-name') },
     {
       question: 'Base directory (e.g. projects/frontend):',
       answer: CONFIRM,
@@ -932,7 +918,7 @@ windowsSkip('netlify init monorepo root and sub directory with netlify.toml', as
           repo_branch: 'main',
           base: 'projects/project2',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: 'netlify/functions',
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },

--- a/tests/integration/420.command.init.test.js
+++ b/tests/integration/420.command.init.test.js
@@ -30,7 +30,7 @@ const assertNetlifyToml = async (t, tomlDir, { command, functions, publish }) =>
 }
 
 test('netlify init existing site', async (t) => {
-  const [command, publish, functions] = ['custom-build-command', 'custom-publish', 'custom-functions']
+  const [command, publish] = ['custom-build-command', 'custom-publish']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
@@ -47,10 +47,6 @@ test('netlify init existing site', async (t) => {
     {
       question: 'Directory to deploy (blank for current dir)',
       answer: answerWithValue(publish),
-    },
-    {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
     },
     {
       question: 'No netlify.toml detected',
@@ -94,7 +90,7 @@ test('netlify init existing site', async (t) => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: 'netlify/functions',
         },
       },
     },
@@ -116,7 +112,7 @@ test('netlify init existing site', async (t) => {
 
       await childProcess
 
-      await assertNetlifyToml(t, builder.directory, { command, functions, publish })
+      await assertNetlifyToml(t, builder.directory, { command, functions: 'netlify/functions', publish })
     })
   })
 })
@@ -427,7 +423,7 @@ test('netlify init new Next.js site with correct default build directory and bui
 })
 
 test('netlify init existing Next.js site with existing plugins', async () => {
-  const [command, publish, functions] = ['custom-build-command', 'custom-publish', 'custom-functions']
+  const [command, publish] = ['custom-build-command', 'custom-publish', 'custom-functions']
   const initQuestions = [
     {
       question: 'Create & configure a new site',
@@ -444,10 +440,6 @@ test('netlify init existing Next.js site with existing plugins', async () => {
     {
       question: 'Directory to deploy (blank for current dir)',
       answer: answerWithValue(publish),
-    },
-    {
-      question: 'Netlify functions folder',
-      answer: answerWithValue(functions),
     },
     {
       question: 'OK to install',
@@ -491,7 +483,7 @@ test('netlify init existing Next.js site with existing plugins', async () => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: functions,
+          functions_dir: 'netlify/functions',
         },
       },
     },

--- a/tests/integration/420.command.init.test.js
+++ b/tests/integration/420.command.init.test.js
@@ -473,7 +473,7 @@ test('netlify init existing Next.js site with existing plugins', async () => {
           provider: 'manual',
           repo_branch: 'main',
           repo_path: 'git@github.com:owner/repo.git',
-          functions_dir: 'netlify/functions',
+          functions_dir: defaultFunctionsDirectory,
         },
       },
     },


### PR DESCRIPTION
#### Summary

This PR contains a few changes to streamline the `init` and `dev` commands:

- Remove message in `link` command pointing to the location of the `state.json` file: https://github.com/netlify/cli/commit/0322ed5949d3807d5c2a68e7e298b5075f458703
- Automatically install recommended plugins in `init` command: https://github.com/netlify/cli/commit/8b4d91c9383de8b906bb2cbbe9ad37e1e94c1139
- Stop prompting users for the functions directory and use default instead: https://github.com/netlify/cli/commit/efc45b5f32582826cdf99bf463b2eb7f74017fcf
- Remove location of `state.json` in `link` confirmation message: https://github.com/netlify/cli/commit/62c566cf5bb8e33a63c7b8e055753ef727c55b24
- Add blank line around prompts: https://github.com/netlify/cli/commit/8d317004d963fea7d195cc06b4d873b91575d175
- Add "Configuring <framework> runtime..." message: https://github.com/netlify/cli/commit/8a3e1828a27525a79bee69c3bde7c22ad166b6a9
- Stop showing `undefined` when default site name is chosen: https://github.com/netlify/cli/commit/c3b1a69e9cdfc3ec82be900a6b9e75d22e197d5f