### PR TITLE
fix: check for any functions when using EF proxy

### DIFF
--- a/src/lib/edge-functions/internal.mjs
+++ b/src/lib/edge-functions/internal.mjs
@@ -33,12 +33,15 @@ export const getInternalFunctions = async () => {
   const path = join(cwd(), getPathInProject([INTERNAL_EDGE_FUNCTIONS_FOLDER]))
 
   try {
-    const stats = await stat(path)
-
-    if (!stats.isDirectory()) {
-      throw new Error('Path is not a directory')
+    await stat(path)
+  } catch {
+    return {
+      functions: [],
+      path: null,
     }
+  }
 
+  try {
     const manifestPath = join(path, 'manifest.json')
     const manifest = JSON.parse(await readFile(manifestPath))
 

--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -89,16 +89,22 @@ export const initializeProxy = async ({
     projectDir,
   })
 
+  if (!userFunctionsPath && !internalFunctionsPath) {
+    return
+  }
+
   return async (req) => {
     const registry = await server
-    if (!registry) return
-    const hasEdgeFunctions = registry.functions.length !== 0
 
-    await registry.initialize()
+    if (!registry) return
+
+    const hasEdgeFunctions = registry.functions.length !== 0
 
     if (req.headers[headers.Passthrough] !== undefined || !hasEdgeFunctions) {
       return
     }
+
+    await registry.initialize()
 
     const geoLocation = await getGeoLocation({ mode: geolocationMode, geoCountry, offline, state })
 

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -747,74 +747,12 @@ test('should respect in-source configuration from edge functions', async (t) => 
         },
       })
       .withEdgeFunction({
-        config: () => ({ path: '/hello' }),
+        config: () => ({ path: '/hello-1' }),
         handler: () => new Response('Hello world'),
         name: 'hello',
       })
-
-    await builder.buildAsync()
-
-    await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
-      const res = await got(`http://localhost:${port}/hello`, { throwHttpErrors: false })
-
-      t.is(res.statusCode, 200)
-      t.is(res.body, 'Hello world')
-
-      // wait for file watcher to be up and running, which might take a little
-      // if we do not wait, the next file change will not be picked up
-      await pause(500)
-
-      await builder
-        .withEdgeFunction({
-          config: () => ({ path: '/hello-2' }),
-          handler: () => new Response('Hello world'),
-          name: 'hello',
-        })
-        .withEdgeFunction({
-          config: () => ({ path: '/internal-2' }),
-          handler: () => new Response('Hello from an internal function'),
-          internal: true,
-          name: 'internal',
-        })
-        .buildAsync()
-
-      await waitForLogMatching('Reloaded edge function')
-
-      const res3 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
-
-      t.is(res3.statusCode, 404)
-
-      const res4 = await got(`http://localhost:${port}/hello-2`, { throwHttpErrors: false })
-
-      t.is(res4.statusCode, 200)
-      t.is(res4.body, 'Hello world')
-
-      const res5 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
-
-      t.is(res5.statusCode, 404)
-
-      const res6 = await got(`http://localhost:${port}/internal-2`, { throwHttpErrors: false })
-
-      t.is(res6.statusCode, 200)
-      t.is(res6.body, 'Hello from an internal function')
-    })
-  })
-})
-
-test('should respect in-source configuration from internal edge functions', async (t) => {
-  await withSiteBuilder('site-with-edge-functions', async (builder) => {
-    const publicDir = 'public'
-    await builder
-      .withNetlifyToml({
-        config: {
-          build: {
-            publish: publicDir,
-            edge_functions: 'netlify/edge-functions',
-          },
-        },
-      })
       .withEdgeFunction({
-        config: () => ({ path: '/internal' }),
+        config: () => ({ path: '/internal-1' }),
         handler: () => new Response('Hello from an internal function'),
         internal: true,
         name: 'internal',
@@ -823,10 +761,15 @@ test('should respect in-source configuration from internal edge functions', asyn
     await builder.buildAsync()
 
     await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
-      const res = await got(`http://localhost:${port}/internal`, { throwHttpErrors: false })
+      const res1 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
 
-      t.is(res.statusCode, 200)
-      t.is(res.body, 'Hello from an internal function')
+      t.is(res1.statusCode, 200)
+      t.is(res1.body, 'Hello world')
+
+      const res2 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
+
+      t.is(res2.statusCode, 200)
+      t.is(res2.body, 'Hello from an internal function')
 
       // wait for file watcher to be up and running, which might take a little
       // if we do not wait, the next file change will not be picked up

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -747,12 +747,74 @@ test('should respect in-source configuration from edge functions', async (t) => 
         },
       })
       .withEdgeFunction({
-        config: () => ({ path: '/hello-1' }),
+        config: () => ({ path: '/hello' }),
         handler: () => new Response('Hello world'),
         name: 'hello',
       })
+
+    await builder.buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
+      const res = await got(`http://localhost:${port}/hello`, { throwHttpErrors: false })
+
+      t.is(res.statusCode, 200)
+      t.is(res.body, 'Hello world')
+
+      // wait for file watcher to be up and running, which might take a little
+      // if we do not wait, the next file change will not be picked up
+      await pause(500)
+
+      await builder
+        .withEdgeFunction({
+          config: () => ({ path: '/hello-2' }),
+          handler: () => new Response('Hello world'),
+          name: 'hello',
+        })
+        .withEdgeFunction({
+          config: () => ({ path: '/internal-2' }),
+          handler: () => new Response('Hello from an internal function'),
+          internal: true,
+          name: 'internal',
+        })
+        .buildAsync()
+
+      await waitForLogMatching('Reloaded edge function')
+
+      const res3 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
+
+      t.is(res3.statusCode, 404)
+
+      const res4 = await got(`http://localhost:${port}/hello-2`, { throwHttpErrors: false })
+
+      t.is(res4.statusCode, 200)
+      t.is(res4.body, 'Hello world')
+
+      const res5 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
+
+      t.is(res5.statusCode, 404)
+
+      const res6 = await got(`http://localhost:${port}/internal-2`, { throwHttpErrors: false })
+
+      t.is(res6.statusCode, 200)
+      t.is(res6.body, 'Hello from an internal function')
+    })
+  })
+})
+
+test('should respect in-source configuration from internal edge functions', async (t) => {
+  await withSiteBuilder('site-with-edge-functions', async (builder) => {
+    const publicDir = 'public'
+    await builder
+      .withNetlifyToml({
+        config: {
+          build: {
+            publish: publicDir,
+            edge_functions: 'netlify/edge-functions',
+          },
+        },
+      })
       .withEdgeFunction({
-        config: () => ({ path: '/internal-1' }),
+        config: () => ({ path: '/internal' }),
         handler: () => new Response('Hello from an internal function'),
         internal: true,
         name: 'internal',
@@ -761,15 +823,10 @@ test('should respect in-source configuration from edge functions', async (t) => 
     await builder.buildAsync()
 
     await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
-      const res1 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
+      const res = await got(`http://localhost:${port}/internal`, { throwHttpErrors: false })
 
-      t.is(res1.statusCode, 200)
-      t.is(res1.body, 'Hello world')
-
-      const res2 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
-
-      t.is(res2.statusCode, 200)
-      t.is(res2.body, 'Hello from an internal function')
+      t.is(res.statusCode, 200)
+      t.is(res.body, 'Hello from an internal function')
 
       // wait for file watcher to be up and running, which might take a little
       // if we do not wait, the next file change will not be picked up

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -751,12 +751,6 @@ test('should respect in-source configuration from edge functions', async (t) => 
         handler: () => new Response('Hello world'),
         name: 'hello',
       })
-      .withEdgeFunction({
-        config: () => ({ path: '/internal-1' }),
-        handler: () => new Response('Hello from an internal function'),
-        internal: true,
-        name: 'internal',
-      })
 
     await builder.buildAsync()
 
@@ -765,11 +759,6 @@ test('should respect in-source configuration from edge functions', async (t) => 
 
       t.is(res1.statusCode, 200)
       t.is(res1.body, 'Hello world')
-
-      const res2 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
-
-      t.is(res2.statusCode, 200)
-      t.is(res2.body, 'Hello from an internal function')
 
       // wait for file watcher to be up and running, which might take a little
       // if we do not wait, the next file change will not be picked up
@@ -781,6 +770,53 @@ test('should respect in-source configuration from edge functions', async (t) => 
           handler: () => new Response('Hello world'),
           name: 'hello',
         })
+        .buildAsync()
+
+      await waitForLogMatching('Reloaded edge function')
+
+      const res2 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
+
+      t.is(res2.statusCode, 404)
+
+      const res3 = await got(`http://localhost:${port}/hello-2`, { throwHttpErrors: false })
+
+      t.is(res3.statusCode, 200)
+      t.is(res3.body, 'Hello world')
+    })
+  })
+})
+
+test('should respect in-source configuration from internal edge functions', async (t) => {
+  await withSiteBuilder('site-with-internal-edge-functions', async (builder) => {
+    const publicDir = 'public'
+    await builder
+      .withNetlifyToml({
+        config: {
+          build: {
+            publish: publicDir,
+          },
+        },
+      })
+      .withEdgeFunction({
+        config: () => ({ path: '/internal-1' }),
+        handler: () => new Response('Hello from an internal function'),
+        internal: true,
+        name: 'internal',
+      })
+
+    await builder.buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
+      const res1 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
+
+      t.is(res1.statusCode, 200)
+      t.is(res1.body, 'Hello from an internal function')
+
+      // wait for file watcher to be up and running, which might take a little
+      // if we do not wait, the next file change will not be picked up
+      await pause(500)
+
+      await builder
         .withEdgeFunction({
           config: () => ({ path: '/internal-2' }),
           handler: () => new Response('Hello from an internal function'),
@@ -791,23 +827,14 @@ test('should respect in-source configuration from edge functions', async (t) => 
 
       await waitForLogMatching('Reloaded edge function')
 
-      const res3 = await got(`http://localhost:${port}/hello-1`, { throwHttpErrors: false })
+      const res2 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
 
-      t.is(res3.statusCode, 404)
+      t.is(res2.statusCode, 404)
 
-      const res4 = await got(`http://localhost:${port}/hello-2`, { throwHttpErrors: false })
+      const res3 = await got(`http://localhost:${port}/internal-2`, { throwHttpErrors: false })
 
-      t.is(res4.statusCode, 200)
-      t.is(res4.body, 'Hello world')
-
-      const res5 = await got(`http://localhost:${port}/internal-1`, { throwHttpErrors: false })
-
-      t.is(res5.statusCode, 404)
-
-      const res6 = await got(`http://localhost:${port}/internal-2`, { throwHttpErrors: false })
-
-      t.is(res6.statusCode, 200)
-      t.is(res6.body, 'Hello from an internal function')
+      t.is(res3.statusCode, 200)
+      t.is(res3.body, 'Hello from an internal function')
     })
   })
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Should fix an issue where having any internal functions with in-source-config, but no other edge functions, would prevent the proxy from running the internal EF.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
