### PR TITLE
fix: print deploy error_message, if exists

### DIFF
--- a/src/utils/deploy/util.mjs
+++ b/src/utils/deploy/util.mjs
@@ -23,7 +23,7 @@ export const waitForDiff = async (api, deployId, siteId, timeout) => {
     switch (siteDeploy.state) {
       // https://github.com/netlify/bitballoon/blob/master/app/models/deploy.rb#L21-L33
       case 'error': {
-        const deployError = new Error(`Deploy ${deployId} had an error`)
+        const deployError = new Error(siteDeploy.error_message || `Deploy ${deployId} had an error`)
         deployError.deploy = siteDeploy
         throw deployError
       }
@@ -60,7 +60,7 @@ export const waitForDeploy = async (api, deployId, siteId, timeout) => {
     switch (siteDeploy.state) {
       // https://github.com/netlify/bitballoon/blob/master/app/models/deploy.rb#L21-L33
       case 'error': {
-        const deployError = new Error(`Deploy ${deployId} had an error`)
+        const deployError = new Error(siteDeploy.error_message || `Deploy ${deployId} had an error`)
         deployError.deploy = siteDeploy
         throw deployError
       }


### PR DESCRIPTION
#### Summary

For deploy that fails while going live, we're currently printing a very non-explanatory error message - although we already might have a good one in `deploy.error_message`! This PR makes it so that that message is printed, if it exists.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
