### PR TITLE
fix: detect requests without body correctly

### DIFF
--- a/src/lib/functions/server.mjs
+++ b/src/lib/functions/server.mjs
@@ -43,7 +43,8 @@ const buildClientContext = function (headers) {
 
 const hasBody = (req) =>
   // copied from is-type package
-  (req.header('transfer-encoding') !== undefined || !Number.isNaN(req.header('content-length'))) &&
+  // eslint-disable-next-line unicorn/prefer-number-properties
+  (req.header('transfer-encoding') !== undefined || !isNaN(req.header('content-length'))) &&
   // we expect a string or a buffer, because we use the two bodyParsers(text, raw) from express
   // eslint-disable-next-line n/prefer-global/buffer
   (typeof req.body === 'string' || Buffer.isBuffer(req.body))

--- a/src/lib/functions/server.mjs
+++ b/src/lib/functions/server.mjs
@@ -43,7 +43,7 @@ const buildClientContext = function (headers) {
 
 const hasBody = (req) =>
   // copied from is-type package
-  (req.get('transfer-encoding') !== undefined || !Number.isNaN(req.headers['content-length'])) &&
+  (req.header('transfer-encoding') !== undefined || !Number.isNaN(req.header('content-length'))) &&
   // we expect a string or a buffer, because we use the two bodyParsers(text, raw) from express
   // eslint-disable-next-line n/prefer-global/buffer
   (typeof req.body === 'string' || Buffer.isBuffer(req.body))
@@ -69,21 +69,21 @@ export const createHandler = function (options) {
       return
     }
 
-    const isBase64Encoded = shouldBase64Encode(request.get('content-type'))
+    const isBase64Encoded = shouldBase64Encode(request.header('content-type'))
     let body
     if (hasBody(request)) {
       body = request.body.toString(isBase64Encoded ? 'base64' : 'utf8')
     }
 
-    let remoteAddress = request.get('x-forwarded-for') || request.connection.remoteAddress || ''
+    let remoteAddress = request.header('x-forwarded-for') || request.connection.remoteAddress || ''
     remoteAddress = remoteAddress
       .split(remoteAddress.includes('.') ? ':' : ',')
       .pop()
       .trim()
 
     let requestPath = request.path
-    if (request.get('x-netlify-original-pathname')) {
-      requestPath = request.get('x-netlify-original-pathname')
+    if (request.header('x-netlify-original-pathname')) {
+      requestPath = request.header('x-netlify-original-pathname')
       delete request.headers['x-netlify-original-pathname']
     }
     const queryParams = Object.entries(request.query).reduce(


### PR DESCRIPTION
if a request goes through an edge function the `content-length` header will be removed and instead the `transfer-enconding` is set to chunked. Our detection in the functions (non-edge) server was detecting these passthrough requests as requests without body, because of the missing `content-length`. `content-length` should be ignored anyways when `transfer-encoding` is used according to [the HTTP/1.1 spec](https://httpwg.org/specs/rfc9112.html#rfc.section.6.1).

Fixes #5030


This also changes `request.get(...)` and `request.headers[...]` to `request.header(...)` for readability. 


![red-fox-in-winter-forest-royalty-free-image-1610492147](https://user-images.githubusercontent.com/231804/205440360-6e3b87fc-f212-40c4-94b8-6843687ec77b.jpeg)
