### PR TITLE
fix: always fetch immutable ef bootstrap version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@bugsnag/js": "7.20.2",
         "@fastify/static": "6.10.2",
-        "@netlify/build": "29.19.0",
+        "@netlify/build": "29.20.0",
         "@netlify/build-info": "7.7.3",
         "@netlify/config": "20.8.0",
         "@netlify/edge-bundler": "8.17.1",
@@ -2256,9 +2256,9 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "node_modules/@netlify/build": {
-      "version": "29.19.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.19.0.tgz",
-      "integrity": "sha512-T0dmPrLotGn1z36dGHFzl1Ndq3DD3APFd+68PlD8k5w/IamnpDkrnNaFpz40+npqK48G+CylLxvXVwLYcHGw2g==",
+      "version": "29.20.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.20.0.tgz",
+      "integrity": "sha512-R2gOkJQYOeitIZtCfQkn1D75ltUsOVuAzbr1fOpvoAqH8xc3Vlw/bmOX2OkF5pGtbvakHay4KvME6q3m2Xxo9g==",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
         "@honeycombio/opentelemetry-node": "^0.4.0",
@@ -25416,9 +25416,9 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "@netlify/build": {
-      "version": "29.19.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.19.0.tgz",
-      "integrity": "sha512-T0dmPrLotGn1z36dGHFzl1Ndq3DD3APFd+68PlD8k5w/IamnpDkrnNaFpz40+npqK48G+CylLxvXVwLYcHGw2g==",
+      "version": "29.20.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-29.20.0.tgz",
+      "integrity": "sha512-R2gOkJQYOeitIZtCfQkn1D75ltUsOVuAzbr1fOpvoAqH8xc3Vlw/bmOX2OkF5pGtbvakHay4KvME6q3m2Xxo9g==",
       "requires": {
         "@bugsnag/js": "^7.0.0",
         "@honeycombio/opentelemetry-node": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@bugsnag/js": "7.20.2",
     "@fastify/static": "6.10.2",
-    "@netlify/build": "29.19.0",
+    "@netlify/build": "29.20.0",
     "@netlify/build-info": "7.7.3",
     "@netlify/config": "20.8.0",
     "@netlify/edge-bundler": "8.17.1",

--- a/src/lib/build.mjs
+++ b/src/lib/build.mjs
@@ -3,6 +3,7 @@ import process from 'process'
 
 import build from '@netlify/build'
 
+import { getBootstrapURL } from './edge-functions/bootstrap.mjs'
 import { featureFlags as edgeFunctionsFeatureFlags } from './edge-functions/consts.mjs'
 
 /**
@@ -43,6 +44,7 @@ export const getBuildOptions = ({
     ...edgeFunctionsFeatureFlags,
     functionsBundlingManifest: true,
   },
+  edgeFunctionsBootstrapURL: getBootstrapURL(),
 })
 
 /**

--- a/src/utils/run-build.mjs
+++ b/src/utils/run-build.mjs
@@ -2,6 +2,7 @@
 import { promises as fs } from 'fs'
 import path, { join } from 'path'
 
+import { getBootstrapURL } from '../lib/edge-functions/bootstrap.mjs'
 import { INTERNAL_EDGE_FUNCTIONS_FOLDER } from '../lib/edge-functions/consts.mjs'
 import { getPathInProject } from '../lib/settings.mjs'
 
@@ -73,6 +74,7 @@ export const runNetlifyBuild = async ({ command, env = {}, options, settings, ti
     cwd: cachedConfig.buildDir,
     quiet: options.quiet,
     saveConfig: options.saveConfig,
+    edgeFunctionsBootstrapURL: getBootstrapURL(),
   }
 
   const devCommand = async (settingsOverrides = {}) => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #5923. 

We had an issue where Deno cached an old version of edge-functions-bootstrap locally. On the next run, Deno re-fetched some of the assets but not others. Since it assumes URLs to be immutable, this shouldn't have made a difference - but because we were using the `https://edge.netlify.com` endpoint to parse Edge Functions config, the contents changed. This broke some customers trying to deploy edge functions locally. I have a hunch that this only affected some versions of Deno and not others.

Anyways, this PR fixes the issue by injecting a deploy-scoped Bootstrap URL into netlify/build (and by extension, into netlify/edge-bundler). Deploy-scoped URLs are immutable, so they should fix this bug.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
