### PR TITLE
feat: add support for edge function bypass logic

### DIFF
--- a/src/lib/edge-functions/headers.mjs
+++ b/src/lib/edge-functions/headers.mjs
@@ -5,6 +5,8 @@ const headers = {
   Geo: 'x-nf-geo',
   Passthrough: 'x-deno-pass',
   RequestID: 'X-NF-Request-ID',
+  FeatureFlags: 'x-nf-feature-flags',
+  EdgeFunctionBypass: 'x-nf-edge-function-bypass',
   IP: 'x-nf-client-connection-ip',
   Site: 'X-NF-Site-Info',
 }

--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -129,11 +129,16 @@ export const initializeProxy = async ({
       return
     }
 
+    const flags = {
+      edge_functions_bootstrap_early_return: true,
+    }
+
     req[headersSymbol] = {
       [headers.Functions]: functionNames.join(','),
       [headers.ForwardedHost]: `localhost:${mainPort}`,
       [headers.Passthrough]: 'passthrough',
       [headers.RequestID]: generateUUID(),
+      [headers.FeatureFlags]: Buffer.from(JSON.stringify(flags)).toString('base64'),
       [headers.IP]: LOCAL_HOST,
     }
 


### PR DESCRIPTION
#### Summary

Works towards https://github.com/netlify/edge-functions-bootstrap/issues/78.

This PR teaches the CLI how to deal with the `x-nf-edge-function-bypass` header that EF bootstrap returns on early returns. It will run a second request that skips edge functions, similar to how the CDN works.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
