### PR TITLE
fix: dont block watching when netlify.toml doesnt exist

### DIFF
--- a/src/lib/edge-functions/registry.mjs
+++ b/src/lib/edge-functions/registry.mjs
@@ -467,17 +467,19 @@ export class EdgeFunctionsRegistry {
    * @param {string} projectDir
    */
   async #setupWatchers(projectDir) {
-    // Creating a watcher for the config file. When it changes, we update the
-    // declarations and see if we need to register or unregister any functions.
-    this.#configWatcher = await watchDebounced(this.#configPath, {
-      onChange: async () => {
-        const newConfig = await this.#getUpdatedConfig()
+    if (this.#configPath) {
+      // Creating a watcher for the config file. When it changes, we update the
+      // declarations and see if we need to register or unregister any functions.
+      this.#configWatcher = await watchDebounced(this.#configPath, {
+        onChange: async () => {
+          const newConfig = await this.#getUpdatedConfig()
 
-        this.#declarationsFromTOML = EdgeFunctionsRegistry.#getDeclarationsFromTOML(newConfig)
+          this.#declarationsFromTOML = EdgeFunctionsRegistry.#getDeclarationsFromTOML(newConfig)
 
-        await this.#checkForAddedOrDeletedFunctions()
-      },
-    })
+          await this.#checkForAddedOrDeletedFunctions()
+        },
+      })
+    }
 
     // While functions are guaranteed to be inside one of the configured
     // directories, they might be importing files that are located in


### PR DESCRIPTION
In Local Dev, when there is no `netlify.toml` (e.g. because in-source-config is being used), `this.#configPath` was undefined. This caused the config file watcher to block indefinitely, so we never got to register the second watcher. This breaks automatic file reloading.

This PR fixes that by skipping the config watcher, if there is no config file. Ideally, we'd have both watchers and chokidar didn't block, so we'd pick up when the config file is added. Let's do that in a follow-up though.