### PR TITLE
fix: graph code generator TOML injection

### DIFF
--- a/src/lib/one-graph/cli-netlify-graph.js
+++ b/src/lib/one-graph/cli-netlify-graph.js
@@ -79,7 +79,7 @@ ${entry}`
   const codegenKeyLine = lines.findIndex((line) => line.trim().startsWith('codeGenerator'))
   const hasCodegenKeyLine = codegenKeyLine !== 1
 
-  if (hasCodegenKeyLine) {
+  if (hasGraphKey && hasCodegenKeyLine) {
     lines.splice(codegenKeyLine, 1, entry)
   } else if (hasGraphKey) {
     lines.splice(graphKeyLine, 0, entry)
@@ -1017,7 +1017,6 @@ module.exports = {
   buildSchema,
   defaultExampleOperationsDoc: NetlifyGraph.defaultExampleOperationsDoc,
   extractFunctionsFromOperationDoc: NetlifyGraph.extractFunctionsFromOperationDoc,
-  generateFunctionsSource: NetlifyGraph.generateFunctionsSource,
   generateFunctionsFile,
   generateHandlerSource: NetlifyGraph.generateHandlerSource,
   generateHandlerByOperationId,


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

- Fixes an issue that can happen when a `netlify.toml` doesn't have any `[graph]` configuration

Previously we could generate:

```toml

[some_config]
foo
codeGenerator = "foo"
```

Now we generate
```toml

[some_config]
foo

[graph]
codeGenerator = "foo"
```

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
