### PR TITLE
Update CODEOWNERS (bulk-codeowners)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-.github/CODEOWNERS        @netlify/netlify-dev
-docs/                     @netlify/netlify-dev @netlify/docs
-site/                     @netlify/netlify-dev @netlify/docs
-/scripts/docs.js          @netlify/netlify-dev @netlify/docs
-/src/functions-templates/ @netlify/runtime-pod-compute 
-/src/lib/functions/       @netlify/runtime-pod-compute 
-/src/lib/edge-functions/  @netlify/runtime-pod-compute 
-/src/utils/functions/     @netlify/runtime-pod-compute 
+.github/CODEOWNERS  @netlify/netlify-dev
+docs/  @netlify/netlify-dev  @netlify/department-docs
+site/  @netlify/netlify-dev  @netlify/department-docs
+/scripts/docs.js  @netlify/netlify-dev  @netlify/department-docs
+/src/functions-templates/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+/src/lib/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+/src/lib/edge-functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+/src/utils/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-.github/CODEOWNERS  @netlify/netlify-dev
-docs/  @netlify/netlify-dev  @netlify/department-docs
-site/  @netlify/netlify-dev  @netlify/department-docs
-/scripts/docs.js  @netlify/netlify-dev  @netlify/department-docs
-/src/functions-templates/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
-/src/lib/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
-/src/lib/edge-functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
-/src/utils/functions/ @netlify/ecosystem-pod-developer-foundations @netlify/runtime-pod-compute
+.github/CODEOWNERS @netlify/netlify-dev 
+docs/ @netlify/netlify-dev  @netlify/department-docs 
+site/ @netlify/netlify-dev  @netlify/department-docs 
+/scripts/docs.js @netlify/netlify-dev  @netlify/department-docs 
+/src/functions-templates/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations
+/src/lib/functions/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations
+/src/lib/edge-functions/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations
+/src/utils/functions/ @netlify/runtime-pod-compute @netlify/ecosystem-pod-developer-foundations


### PR DESCRIPTION

Updating the CODOWNERS file to accomodate the reorg.

## How this change was made
Changes are being made to replace no-longer-valid team names with the names of teams
that are replacing them, and adding what will be the new names for teams that should
exist post-reorg.

The code making these changes is in https://github.com/netlify/codeowners-scanner/

The announcement about this is in [#crew-engineering](https://netlify.slack.com/archives/CPJQSPQE4/p1683313309631019)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>