### PR TITLE
feat: add ability to provide existing file digest

### DIFF
--- a/src/commands/deploy/deploy.mjs
+++ b/src/commands/deploy/deploy.mjs
@@ -304,6 +304,7 @@ const runDeploy = async ({
   deployFolder,
   deployTimeout,
   deployToProduction,
+  existingFileDigest,
   functionsConfig,
   functionsFolder,
   silent,
@@ -338,6 +339,7 @@ const runDeploy = async ({
     // @ts-ignore
     results = await deploySite(api, siteId, deployFolder, {
       configPath,
+      existingFileDigest,
       fnDir: functionDirectories,
       functionsConfig,
       statusCb: silent ? () => {} : deployProgressCb(),
@@ -640,6 +642,7 @@ const deploy = async (options, command) => {
     deployFolder,
     deployTimeout: options.timeout * SEC_TO_MILLISEC || DEFAULT_DEPLOY_TIMEOUT,
     deployToProduction,
+    existingFileDigest: options.existingFileDigest,
     functionsConfig,
     // pass undefined functionsFolder if doesn't exist
     functionsFolder: functionsFolderStat && functionsFolder,
@@ -779,6 +782,11 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
       '--skip-functions-cache',
       'Ignore any functions created as part of a previous `build` or `deploy` commands, forcing them to be bundled again as part of the deployment',
       false,
+    )
+    .option(
+      '--existing-file-digest <json>',
+      'Preload the file digest with known existing assets for incremental deploys',
+      JSON.parse,
     )
     .addExamples([
       'netlify deploy',

--- a/src/utils/deploy/deploy-site.mjs
+++ b/src/utils/deploy/deploy-site.mjs
@@ -31,6 +31,7 @@ export const deploySite = async (
     deployId: deployIdOpt = null,
     deployTimeout = DEFAULT_DEPLOY_TIMEOUT,
     draft = false,
+    existingFileDigest = {},
     filter,
     fnDir = [],
     functionsConfig,
@@ -122,7 +123,7 @@ For more information, visit https://ntl.fyi/cli-native-modules.`)
   let deployParams = cleanDeep({
     siteId,
     body: {
-      files,
+      files: { ...existingFileDigest.files, ...files },
       functions,
       function_schedules: functionSchedules,
       functions_config: fnConfig,

--- a/tests/integration/incremental-site/README.md
+++ b/tests/integration/incremental-site/README.md
@@ -1,0 +1,66 @@
+# Incremental Deploys
+
+In this example, we upload one directory, then we _append_ (incrementally upload) to the deploy with a new directory.
+This can be leveraged for build-time "on-demand ISR"-like capabilities with CI/CD caching the previous deploys file
+digest.
+
+1. Upload the `base-deploy` directory to a Netlify site
+
+```
+netlify deploy -d ./base-deploy
+```
+
+> ```
+> ...
+> ✔ CDN requesting 4 files
+> ...
+> ```
+
+2. Confirm file `one` exists:
+
+```
+curl -I https://$WEBSITE_DRAFT_URL/one
+```
+
+> ```
+> HTTP/2 200
+> ...
+> ```
+
+3. Upload the `new-deploy` directory, but pass the existing file digest JSON
+
+```
+netlify deploy -d ./new-deploy --existing-file-digest "$(<./base-deploy.json)"
+```
+
+> ```
+> ...
+> ✔ CDN requesting 1 files
+> ...
+> ```
+
+4. Confirm file `two` exists
+
+```
+curl -I https://$WEBSITE_DRAFT_URL/two
+```
+
+> ```
+> HTTP/2 200
+> ...
+> ```
+
+5. Confirm file `one` also _still_ exists
+
+```
+curl -I https://$WEBSITE_DRAFT_URL/one
+```
+
+> ```
+> HTTP/2 200
+> ...
+> ```
+
+```
+
+```

--- a/tests/integration/incremental-site/base-deploy.json
+++ b/tests/integration/incremental-site/base-deploy.json
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "netlify.toml": "395fc2be95377d1e0f95eec2cd983d7a26e48a39",
+    "one.html": "9e09cdc8f140342ddc2508380d43aa0447a46478"
+  }
+}

--- a/tests/integration/incremental-site/base-deploy/one.html
+++ b/tests/integration/incremental-site/base-deploy/one.html
@@ -1,0 +1,1 @@
+a1ca9451cd6e8fc01daaa28d4becc997

--- a/tests/integration/incremental-site/new-deploy/two.html
+++ b/tests/integration/incremental-site/new-deploy/two.html
@@ -1,0 +1,1 @@
+952bf0d25bdc98adede3ed91065c7dc8


### PR DESCRIPTION
#### Summary

Simulates On-Demand ISR by adding the ability to provide an existing file digest, without requiring those files to actually exist or be hashed (#297).

### Rationale

Currently [On-Demand ISR is not supported](https://github.com/netlify/next-runtime/issues/1288) on the Next.js Runtime. We can emulate this capability with external CI and the Netlify CLI by simply redoing the deploy with the changed files, plus all the previous deploys' files. The Netlify CLI hashes all these files, and the Netlify API will reply that only the changed files need to be uploaded.

If there are a lot of these files, we ask our CI to restore and then Netlify CLI to hash files that we know we have no intention of uploading.

Instead, the CI could just cache only the previous deploys' file digest JSON (or re-request it using the undocumented API `/api/v1/deploys/{deploy_id}/files`), and enable the CLI deploy command to merge the digest of just the new files, with the previous digest.

This is a WIP and more of a PoC of a strategy that could enable performant incremental uploads with an external build system, which is likely not the direction Netlify hopes to pursue.

```mermaid
---
title: Normal On-Demand ISR Workflow
---
flowchart LR
    CMS -->|New Content| Netlify
    Netlify -->|New Pages| Site
```

```mermaid
---
title: CI-Based "On-Demand ISR" Workflow
---
flowchart LR
    CMS -->|New Content| CI
    CACHE -->|Previous Content| CI
    CI -->|New + Previous Pages| Site
```

### Demo

1. Upload the `base-deploy` directory containing only `one.html` to a Netlify site

```
netlify deploy -d ./base-deploy
```

> ```
> ...
> ✔ CDN requesting 4 files
> ...
> ```
2. Confirm file `one` exists:

```
curl -I https://$WEBSITE_DRAFT_URL/one
```

> ```
> HTTP/2 200
> ...
> ```
3. Upload the `new-deploy` directory containing only `two.html`, but pass the existing file digest JSON

```
netlify deploy -d ./new-deploy --existing-file-digest "$(<./base-deploy.json)"
```

> ```
> ...
> ✔ CDN requesting 1 files
> ...
> ```
4. Confirm file `two` exists

```
curl -I https://$WEBSITE_DRAFT_URL/two
```

> ```
> HTTP/2 200
> ...
> ```
5. Confirm file `one` also _still_ exists

```
curl -I https://$WEBSITE_DRAFT_URL/one
```

> ```
> HTTP/2 200
> ...
> ```
```
```

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅