### PR TITLE
fix: add test for v2 error screen with text/html content-type

### DIFF
--- a/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/uncaught-exception.mjs
+++ b/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/uncaught-exception.mjs
@@ -1,0 +1,3 @@
+export default async () => {
+  throw new Error('💣')
+}

--- a/tests/integration/commands/dev/v2-api.test.ts
+++ b/tests/integration/commands/dev/v2-api.test.ts
@@ -66,7 +66,7 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
 
     test<FixtureTestContext>('brotli encoding works', async ({ devServer }) => {
       const response = await fetch(`http://localhost:${devServer.port}/.netlify/functions/brotli`)
-      
+
       expect(response.status).toBe(200)
       expect(await response.text()).toBe("What's 🍞🏄‍♀️? A breadboard!".repeat(100))
     })
@@ -76,6 +76,18 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
 
       expect(response.status).toBe(200)
       expect(await response.text()).toBe('pong')
+    })
+
+    test<FixtureTestContext>('shows netlify-branded error screen', async ({ devServer }) => {
+      const response = await fetch(`http://localhost:${devServer.port}/.netlify/functions/uncaught-exception`, {
+        headers: {
+          Accept: 'text/html',
+        },
+      })
+
+      expect(response.status).toBe(500)
+      expect(response.headers.get('content-type')).toBe('text/html')
+      expect(await response.text()).toContain('<html>')
     })
   })
 })


### PR DESCRIPTION
#### Summary

Fixes https://github.com/netlify/cli/issues/5839. Turns out we were showing the error screen already, and I didn't look close enough. This PR adds a test for that.

What we were missing though is a `text/html` content-type. This PR adds that.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
