### PR TITLE
fix: ensure edge functions work with HTTPS mode

### DIFF
--- a/src/lib/edge-functions/headers.mjs
+++ b/src/lib/edge-functions/headers.mjs
@@ -1,6 +1,5 @@
 const headers = {
   ForwardedHost: 'x-forwarded-host',
-  ForwardedProtocol: 'x-forwarded-proto',
   Functions: 'x-nf-edge-functions',
   Geo: 'x-nf-geo',
   Passthrough: 'x-nf-passthrough',

--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -603,8 +603,8 @@ export const startProxy = async function ({
 
   // If we're running the main server on HTTPS, we need to start a secondary
   // server on HTTP for receiving passthrough requests from edge functions.
-  // This lets us run the Deno server on HTTP and avoid complications with
-  // certificates.
+  // This lets us run the Deno server on HTTP and avoid the complications of
+  // Deno talking to Node on HTTPS with potentially untrusted certificates.
   if (secondaryServerPort) {
     const secondaryServer = http.createServer(onRequestWithOptions)
 

--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -13,6 +13,7 @@ import contentType from 'content-type'
 import cookie from 'cookie'
 import { get } from 'dot-prop'
 import generateETag from 'etag'
+import getAvailablePort from 'get-port'
 import httpProxy from 'http-proxy'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import jwtDecode from 'jwt-decode'
@@ -545,6 +546,7 @@ export const startProxy = async function ({
   siteInfo,
   state,
 }) {
+  const secondaryServerPort = settings.https ? await getAvailablePort() : null
   const functionsServer = settings.functionsPort ? `http://127.0.0.1:${settings.functionsPort}` : null
   const edgeFunctionsProxy = await initializeEdgeFunctionsProxy({
     config,
@@ -555,9 +557,10 @@ export const startProxy = async function ({
     geoCountry,
     getUpdatedConfig,
     inspectSettings,
+    mainPort: settings.port,
     offline,
+    passthroughPort: secondaryServerPort || settings.port,
     projectDir,
-    settings,
     siteInfo,
     state,
   })
@@ -586,16 +589,30 @@ export const startProxy = async function ({
     functionsServer,
     edgeFunctionsProxy,
   })
-  const server = settings.https
+  const primaryServer = settings.https
     ? https.createServer({ cert: settings.https.cert, key: settings.https.key }, onRequestWithOptions)
     : http.createServer(onRequestWithOptions)
-
-  server.on('upgrade', function onUpgrade(req, socket, head) {
+  const onUpgrade = function onUpgrade(req, socket, head) {
     proxy.ws(req, socket, head)
-  })
+  }
 
-  server.listen({ port: settings.port })
-  await once(server, 'listening')
+  primaryServer.on('upgrade', onUpgrade)
+
+  primaryServer.listen({ port: settings.port })
+  await once(primaryServer, 'listening')
+
+  // If we're running the main server on HTTPS, we need to start a secondary
+  // server on HTTP for receiving passthrough requests from edge functions.
+  // This lets us run the Deno server on HTTP and avoid complications with
+  // certificates.
+  if (secondaryServerPort) {
+    const secondaryServer = http.createServer(onRequestWithOptions)
+
+    secondaryServer.on('upgrade', onUpgrade)
+
+    secondaryServer.listen({ port: secondaryServerPort })
+    await once(secondaryServer, 'listening')
+  }
 
   const scheme = settings.https ? 'https' : 'http'
   return `${scheme}://localhost:${settings.port}`


### PR DESCRIPTION
#### Summary

This PR addresses an issue where enabling HTTPS may cause edge functions that make passthrough calls to fail due to untrusted certificates.

Rather than running the Deno server on HTTPS with the same certificate provided to the Netlify CLI, we'll run the Deno server on HTTP. To make passthrough calls work, we'll start a secondary CLI server on HTTP and use that for passthrough calls.