### PR TITLE
fix: set Host header on edge functions in HTTPS

### DIFF
--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -131,10 +131,11 @@ export const initializeProxy = async ({
     }
 
     const featureFlags = ['edge_functions_bootstrap_failure_mode']
+    const forwardedHost = `localhost:${passthroughPort}`
 
     req[headersSymbol] = {
       [headers.FeatureFlags]: getFeatureFlagsHeader(featureFlags),
-      [headers.ForwardedHost]: `localhost:${passthroughPort}`,
+      [headers.ForwardedHost]: forwardedHost,
       [headers.Functions]: functionNames.join(','),
       [headers.InvocationMetadata]: getInvocationMetadataHeader(invocationMetadata),
       [headers.IP]: LOCAL_HOST,
@@ -143,6 +144,13 @@ export const initializeProxy = async ({
 
     if (debug) {
       req[headersSymbol][headers.DebugLogging] = '1'
+    }
+
+    // If we're using a different port for passthrough requests, which is the
+    // case when the CLI is running on HTTPS, use it on the Host header so
+    // that the request URL inside the edge function is something accessible.
+    if (mainPort !== passthroughPort) {
+      req[headersSymbol].host = forwardedHost
     }
 
     return `http://${LOCAL_HOST}:${isolatePort}`


### PR DESCRIPTION
#### Summary

Sets the `Host` header to the passthrough URL in edge functions, so that `req.url` contains a valid URL when running the CLI on HTTPS.