### PR TITLE
fix: discard edge function declarations without a path or pattern

### DIFF
--- a/src/lib/edge-functions/registry.cjs
+++ b/src/lib/edge-functions/registry.cjs
@@ -11,11 +11,20 @@ const { NETLIFYDEVERR, NETLIFYDEVLOG, chalk, log, warn, watchDebounced } = requi
  */
 
 /**
- * @typedef EdgeFunctionDeclaration
+ * @typedef EdgeFunctionDeclarationWithPath
  * @type {object}
  * @property {string} function
  * @property {string} path
  */
+
+/**
+ * @typedef EdgeFunctionDeclarationWithPattern
+ * @type {object}
+ * @property {string} function
+ * @property {RegExp} pattern
+ */
+
+/** @typedef {(EdgeFunctionDeclarationWithPath | EdgeFunctionDeclarationWithPattern) } EdgeFunctionDeclaration */
 
 class EdgeFunctionsRegistry {
   /**
@@ -341,7 +350,9 @@ class EdgeFunctionsRegistry {
       }
     })
 
-    return declarations
+    const filteredDeclarations = declarations.filter((declaration) => 'path' in declaration || 'pattern' in declaration)
+
+    return filteredDeclarations
   }
 
   processGraph(graph) {


### PR DESCRIPTION
#### Summary

In certain situations, CLI is calling Edge Bundler's `generateManifest` function with functions that don't have a `path` or a `pattern` properties, which violates the expected type. This is causing a fatal error when running `netlify dev`.

This PR fixes that by discarding any invalid declarations.