### PR TITLE
chore: fix grouping of renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,5 +8,15 @@
       matchPackageNames: ['netlify-onegraph-internal'],
       enabled: false,
     },
+    {
+      "matchManagers": ["npm"],
+      "matchSourceUrlPrefixes": ["https://github.com/netlify/build"],
+      "groupName": "Netlify packages"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@netlify/zip-it-and-ship-it"],
+      "groupName": "Netlify packages"
+    },
   ],
 }


### PR DESCRIPTION
#### Summary

Before I update these grouping rules in the shared config, I wanted to test them here. In the [shared config](https://github.com/netlify/renovate-config/blob/main/shared.json#L19-L24) I think they are wrong as `matchSourceUrlPrefixes` and `matchPackageNames` are combined with AND, which doesn't match anything.

Let's see if this does fix the grouping.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
