### PR TITLE
feat: error when V2 functions are used with Node <18

### DIFF
--- a/src/lib/functions/runtimes/js/worker.mjs
+++ b/src/lib/functions/runtimes/js/worker.mjs
@@ -11,7 +11,7 @@ if (isMainThread) {
 
 sourceMapSupport.install()
 
-lambdaLocal.getLogger().level = 'warn'
+lambdaLocal.getLogger().level = 'alert'
 
 const { clientContext, entryFilePath, event, timeoutMs } = workerData
 


### PR DESCRIPTION
#### Summary

The v2 API for functions requires Node 18 or greater, since it uses built-ins like `Request` and `Response`. If people try to use a function with an older version of Node, it will fail and they might be confused as to why.

In this PR we check for that scenario specifically and show a friendly error message. It also tidies up the logic for reloading functions. Finally, it ensures that if there was a build error in the function, it will be shown in the Netlify-branded error page when the function is accessed.

<img width="1141" alt="Screenshot 2023-08-04 at 00 03 05" src="https://github.com/netlify/cli/assets/4162329/b4982a6e-16f2-4c0b-a5ca-8e5725ab5646">

