### PR TITLE
fix: framework name in reporting

### DIFF
--- a/src/utils/detect-server-settings.mjs
+++ b/src/utils/detect-server-settings.mjs
@@ -209,11 +209,11 @@ const detectChangesInNewSettings = (frameworkSettings, newSettings, metadata) =>
   const message = ['']
   const [setting] = newSettings
 
-  if (frameworkSettings?.framework !== setting?.framework) {
+  if (frameworkSettings?.framework !== setting?.framework.name) {
     message.push(
       `- Framework does not match:`,
       `   [old]: ${frameworkSettings?.framework}`,
-      `   [new]: ${setting?.framework}`,
+      `   [new]: ${setting?.framework.name}`,
       '',
     )
   }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary


The framework object changed quite a while back but it got never fixed here:
This results in settings mismatch errors:
![CleanShot 2023-07-19 at 09 30 15](https://github.com/netlify/cli/assets/11156362/209c9077-ece0-4b52-ba37-b873483360a4)


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
