### PR TITLE
fix: support multiple path values in edge functions config

### DIFF
--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -707,7 +707,7 @@ test('should respect in-source configuration from edge functions', async (t) => 
 
       await builder
         .withEdgeFunction({
-          config: { path: '/hello-2' },
+          config: { path: ['/hello-2', '/hello-3'] },
           handler: () => new Response('Hello world'),
           name: 'hello',
         })
@@ -723,6 +723,11 @@ test('should respect in-source configuration from edge functions', async (t) => 
 
       t.is(res3.statusCode, 200)
       t.is(res3.body, 'Hello world')
+
+      const res4 = await got(`http://localhost:${port}/hello-3`, { throwHttpErrors: false })
+
+      t.is(res4.statusCode, 200)
+      t.is(res4.body, 'Hello world')
     })
   })
 })


### PR DESCRIPTION
#### Summary

Fixes an issue where an error is thrown for edge functions defining a `path` property with multiple values via in-source configuration.