### PR TITLE
fix: ef error page should have 500 status code

### DIFF
--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -507,6 +507,7 @@ const initializeProxy = async function ({ configPath, distDir, env, host, port, 
         const contentLength = Buffer.from(errorResponse, 'utf8').byteLength
 
         res.setHeader('content-length', contentLength)
+        res.statusCode = 500
         res.write(errorResponse)
         return res.end()
       }

--- a/tests/integration/100.command.dev.test.cjs
+++ b/tests/integration/100.command.dev.test.cjs
@@ -577,8 +577,10 @@ test('When an edge function throws uncaught exception, the dev server continues 
     await withDevServer({ cwd: builder.directory }, async (server) => {
       const response1 = await got(`${server.url}/hello`, {
         decompress: false,
+        throwHttpErrors: false,
       })
-      t.is(response1.statusCode, 200)
+      t.is(response1.statusCode, 500)
+      t.regex(response1.body, /TypeError: Invalid URL/)
     })
   })
 })


### PR DESCRIPTION
Currently, we're returning a 200 status code for the error page. This PR changes that to a 500.