### PR TITLE
fix: gracefully handle errors when setting headers

### DIFF
--- a/src/lib/functions/server.mjs
+++ b/src/lib/functions/server.mjs
@@ -168,7 +168,7 @@ export const createHandler = function (options) {
         return
       }
 
-      handleSynchronousFunction(error, result, request, response)
+      handleSynchronousFunction({ error, functionName: func.name, result, request, response })
     }
   }
 }


### PR DESCRIPTION
#### Summary

When we finish processing a serverless function and transfer any header it sets into the final response, we're doing [a `setHeader call`](https://github.com/netlify/cli/blob/main/src/lib/functions/synchronous.mjs#L15) that may throw. When that happens, the entire app crashes.

This PR addresses that by gracefully handling the error, showing a log in the terminal and displaying the function error page.

<img width="1080" alt="Screenshot 2023-01-20 at 10 27 31" src="https://user-images.githubusercontent.com/4162329/213674988-39df621c-5afe-40ca-bca2-101a546b696d.png">