### PR TITLE
feat(ef templates): replace context.json with Response.json

### DIFF
--- a/src/functions-templates/typescript/geolocation/{{name}}.ts
+++ b/src/functions-templates/typescript/geolocation/{{name}}.ts
@@ -17,7 +17,7 @@ export default async (request: Request, context: Context) => {
   //   }
   // }
 
-  return context.json({
+  return Response.json({
     geo: context.geo,
     header: request.headers.get("x-nf-geo"),
   });

--- a/src/functions-templates/typescript/json/{{name}}.ts
+++ b/src/functions-templates/typescript/json/{{name}}.ts
@@ -1,5 +1,5 @@
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  return context.json({ hello: "world" });
+  return Response.json({ hello: "world" });
 };

--- a/src/functions-templates/typescript/json/{{name}}.ts
+++ b/src/functions-templates/typescript/json/{{name}}.ts
@@ -1,5 +1,5 @@
 import type { Context } from "https://edge.netlify.com";
 
 export default async (request: Request, context: Context) => {
-  return Response.json({ hello: "world" });
+  return Response.json({ hello: "world", location: context.geo.city });
 };


### PR DESCRIPTION
As per https://github.com/netlify/edge-functions-bootstrap/pull/142#issuecomment-1368897194, let's change the ef template code to use `Response.json` instead of the soon-to-be-deprecated `context.json`.