### PR TITLE
feat: add metadata and `onError` to edge functions

### DIFF
--- a/src/lib/edge-functions/bootstrap.mjs
+++ b/src/lib/edge-functions/bootstrap.mjs
@@ -1,5 +1,5 @@
 import { env } from 'process'
 
-const latestBootstrapURL = 'https://64109c4552d9020008b9dadc--edge.netlify.com/bootstrap/index-combined.ts'
+const latestBootstrapURL = 'https://6419767d9dc968000848742a--edge.netlify.com/bootstrap/index-combined.ts'
 
 export const getBootstrapURL = () => env.NETLIFY_EDGE_BOOTSTRAP || latestBootstrapURL

--- a/src/lib/edge-functions/headers.mjs
+++ b/src/lib/edge-functions/headers.mjs
@@ -25,3 +25,12 @@ export const getFeatureFlagsHeader = (featureFlags) => {
 
   return Buffer.from(JSON.stringify(featureFlagsObject)).toString('base64')
 }
+
+/**
+ * Takes the invocation metadata object and produces a Base64-encoded JSON
+ * object that the bootstrap layer can understand.
+ *
+ * @param {object} metadata
+ * @returns {string}
+ */
+export const getInvocationMetadataHeader = (metadata) => Buffer.from(JSON.stringify(metadata)).toString('base64')

--- a/src/lib/edge-functions/headers.mjs
+++ b/src/lib/edge-functions/headers.mjs
@@ -1,6 +1,8 @@
 const headers = {
+  FeatureFlags: 'x-nf-feature-flags',
   ForwardedHost: 'x-forwarded-host',
   Functions: 'x-nf-edge-functions',
+  InvocationMetadata: 'x-nf-edge-functions-metadata',
   Geo: 'x-nf-geo',
   Passthrough: 'x-nf-passthrough',
   IP: 'x-nf-client-connection-ip',

--- a/src/lib/edge-functions/headers.mjs
+++ b/src/lib/edge-functions/headers.mjs
@@ -1,4 +1,7 @@
-const headers = {
+// @ts-check
+import { Buffer } from 'buffer'
+
+export const headers = {
   FeatureFlags: 'x-nf-feature-flags',
   ForwardedHost: 'x-forwarded-host',
   Functions: 'x-nf-edge-functions',
@@ -10,4 +13,15 @@ const headers = {
   DebugLogging: 'x-nf-debug-logging',
 }
 
-export default headers
+/**
+ * Takes an array of feature flags and produces a Base64-encoded JSON object
+ * that the bootstrap layer can understand.
+ *
+ * @param {Array<string>} featureFlags
+ * @returns {string}
+ */
+export const getFeatureFlagsHeader = (featureFlags) => {
+  const featureFlagsObject = featureFlags.reduce((acc, flagName) => ({ ...acc, [flagName]: true }), {})
+
+  return Buffer.from(JSON.stringify(featureFlagsObject)).toString('base64')
+}

--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -12,7 +12,7 @@ import { startSpinner, stopSpinner } from '../spinner.mjs'
 
 import { getBootstrapURL } from './bootstrap.mjs'
 import { DIST_IMPORT_MAP_PATH } from './consts.mjs'
-import { headers, getFeatureFlagsHeader } from './headers.mjs'
+import { headers, getFeatureFlagsHeader, getInvocationMetadataHeader } from './headers.mjs'
 import { getInternalFunctions } from './internal.mjs'
 import { EdgeFunctionsRegistry } from './registry.mjs'
 
@@ -110,7 +110,6 @@ export const initializeProxy = async ({
 
     const url = new URL(req.url, `http://${LOCAL_HOST}:${mainPort}`)
     const { functionNames, invocationMetadata, orphanedDeclarations } = registry.matchURLPath(url.pathname)
-    const invocationMetadataHeader = Buffer.from(JSON.stringify(invocationMetadata)).toString('base64')
 
     // If the request matches a config declaration for an Edge Function without
     // a matching function file, we warn the user.
@@ -136,7 +135,7 @@ export const initializeProxy = async ({
       [headers.FeatureFlags]: getFeatureFlagsHeader(featureFlags),
       [headers.ForwardedHost]: `localhost:${passthroughPort}`,
       [headers.Functions]: functionNames.join(','),
-      [headers.InvocationMetadata]: invocationMetadataHeader,
+      [headers.InvocationMetadata]: getInvocationMetadataHeader(invocationMetadata),
       [headers.IP]: LOCAL_HOST,
       [headers.Passthrough]: 'passthrough',
     }

--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -12,7 +12,7 @@ import { startSpinner, stopSpinner } from '../spinner.mjs'
 
 import { getBootstrapURL } from './bootstrap.mjs'
 import { DIST_IMPORT_MAP_PATH } from './consts.mjs'
-import headers from './headers.mjs'
+import { headers, getFeatureFlagsHeader } from './headers.mjs'
 import { getInternalFunctions } from './internal.mjs'
 import { EdgeFunctionsRegistry } from './registry.mjs'
 
@@ -51,12 +51,6 @@ export const createSiteInfoHeader = (siteInfo = {}) => {
   const site = { id, name, url }
   const siteString = JSON.stringify(site)
   return Buffer.from(siteString).toString('base64')
-}
-
-const getFeatureFlagsHeader = (featureFlags) => {
-  const featureFlagsObject = featureFlags.reduce((acc, flagName) => ({ ...acc, [flagName]: true }), {})
-
-  return Buffer.from(JSON.stringify(featureFlagsObject)).toString('base64')
 }
 
 export const initializeProxy = async ({

--- a/src/lib/edge-functions/registry.mjs
+++ b/src/lib/edge-functions/registry.mjs
@@ -268,6 +268,10 @@ export class EdgeFunctionsRegistry {
       functionConfig: this.declarationsFromSource,
       functions: this.functions,
     })
+    const invocationMetadata = {
+      function_config: manifest.function_config,
+      routes: manifest.routes.map((route) => ({ function: route.function, pattern: route.pattern })),
+    }
     const routes = [...manifest.routes, ...manifest.post_cache_routes].map((route) => ({
       ...route,
       pattern: new RegExp(route.pattern),
@@ -283,7 +287,7 @@ export class EdgeFunctionsRegistry {
       .map((route) => route.function)
     const orphanedDeclarations = this.matchURLPathAgainstOrphanedDeclarations(urlPath)
 
-    return { functionNames, orphanedDeclarations }
+    return { functionNames, invocationMetadata, orphanedDeclarations }
   }
 
   matchURLPathAgainstOrphanedDeclarations(urlPath) {


### PR DESCRIPTION
#### Summary

This PR contains the following changes:

- Starts sending the invocation metadata object to the isolate via a header
- Starts sending select feature flags to the isolate via a header (currently only `edge_functions_bootstrap_failure_mode`)
- Updates the bootstrap layer version