### PR TITLE
feat: add canonical redirect for static html files

### DIFF
--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -493,13 +493,14 @@ const onRequest = async (
   res.setHeader('server', 'Netlify')
 
   if (req.method === 'GET') {
-    const staticFile = await getStatic(decodeURIComponent(req.url), settings.dist)
+    const decodedUrl = decodeURIComponent(req.url)
+    const staticFile = await getStatic(decodedUrl, settings.dist)
 
-    if (staticFile && req.url !== staticFile && (staticFile.endsWith('.html') || staticFile.endsWith('.htm'))) {
+    if (staticFile && decodedUrl !== staticFile && (staticFile.endsWith('.html') || staticFile.endsWith('.htm'))) {
       const canonicalPath = getCanonicalURLPath(staticFile)
 
-      if (canonicalPath !== req.url) {
-        console.log(`${NETLIFYDEVLOG} Redirecting to canonical URL ${req.url} -> ${canonicalPath}`)
+      if (canonicalPath !== decodedUrl) {
+        console.log(`${NETLIFYDEVLOG} Redirecting to canonical URL ${decodedUrl} -> ${canonicalPath}`)
         res.setHeader('age', '0')
         res.setHeader('cache-control', 'public, max-age=0, must-revalidate')
         res.setHeader(NFRequestID, generateRequestID())

--- a/src/utils/proxy/alternative-paths-for.mjs
+++ b/src/utils/proxy/alternative-paths-for.mjs
@@ -4,7 +4,9 @@ import isFunction from './is-function.mjs'
 const assetExtensionRegExp = /\.(html?|png|jpg|js|css|svg|gif|ico|woff|woff2)$/
 
 /**
- * For an URL get alternative static file paths
+ * For an URL get all possible static file paths that the URL could refer to
+ *
+ * /foo/ -> /foo/index.html, /foo/index.htm, /foo.html, /foo.htm
  *
  * @param {string} url
  *

--- a/src/utils/proxy/alternative-paths-for.mjs
+++ b/src/utils/proxy/alternative-paths-for.mjs
@@ -1,0 +1,33 @@
+import isFunction from './is-function.mjs'
+
+// Used as an optimization to avoid dual lookups for missing assets
+const assetExtensionRegExp = /\.(html?|png|jpg|js|css|svg|gif|ico|woff|woff2)$/
+
+/**
+ * For an URL get alternative static file paths
+ *
+ * @param {string} url
+ *
+ * @returns {string[]}
+ */
+const alternativePathsFor = function (url) {
+  if (isFunction(true, url)) {
+    return []
+  }
+
+  const paths = []
+  if (url[url.length - 1] === '/') {
+    const end = url.length - 1
+    const urlWithoutSlash = url.slice(0, end)
+    if (url !== '/') {
+      paths.push(`${urlWithoutSlash}.html`, `${urlWithoutSlash}.htm`)
+    }
+    paths.push(`${url}index.html`, `${url}index.htm`)
+  } else if (!assetExtensionRegExp.test(url)) {
+    paths.push(`${url}.html`, `${url}.htm`, `${url}/index.html`, `${url}/index.htm`)
+  }
+
+  return paths
+}
+
+export default alternativePathsFor

--- a/src/utils/proxy/find-static-file-for-url-path.mjs
+++ b/src/utils/proxy/find-static-file-for-url-path.mjs
@@ -5,12 +5,14 @@ import { locatePath } from 'locate-path'
 import alternativePathsFor from './alternative-paths-for.mjs'
 
 /**
+ * Tries to find an existing static file in `publicFolder` that the `pathname`
+ * is referring to
  *
  * @param {string} pathname
  * @param {string} publicFolder
  * @returns {Promise<string | undefined>}
  */
-const getStatic = async function (pathname, publicFolder) {
+const findStaticFileForURLPath = async function (pathname, publicFolder) {
   const alternatives = [pathname, ...alternativePathsFor(pathname)].map((filePath) =>
     resolve(publicFolder, filePath.slice(1)),
   )
@@ -23,4 +25,4 @@ const getStatic = async function (pathname, publicFolder) {
   return `/${relative(publicFolder, file)}`
 }
 
-export default getStatic
+export default findStaticFileForURLPath

--- a/src/utils/proxy/get-canonical-url-path.mjs
+++ b/src/utils/proxy/get-canonical-url-path.mjs
@@ -1,7 +1,6 @@
 import { basename, extname } from 'path'
 
 /**
- * @param {string} reqPath
  * @param {string} staticFile
  *
  * @returns {string}

--- a/src/utils/proxy/get-canonical-url-path.mjs
+++ b/src/utils/proxy/get-canonical-url-path.mjs
@@ -1,0 +1,25 @@
+import { basename, extname } from 'path'
+
+/**
+ * @param {string} reqPath
+ * @param {string} staticFile
+ *
+ * @returns {string}
+ */
+const getCanonicalURLPath = (staticFile) => {
+  const base = basename(staticFile)
+
+  if (base === 'index.html' || base === 'index.htm') {
+    return staticFile.slice(0, -base.length)
+  }
+
+  const ext = extname(staticFile)
+
+  if (ext === '.html' || ext === '.htm') {
+    return staticFile.slice(0, -ext.length)
+  }
+
+  return staticFile
+}
+
+export default getCanonicalURLPath

--- a/src/utils/proxy/get-static.mjs
+++ b/src/utils/proxy/get-static.mjs
@@ -1,0 +1,26 @@
+import { relative, resolve } from 'path'
+
+import { locatePath } from 'locate-path'
+
+import alternativePathsFor from './alternative-paths-for.mjs'
+
+/**
+ *
+ * @param {string} pathname
+ * @param {string} publicFolder
+ * @returns {Promise<string | undefined>}
+ */
+const getStatic = async function (pathname, publicFolder) {
+  const alternatives = [pathname, ...alternativePathsFor(pathname)].map((filePath) =>
+    resolve(publicFolder, filePath.slice(1)),
+  )
+
+  const file = await locatePath(alternatives)
+  if (file === undefined) {
+    return
+  }
+
+  return `/${relative(publicFolder, file)}`
+}
+
+export default getStatic

--- a/src/utils/proxy/is-function.mjs
+++ b/src/utils/proxy/is-function.mjs
@@ -1,7 +1,7 @@
 const FUNCTION_PATH_REGEX = /^\/.netlify\/(functions|builders)\/.+/
 
 /**
- * Is the URL a function url
+ * Checks whether the URL targets a serverless function
  *
  * @param {number | undefined} functionsPort
  * @param {string} url

--- a/src/utils/proxy/is-function.mjs
+++ b/src/utils/proxy/is-function.mjs
@@ -1,0 +1,12 @@
+const FUNCTION_PATH_REGEX = /^\/.netlify\/(functions|builders)\/.+/
+
+/**
+ * Is the URL a function url
+ *
+ * @param {number | undefined} functionsPort
+ * @param {string} url
+ * @returns {boolean}
+ */
+const isFunction = (functionsPort, url) => Boolean(functionsPort && FUNCTION_PATH_REGEX.test(url))
+
+export default isFunction

--- a/tests/integration/__fixtures__/dev-server-with-static-files/netlify.toml
+++ b/tests/integration/__fixtures__/dev-server-with-static-files/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+publish = "public/"
+

--- a/tests/integration/commands/dev/static-files.test.mjs
+++ b/tests/integration/commands/dev/static-files.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+
+import { setupFixtureTests } from '../../utils/fixture.mjs'
+
+describe('dev command : static files', () => {
+  setupFixtureTests({ devServer: true, fixture: 'dev-server-with-static-files' }, () => {
+    test.concurrent('should redirect /folder to /folder/', async ({ devServer }) => {
+      const response = await devServer.get('/folder', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/folder/')
+    })
+
+    test.concurrent('should redirect /file/ to /file', async ({ devServer }) => {
+      const response = await devServer.get('/file/', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/file')
+    })
+
+    test.concurrent('should redirect /folder/index.html/ to /folder/', async ({ devServer }) => {
+      const response = await devServer.get('/folder/index.html/', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/folder/')
+    })
+
+    test.concurrent('should redirect /file.html/ to /file', async ({ devServer }) => {
+      const response = await devServer.get('/file.html/', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/file')
+    })
+
+    test.concurrent('should not redirect /folder/index.html', async ({ devServer }) => {
+      const response = await devServer.get('/folder/index.html', { followRedirect: false })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    test.concurrent('should not redirect /folder/', async ({ devServer }) => {
+      const response = await devServer.get('/folder/', { followRedirect: false })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    test.concurrent('should not redirect /file', async ({ devServer }) => {
+      const response = await devServer.get('/file', { followRedirect: false })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    test.concurrent('should not redirect /file.html', async ({ devServer }) => {
+      const response = await devServer.get('/file.html', { followRedirect: false })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+})

--- a/tests/integration/commands/dev/static-files.test.mjs
+++ b/tests/integration/commands/dev/static-files.test.mjs
@@ -55,5 +55,11 @@ describe('dev command : static files', () => {
 
       expect(response.statusCode).toBe(200)
     })
+
+    test.concurrent('should not redirect /file with spaces', async ({ devServer }) => {
+      const response = await devServer.get('/file with spaces', { followRedirect: false })
+
+      expect(response.statusCode).toBe(200)
+    })
   })
 })

--- a/tests/integration/commands/dev/static-files.test.mjs
+++ b/tests/integration/commands/dev/static-files.test.mjs
@@ -11,11 +11,25 @@ describe('dev command : static files', () => {
       expect(response.headers.location).toBe('/folder/')
     })
 
+    test.concurrent('should redirect /folder to /folder/ with query params', async ({ devServer }) => {
+      const response = await devServer.get('/folder?asdf', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/folder/?asdf')
+    })
+
     test.concurrent('should redirect /file/ to /file', async ({ devServer }) => {
       const response = await devServer.get('/file/', { followRedirect: false })
 
       expect(response.statusCode).toBe(301)
       expect(response.headers.location).toBe('/file')
+    })
+
+    test.concurrent('should redirect /file/ to /file with query params', async ({ devServer }) => {
+      const response = await devServer.get('/file/?asdf', { followRedirect: false })
+
+      expect(response.statusCode).toBe(301)
+      expect(response.headers.location).toBe('/file?asdf')
     })
 
     test.concurrent('should redirect /folder/index.html/ to /folder/', async ({ devServer }) => {

--- a/tests/integration/utils/dev-server.cjs
+++ b/tests/integration/utils/dev-server.cjs
@@ -3,6 +3,7 @@ const process = require('process')
 
 const execa = require('execa')
 const getPort = require('get-port')
+const got = require('got')
 const pTimeout = require('p-timeout')
 
 const cliPath = require('./cli-path.cjs')
@@ -78,6 +79,22 @@ const startServer = async ({
             port,
             errorBuffer,
             outputBuffer,
+            /**
+             * @param {string | URL} urlPath
+             * @param {import('got').OptionsOfTextResponseBody} options
+             * @returns {import('got').CancelableRequest<Response<string>>}
+             */
+            async get(urlPath, options) {
+              return got(`http://localhost:${port}${urlPath}`, options)
+            },
+            /**
+             * @param {string | URL} urlPath
+             * @param {import('got').OptionsOfTextResponseBody} options
+             * @returns {import('got').CancelableRequest<Response<string>>}
+             */
+            async post(urlPath, options) {
+              return got.post(`http://localhost:${port}${urlPath}`, options)
+            },
             waitForLogMatching(match) {
               // eslint-disable-next-line promise/param-names
               return new Promise((resolveWait) => {

--- a/tests/unit/utils/proxy/__snapshots__/alternative-paths-for.test.mjs.snap
+++ b/tests/unit/utils/proxy/__snapshots__/alternative-paths-for.test.mjs.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`alternativePathsFor > file in subfolder url 1`] = `[]`;
+
+exports[`alternativePathsFor > file url 1`] = `
+[
+  "/file.html",
+  "/file.htm",
+  "/file/index.html",
+  "/file/index.htm",
+]
+`;
+
+exports[`alternativePathsFor > folder url 1`] = `
+[
+  "/folder.html",
+  "/folder.htm",
+  "/folder/index.html",
+  "/folder/index.htm",
+]
+`;

--- a/tests/unit/utils/proxy/alternative-paths-for.test.mjs
+++ b/tests/unit/utils/proxy/alternative-paths-for.test.mjs
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest'
+
+import alternativePathsFor from '../../../../src/utils/proxy/alternative-paths-for.mjs'
+
+describe('alternativePathsFor', () => {
+  test('folder url', () => {
+    expect(alternativePathsFor('/folder/')).toMatchSnapshot()
+  })
+
+  test('file url', () => {
+    expect(alternativePathsFor('/file')).toMatchSnapshot()
+  })
+
+  test('file in subfolder url', () => {
+    expect(alternativePathsFor('/folder/index.html')).toMatchSnapshot()
+  })
+})

--- a/tests/unit/utils/proxy/find-static-file-for-url-path.test.mjs
+++ b/tests/unit/utils/proxy/find-static-file-for-url-path.test.mjs
@@ -1,13 +1,13 @@
 import { locatePath } from 'locate-path'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-import getStatic from '../../../../src/utils/proxy/get-static.mjs'
+import findStaticFileForURLPath from '../../../../src/utils/proxy/find-static-file-for-url-path.mjs'
 
 vi.mock('locate-path', () => ({
   locatePath: vi.fn(),
 }))
 
-describe('getStatic', () => {
+describe('findStaticFileForURLPath', () => {
   beforeEach(() => {
     vi.mocked(locatePath).mockClear()
   })
@@ -15,14 +15,14 @@ describe('getStatic', () => {
   test('finds html file', async () => {
     vi.mocked(locatePath).mockReturnValueOnce('/folder.html')
 
-    expect(await getStatic('/folder/', '/')).toEqual('/folder.html')
+    expect(await findStaticFileForURLPath('/folder/', '/')).toEqual('/folder.html')
     expect(locatePath).toHaveBeenCalledOnce()
   })
 
   test('nothing found', async () => {
     vi.mocked(locatePath).mockReturnValueOnce()
 
-    expect(await getStatic('/folder/', '/')).toEqual(undefined)
+    expect(await findStaticFileForURLPath('/folder/', '/')).toEqual(undefined)
     expect(locatePath).toHaveBeenCalledOnce()
   })
 })

--- a/tests/unit/utils/proxy/get-canonical-url-path.test.mjs
+++ b/tests/unit/utils/proxy/get-canonical-url-path.test.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+
+import getCanonicalPath from '../../../../src/utils/proxy/get-canonical-url-path.mjs'
+
+const testCases = [
+  ['/folder/index.html', '/folder/'],
+  ['/folder/index.htm', '/folder/'],
+
+  ['/folder/index.htm/index.html', '/folder/index.htm/'],
+  ['/folder/index.htm/index.htm', '/folder/index.htm/'],
+  ['/folder/index.html/index.html', '/folder/index.html/'],
+  ['/folder/index.html/index.htm', '/folder/index.html/'],
+
+  ['/file.html', '/file'],
+  ['/file.htm', '/file'],
+
+  ['/file.css', '/file.css'],
+]
+
+describe('getCanonicalPath', () => {
+  test.each(testCases)('canonical path for %s is %s', (staticFile, expected) => {
+    expect(getCanonicalPath(staticFile)).toEqual(expected)
+  })
+})

--- a/tests/unit/utils/proxy/get-static.test.mjs
+++ b/tests/unit/utils/proxy/get-static.test.mjs
@@ -1,0 +1,28 @@
+import { locatePath } from 'locate-path'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import getStatic from '../../../../src/utils/proxy/get-static.mjs'
+
+vi.mock('locate-path', () => ({
+  locatePath: vi.fn(),
+}))
+
+describe('getStatic', () => {
+  beforeEach(() => {
+    vi.mocked(locatePath).mockClear()
+  })
+
+  test('finds html file', async () => {
+    vi.mocked(locatePath).mockReturnValueOnce('/folder.html')
+
+    expect(await getStatic('/folder/', '/')).toEqual('/folder.html')
+    expect(locatePath).toHaveBeenCalledOnce()
+  })
+
+  test('nothing found', async () => {
+    vi.mocked(locatePath).mockReturnValueOnce()
+
+    expect(await getStatic('/folder/', '/')).toEqual(undefined)
+    expect(locatePath).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/utils/proxy/is-function.test.mjs
+++ b/tests/unit/utils/proxy/is-function.test.mjs
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+import isFunction from '../../../../src/utils/proxy/is-function.mjs'
+
+describe('getCanonicalPath', () => {
+  test('returns true when port set and function url', () => {
+    expect(isFunction(123, '/.netlify/functions/hello')).toEqual(true)
+  })
+
+  test('returns true when port set and builder url', () => {
+    expect(isFunction(123, '/.netlify/builders/hello')).toEqual(true)
+  })
+
+  test('returns false when port set but not function url', () => {
+    expect(isFunction(123, '/other/hello')).toEqual(false)
+  })
+
+  test('returns false when port not set', () => {
+    expect(isFunction(undefined, '/.netlify/functions/hello')).toEqual(false)
+  })
+})


### PR DESCRIPTION
#### Summary

Fixes https://github.com/netlify/pod-compute/issues/432

This adds canonical redirect for HTML files, the same as in production.

This is done on every request before proxying to the static file server or the frameworks dev server. Although if a framework uses an in-memory dev server we cannot mimic the behavior, as there are no static files to check against.

Most of the new files is restructuring so that I was able to write unit tests for each file.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
