### PR TITLE
chore: acceptance test for top-level exceptions in edge functions

### DIFF
--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -758,7 +758,7 @@ test('should respect excluded paths', async (t) => {
   })
 })
 
-test.only('top-level exceptions should be printed properly', async (t) => {
+test('top-level exceptions should be printed properly', async (t) => {
   await withSiteBuilder('site-with-exceptions', async (builder) => {
     const publicDir = 'public'
     await builder


### PR DESCRIPTION
#### Summary

Right now, when a top-level exception happens in an edge function, we're showing a somewhat cryptic error message in local dev:

```js
[include] TypeError: func.function is not a function
    at https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/function_chain.ts:338:28
    at https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/util/named_wrapper.ts:19:24
    at nf_req_16371aa5-22b6-4890-852b-c28f20abdd42 (https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/util/named_wrapper.ts:12:68)
    at callWithNamedWrapper (https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/util/named_wrapper.ts:19:10)
    at FunctionChain.runFunction (https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/function_chain.ts:337:30)
    at FunctionChain.runFunction (https://639708f6d7f813000870695c--edge.netlify.app/bootstrap/function_chain.ts:357:21)
```

Instead, it should show the stacktrace of the actual exception. This PR adds a reproduction test for this.