### PR TITLE
feat: Revert run framework detection and run plugins on netlify build

### DIFF
--- a/src/commands/build/build.js
+++ b/src/commands/build/build.js
@@ -7,7 +7,11 @@ const { error, exit, generateNetlifyGraphJWT, getEnvelopeEnv, getToken, normaliz
 /**
  * @param {import('../../lib/build').BuildConfig} options
  */
-const checkOptions = ({ token }) => {
+const checkOptions = ({ cachedConfig: { siteInfo = {} }, token }) => {
+  if (!siteInfo.id) {
+    error('Could not find the site ID. Please run netlify link.')
+  }
+
   if (!token) {
     error('Could not find the access token. Please run netlify login.')
   }
@@ -68,7 +72,7 @@ const build = async (options, command) => {
     await injectEnv(command, { api, buildOptions, context, site, siteInfo })
   }
 
-  const { exitCode } = await runBuild(buildOptions, command, options)
+  const { exitCode } = await runBuild(buildOptions)
   exit(exitCode)
 }
 

--- a/src/commands/deploy/deploy.js
+++ b/src/commands/deploy/deploy.js
@@ -375,11 +375,10 @@ const runDeploy = async ({
  *
  * @param {object} config
  * @param {*} config.cachedConfig
- * @param {*} config.command
  * @param {import('commander').OptionValues} config.options The options of the command
  * @returns
  */
-const handleBuild = async ({ cachedConfig, command, options }) => {
+const handleBuild = async ({ cachedConfig, options }) => {
   if (!options.build) {
     return {}
   }
@@ -389,7 +388,7 @@ const handleBuild = async ({ cachedConfig, command, options }) => {
     token,
     options,
   })
-  const { configMutations, exitCode, newConfig } = await runBuild(resolvedOptions, command, options)
+  const { configMutations, exitCode, newConfig } = await runBuild(resolvedOptions)
   if (exitCode !== 0) {
     exit(exitCode)
   }
@@ -574,7 +573,6 @@ const deploy = async (options, command) => {
 
   const { newConfig, configMutations = [] } = await handleBuild({
     cachedConfig: command.netlify.cachedConfig,
-    command,
     options,
   })
   const config = newConfig || command.netlify.config

--- a/src/utils/detect-server-settings.js
+++ b/src/utils/detect-server-settings.js
@@ -158,10 +158,7 @@ const handleStaticServer = async ({ devConfig, options, projectDir }) => {
  */
 const getSettingsFromFramework = (framework) => {
   const {
-    build: {
-      directory: dist,
-      commands: [buildCommand],
-    },
+    build: { directory: dist },
     dev: {
       commands: [command],
       port: frameworkPort,
@@ -175,7 +172,6 @@ const getSettingsFromFramework = (framework) => {
 
   return {
     command,
-    buildCommand,
     frameworkPort,
     dist: staticDir || dist,
     framework: frameworkName,
@@ -254,7 +250,6 @@ const handleCustomFramework = ({ devConfig }) => {
 const mergeSettings = async ({ devConfig, frameworkSettings = {} }) => {
   const {
     command: frameworkCommand,
-    buildCommand,
     frameworkPort: frameworkDetectedPort,
     dist,
     framework,
@@ -268,7 +263,6 @@ const mergeSettings = async ({ devConfig, frameworkSettings = {} }) => {
   const useStaticServer = !(command && frameworkPort)
   return {
     command,
-    buildCommand,
     frameworkPort: useStaticServer ? await getStaticServerPort({ devConfig }) : frameworkPort,
     dist: devConfig.publish || dist || getDefaultDist(),
     framework,

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -3,7 +3,6 @@ export type FrameworkNames = '#static' | '#auto' | '#custom' | string
 export type FrameworkInfo = {
   build: {
     directory: string
-    commands: string[]
   }
   dev: {
     commands: string[]
@@ -33,8 +32,6 @@ export type BaseServerSettings = {
   env?: NodeJS.ProcessEnv
   pollingStrategies?: string[]
   plugins?: string[]
-  /** The command that was provided for the dev config */
-  buildCommand?: string
 }
 
 export type ServerSettings = BaseServerSettings & {

--- a/tests/integration/110.command.build.test.js
+++ b/tests/integration/110.command.build.test.js
@@ -241,6 +241,23 @@ test('should error when using invalid netlify.toml', async (t) => {
   })
 })
 
+test('should error when a site id is missing', async (t) => {
+  await withSiteBuilder('no-site-id-site', async (builder) => {
+    builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
+
+    await builder.buildAsync()
+
+    await withMockApi(routes, async ({ apiUrl }) => {
+      await runBuildCommand(t, builder.directory, {
+        apiUrl,
+        exitCode: 1,
+        output: 'Could not find the site ID',
+        env: { ...defaultEnvs, NETLIFY_SITE_ID: '' },
+      })
+    })
+  })
+})
+
 test('should not require a linked site when offline flag is set', async (t) => {
   await withSiteBuilder('success-site', async (builder) => {
     await builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } }).buildAsync()
@@ -265,30 +282,6 @@ test('should not send network requests when offline flag is set', async (t) => {
       })
 
       t.is(requests.length, 0)
-    })
-  })
-})
-
-test('should run without site id', async (t) => {
-  await withSiteBuilder('success-site', async (builder) => {
-    builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
-
-    await builder.buildAsync()
-    await withMockApi(routesWithCommand, async ({ apiUrl }) => {
-      await runBuildCommand(t, builder.directory, { apiUrl, output: 'testCommand' })
-    })
-  })
-})
-
-test('should add plugin if framework is detected', async (t) => {
-  await withSiteBuilder('success-site', async (builder) => {
-    builder.withPackageJson({ packageJson: { dependencies: { next: '^12.2.0' }, scripts: { build: 'next build' } } })
-
-    await builder.buildAsync()
-
-    await withMockApi(routes, async ({ apiUrl }) => {
-      // Error expected as this isn't a real next app
-      await runBuildCommand(t, builder.directory, { apiUrl, output: '@netlify/plugin-nextjs', exitCode: 2 })
     })
   })
 })


### PR DESCRIPTION
#### Summary

This reverts commit c85efc45bd46ee4038fbe44f64fe99ce0b25eb7b. (PR: https://github.com/netlify/cli/pull/5029) which added framework detection on netlify build and netlify deploy --build

Due to a number of issues, I'm reverting this feature until some bugs have been ironed out and more thoroughly tested. 

Related:
https://github.com/netlify/cli/issues/5080
https://github.com/netlify/cli/issues/5036
https://github.com/netlify/cli/issues/5082

