### PR TITLE
fix: centralize edge functions feature flags

### DIFF
--- a/src/commands/deploy/deploy.mjs
+++ b/src/commands/deploy/deploy.mjs
@@ -12,6 +12,7 @@ import prettyjson from 'prettyjson'
 
 import { cancelDeploy } from '../../lib/api.mjs'
 import { getBuildOptions, runBuild } from '../../lib/build.mjs'
+import { featureFlags as edgeFunctionsFeatureFlags } from '../../lib/edge-functions/consts.mjs'
 import { normalizeFunctionsConfig } from '../../lib/functions/config.mjs'
 import { getLogMessage } from '../../lib/log.mjs'
 import { startSpinner, stopSpinner } from '../../lib/spinner.cjs'
@@ -409,9 +410,7 @@ const bundleEdgeFunctions = async (options) => {
   const { severityCode, success } = await runCoreSteps(['edge_functions_bundling'], {
     ...options,
     buffer: true,
-    featureFlags: {
-      edge_functions_read_deno_config: true,
-    },
+    featureFlags: edgeFunctionsFeatureFlags,
   })
 
   if (!success) {

--- a/src/lib/build.mjs
+++ b/src/lib/build.mjs
@@ -3,6 +3,8 @@ import process from 'process'
 
 import build from '@netlify/build'
 
+import { featureFlags as edgeFunctionsFeatureFlags } from './edge-functions/consts.mjs'
+
 /**
  * The buildConfig + a missing cachedConfig
  * @typedef BuildConfig
@@ -38,9 +40,8 @@ export const getBuildOptions = ({
   offline,
   cwd,
   featureFlags: {
-    edge_functions_config_export: true,
+    ...edgeFunctionsFeatureFlags,
     functionsBundlingManifest: true,
-    edge_functions_produce_eszip: true,
     project_deploy_configuration_api_use_per_function_configuration_files: true,
   },
 })

--- a/src/lib/edge-functions/consts.mjs
+++ b/src/lib/edge-functions/consts.mjs
@@ -2,3 +2,10 @@ export const DIST_IMPORT_MAP_PATH = 'edge-functions-import-map.json'
 export const INTERNAL_EDGE_FUNCTIONS_FOLDER = 'edge-functions'
 export const EDGE_FUNCTIONS_FOLDER = 'edge-functions-dist'
 export const PUBLIC_URL_PATH = '.netlify/internal/edge-functions'
+
+// Feature flags related to Edge Functions that should be passed along to
+// Netlify Build.
+export const featureFlags = {
+  edge_functions_config_export: true,
+  edge_functions_read_deno_config: true,
+}


### PR DESCRIPTION
#### Summary

We have two different places where we need to send edge functions feature flags to Netlify Build. This PR centralises them.