### PR TITLE
fix: expose env variables from config to edge functions

### DIFF
--- a/src/lib/edge-functions/registry.mjs
+++ b/src/lib/edge-functions/registry.mjs
@@ -214,7 +214,8 @@ export class EdgeFunctionsRegistry {
         variable.sources.includes('ui') ||
         variable.sources.includes('account') ||
         variable.sources.includes('addons') ||
-        variable.sources.includes('internal')
+        variable.sources.includes('internal') ||
+        variable.sources.includes('configFile')
       ) {
         env[key] = variable.value
       }


### PR DESCRIPTION
#### Summary

We currently have a bug where environment variables declared in `netlify.toml` are not exposed to edge functions.

To reproduce:

1. Write the following in `netlify.toml`

    ```toml
    [context.dev.environment]
    FOO = "bar"
    ```

2. Observe the log line:

    ```
    ◈ Injected netlify.toml file env var: FOO
    ```

3. Write an edge function that prints the value of the environment variable and observe it's empty

This PR fixes that.