### PR TITLE
fix: prevent cli install for incompatible node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "/bin",
     "/npm-shrinkwrap.json",
     "/scripts/postinstall.mjs",
+    "/scripts/preinstall.cjs",
     "/src/**/*.cjs",
     "/src/**/*.js",
     "/src/**/*.mjs",
@@ -220,6 +221,7 @@
     "site:build": "run-s site:build:*",
     "site:build:install": "cd site && npm ci --no-audit",
     "site:build:assets": "cd site && npm run build",
+    "preinstall": "node ./scripts/preinstall.cjs",
     "postinstall": "node ./scripts/postinstall.mjs",
     "certs": "openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -subj \"/CN=localhost\" -extensions EXT -config certconf"
   },

--- a/scripts/preinstall.cjs
+++ b/scripts/preinstall.cjs
@@ -1,0 +1,17 @@
+const process = require('process')
+
+const semver = require('semver')
+
+const { engines } = require('../package.json')
+
+const checkForSupportedNodeVersion = () => {
+  const requiredVersion = engines.node
+  const currentVersion = process.version
+
+  if (!semver.satisfies(currentVersion, requiredVersion)) {
+    console.log(`Netlify CLI requires NodeJS version ${requiredVersion} ; Current version is ${currentVersion}`)
+    process.exit(1)
+  }
+}
+
+checkForSupportedNodeVersion()


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #4489 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

Netlify CLI currently installs for incompatible NodeJS versions (may show a warning) but fails when Netlify CLI runs due to newer features/syntax not being supported by older versions of NodeJS.

This PR adds a preinstall script to report an error & prevent installing Netlify CLI if the NodeJS version on the host machine is  incompatible.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
