### PR TITLE
fix: load internal environment variables in Envelope

### DIFF
--- a/src/commands/dev/dev.mjs
+++ b/src/commands/dev/dev.mjs
@@ -88,7 +88,8 @@ const dev = async (options, command) => {
 
   let { env } = cachedConfig
 
-  env.NETLIFY_DEV = { sources: ['internal'], value: 'true' }
+  process.env.NETLIFY_DEV = 'true'
+  env.NETLIFY_DEV = { sources: ['internal'], value: process.env.NETLIFY_DEV }
 
   if (!options.offline && siteInfo.use_envelope) {
     env = await getEnvelopeEnv({ api, context: options.context, env, siteInfo })

--- a/src/commands/dev/dev.mjs
+++ b/src/commands/dev/dev.mjs
@@ -88,8 +88,7 @@ const dev = async (options, command) => {
 
   let { env } = cachedConfig
 
-  process.env.NETLIFY_DEV = 'true'
-  env.NETLIFY_DEV = { sources: ['internal'], value: process.env.NETLIFY_DEV }
+  env.NETLIFY_DEV = { sources: ['internal'], value: 'true' }
 
   if (!options.offline && siteInfo.use_envelope) {
     env = await getEnvelopeEnv({ api, context: options.context, env, siteInfo })

--- a/src/utils/env/index.mjs
+++ b/src/utils/env/index.mjs
@@ -146,6 +146,7 @@ export const getEnvelopeEnv = async ({ api, context = 'dev', env, key = '', scop
   const accountEnv = formatEnvelopeData({ context, envelopeItems: accountEnvelopeItems, scope, source: 'account' })
   const siteEnv = formatEnvelopeData({ context, envelopeItems: siteEnvelopeItems, scope, source: 'ui' })
   const generalEnv = filterEnvBySource(env, 'general')
+  const internalEnv = filterEnvBySource(env, 'internal')
   const addonsEnv = filterEnvBySource(env, 'addons')
   const configFileEnv = filterEnvBySource(env, 'configFile')
 
@@ -159,6 +160,7 @@ export const getEnvelopeEnv = async ({ api, context = 'dev', env, key = '', scop
     ...(includeConfigEnvVars ? addonsEnv : {}),
     ...siteEnv,
     ...(includeConfigEnvVars ? configFileEnv : {}),
+    ...internalEnv,
   }
 }
 

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -971,7 +971,7 @@ test('should inject the `NETLIFY_DEV` environment variable in the process (legac
   const externalServerPath = path.join(__dirname, 'utils', 'external-server-cli.cjs')
   const command = `node ${externalServerPath} ${externalServerPort}`
 
-  await withSiteBuilder('site-with-edge-functions-and-env', async (builder) => {
+  await withSiteBuilder('site-with-legacy-env-vars', async (builder) => {
     const publicDir = 'public'
 
     await builder
@@ -1045,7 +1045,7 @@ test('should inject the `NETLIFY_DEV` environment variable in the process', asyn
   const externalServerPath = path.join(__dirname, 'utils', 'external-server-cli.cjs')
   const command = `node ${externalServerPath} ${externalServerPort}`
 
-  await withSiteBuilder('site-with-edge-functions-and-env', async (builder) => {
+  await withSiteBuilder('site-with-env-vars', async (builder) => {
     const publicDir = 'public'
 
     await builder

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -5,6 +5,7 @@ const path = require('path')
 const avaTest = require('ava')
 const { isCI } = require('ci-info')
 const dotProp = require('dot-prop')
+const getAvailablePort = require('get-port')
 const jwt = require('jsonwebtoken')
 const { Response } = require('node-fetch')
 
@@ -959,6 +960,125 @@ test('should have only allowed environment variables set', async (t) => {
           t.false(envKeys.includes('NODE_ENV'))
           t.false(envKeys.includes('DEPLOY_URL'))
           t.false(envKeys.includes('URL'))
+        },
+      )
+    })
+  })
+})
+
+test('should inject the `NETLIFY_DEV` environment variable in the process (legacy environment variables)', async (t) => {
+  const externalServerPort = await getAvailablePort()
+  const externalServerPath = path.join(__dirname, 'utils', 'external-server-cli.cjs')
+  const command = `node ${externalServerPath} ${externalServerPort}`
+
+  await withSiteBuilder('site-with-edge-functions-and-env', async (builder) => {
+    const publicDir = 'public'
+
+    await builder
+      .withNetlifyToml({
+        config: {
+          build: {
+            publish: publicDir,
+          },
+          dev: {
+            command,
+            publish: publicDir,
+            targetPort: externalServerPort,
+            framework: '#custom',
+          },
+        },
+      })
+      .buildAsync()
+
+    await withDevServer({ cwd: builder.directory }, async ({ port }) => {
+      const response = await got(`http://localhost:${port}/`).json()
+
+      t.is(response.env.NETLIFY_DEV, 'true')
+    })
+  })
+})
+
+test('should inject the `NETLIFY_DEV` environment variable in the process', async (t) => {
+  const siteInfo = {
+    account_slug: 'test-account',
+    build_settings: {
+      env: {},
+    },
+    id: 'site_id',
+    name: 'site-name',
+    use_envelope: true,
+  }
+  const existingVar = {
+    key: 'EXISTING_VAR',
+    scopes: ['builds', 'functions'],
+    values: [
+      {
+        id: '1234',
+        context: 'production',
+        value: 'envelope-prod-value',
+      },
+      {
+        id: '2345',
+        context: 'dev',
+        value: 'envelope-dev-value',
+      },
+    ],
+  }
+  const routes = [
+    { path: 'sites/site_id', response: siteInfo },
+    { path: 'sites/site_id/service-instances', response: [] },
+    {
+      path: 'accounts',
+      response: [{ slug: siteInfo.account_slug }],
+    },
+    {
+      path: 'accounts/test-account/env/EXISTING_VAR',
+      response: existingVar,
+    },
+    {
+      path: 'accounts/test-account/env',
+      response: [existingVar],
+    },
+  ]
+
+  const externalServerPort = await getAvailablePort()
+  const externalServerPath = path.join(__dirname, 'utils', 'external-server-cli.cjs')
+  const command = `node ${externalServerPath} ${externalServerPort}`
+
+  await withSiteBuilder('site-with-edge-functions-and-env', async (builder) => {
+    const publicDir = 'public'
+
+    await builder
+      .withNetlifyToml({
+        config: {
+          build: {
+            publish: publicDir,
+          },
+          dev: {
+            command,
+            publish: publicDir,
+            targetPort: externalServerPort,
+            framework: '#custom',
+          },
+        },
+      })
+      .buildAsync()
+
+    await withMockApi(routes, async ({ apiUrl }) => {
+      await withDevServer(
+        {
+          cwd: builder.directory,
+          offline: false,
+          env: {
+            NETLIFY_API_URL: apiUrl,
+            NETLIFY_SITE_ID: 'site_id',
+            NETLIFY_AUTH_TOKEN: 'fake-token',
+          },
+        },
+        async ({ port }) => {
+          const response = await got(`http://localhost:${port}/`).json()
+
+          t.is(response.env.NETLIFY_DEV, 'true')
         },
       )
     })

--- a/tests/integration/utils/external-server-cli.cjs
+++ b/tests/integration/utils/external-server-cli.cjs
@@ -1,0 +1,13 @@
+const process = require('process')
+
+const { startExternalServer } = require('./external-server.cjs')
+
+const port = Number.parseInt(process.argv[2])
+
+if (Number.isNaN(port)) {
+  throw new TypeError(`Invalid port`)
+}
+
+console.log('Running external server on port', port, process.env.NETLIFY_DEV)
+
+startExternalServer({ port })

--- a/tests/integration/utils/external-server.cjs
+++ b/tests/integration/utils/external-server.cjs
@@ -1,13 +1,15 @@
+const { env } = require('process')
+
 const express = require('express')
 
-const startExternalServer = () => {
+const startExternalServer = ({ port } = {}) => {
   const app = express()
   app.use(express.urlencoded({ extended: true }))
   app.all('*', function onRequest(req, res) {
-    res.json({ url: req.url, body: req.body, method: req.method, headers: req.headers })
+    res.json({ url: req.url, body: req.body, method: req.method, headers: req.headers, env })
   })
 
-  return app.listen()
+  return app.listen({ port })
 }
 
 module.exports = {


### PR DESCRIPTION
#### Summary

https://github.com/netlify/cli/pull/5338 has changed the way the `NETLIFY_DEV` environment variable is set. Rather than mutating `process.env` immediately, we set a variable in the `env` object with the type `internal`, which is processed as a type of environment variable that can't be overridden.

Unfortunately, this wasn't added to the Envelope methods, and so the variable was being removed for sites with Envelope enabled.

This PR addresses that and adds some tests (to both legacy and new environment variable systems) to ensure we don't introduce this regression again.