### PR TITLE
chore: print env var scope during ntl dev

### DIFF
--- a/src/commands/dev/dev.cjs
+++ b/src/commands/dev/dev.cjs
@@ -448,7 +448,7 @@ const dev = async (options, command) => {
 
   if (!options.offline && siteInfo.use_envelope) {
     env = await getEnvelopeEnv({ api, context: options.context, env, siteInfo })
-    log(`${NETLIFYDEVLOG} Injecting environment variable values from ${chalk.yellow('all scopes')}`)
+    log(`${NETLIFYDEVLOG} Injecting environment variable values for ${chalk.yellow('all scopes')}`)
   }
 
   await injectEnvVariables({ devConfig, env, site })

--- a/src/commands/dev/dev.cjs
+++ b/src/commands/dev/dev.cjs
@@ -448,6 +448,7 @@ const dev = async (options, command) => {
 
   if (!options.offline && siteInfo.use_envelope) {
     env = await getEnvelopeEnv({ api, context: options.context, env, siteInfo })
+    log(`${NETLIFYDEVLOG} Injecting environment variable values from ${chalk.yellow('all scopes')}`)
   }
 
   await injectEnvVariables({ devConfig, env, site })


### PR DESCRIPTION
#### Summary

![Screenshot 2022-10-27 at 10 06 29](https://user-images.githubusercontent.com/236451/198354377-ef8e4253-d6ab-4985-ad70-869b1eddb560.png)


This PR prints a message for sites that are using Envelope during `netlify dev` that environment variable values are being used for all scopes. This local behavior is slightly different than what occurs on Netlify, as env vars can be scoped to e.g. builds _or_ functions. Locally, this scoping doesn't happen -- everything is available in the same `process.env`. This log hopefully brings attention to that difference! 

Fixes https://github.com/netlify/pillar-workflow/issues/812

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
