### PR TITLE
fix: correctly reload edge functions on change

### DIFF
--- a/tests/integration/commands/dev/scheduled-functions.test.ts
+++ b/tests/integration/commands/dev/scheduled-functions.test.ts
@@ -38,7 +38,7 @@ describe('scheduled functions', () => {
             }
           })`,
         })
-        .buildAsync()
+        .build()
 
       const DETECT_FILE_CHANGE_DELAY = 500
       await pause(DETECT_FILE_CHANGE_DELAY)

--- a/tests/integration/utils/dev-server.cjs
+++ b/tests/integration/utils/dev-server.cjs
@@ -119,11 +119,12 @@ const startDevServer = async (options, expectFailure) => {
   // eslint-disable-next-line fp/no-loops
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const { timeout, ...server } = await startServer({ ...options, expectFailure })
-      if (timeout) {
-        throw new Error(`Timed out starting dev server.\nServer Output:\n${server.output}`)
+      // do not use destruction, as we use getters which otherwise would be evaluated here
+      const devServer = await startServer({ ...options, expectFailure })
+      if (devServer.timeout) {
+        throw new Error(`Timed out starting dev server.\nServer Output:\n${devServer.output}`)
       }
-      return server
+      return devServer
     } catch (error) {
       if (attempt === maxAttempts || expectFailure) {
         throw error

--- a/tests/integration/utils/site-builder.cjs
+++ b/tests/integration/utils/site-builder.cjs
@@ -82,6 +82,11 @@ class SiteBuilder {
     return this
   }
 
+  /**
+   *
+   * @param {{config?:any, handler:any, internal?:boolean, name?:string, pathPrefix?:string}} param0
+   * @returns
+   */
   withEdgeFunction({ config, handler, internal = false, name = 'function', pathPrefix = '' }) {
     const edgeFunctionsDirectory = internal ? '.netlify/edge-functions' : 'netlify/edge-functions'
     const dest = path.join(this.directory, pathPrefix, edgeFunctionsDirectory, `${name}.js`)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

The problem was that when the handling of internal and user functions was split, the detection for added/deleted function broke. All edge functions were always removed on change, because when detecting internal functions, the user functions were marked as deleted, and vice versa.



Ref https://github.com/netlify/pillar-support/issues/379


