### PR TITLE
fix: use `packagePath` to compute internal functions directories

### DIFF
--- a/src/commands/deploy/deploy.mjs
+++ b/src/commands/deploy/deploy.mjs
@@ -324,6 +324,7 @@ const runDeploy = async ({
   deployToProduction,
   functionsConfig,
   functionsFolder,
+  packagePath,
   silent,
   site,
   siteData,
@@ -345,13 +346,13 @@ const runDeploy = async ({
     results = await api.createSiteDeploy({ siteId, title, body: { draft, branch: alias } })
     deployId = results.id
 
-    const internalFunctionsFolder = await getInternalFunctionsDir({ base: site.root })
+    const internalFunctionsFolder = await getInternalFunctionsDir({ base: site.root, packagePath })
 
     // The order of the directories matter: zip-it-and-ship-it will prioritize
     // functions from the rightmost directories. In this case, we want user
     // functions to take precedence over internal functions.
     const functionDirectories = [internalFunctionsFolder, functionsFolder].filter(Boolean)
-    const manifestPath = skipFunctionsCache ? null : await getFunctionsManifestPath({ base: site.root })
+    const manifestPath = skipFunctionsCache ? null : await getFunctionsManifestPath({ base: site.root, packagePath })
 
     // @ts-ignore
     results = await deploySite(api, siteId, deployFolder, {
@@ -367,6 +368,7 @@ const runDeploy = async ({
       workingDir: command.workingDir,
       manifestPath,
       skipFunctionsCache,
+      siteRoot: site.root,
     })
   } catch (error_) {
     if (deployId) {
@@ -657,6 +659,7 @@ const deploy = async (options, command) => {
     functionsConfig,
     // pass undefined functionsFolder if doesn't exist
     functionsFolder: functionsFolderStat && functionsFolder,
+    packagePath: command.workspacePackage,
     silent: options.json || options.silent,
     site,
     siteData,

--- a/src/utils/deploy/deploy-site.mjs
+++ b/src/utils/deploy/deploy-site.mjs
@@ -40,6 +40,7 @@ export const deploySite = async (
     // API calls this the 'title'
     message: title,
     siteEnv,
+    siteRoot,
     skipFunctionsCache,
     statusCb = () => {
       /* default to noop */
@@ -78,6 +79,7 @@ export const deploySite = async (
         manifestPath,
         skipFunctionsCache,
         siteEnv,
+        rootDir: siteRoot,
       }),
     ])
   const edgeFunctionsCount = Object.keys(files).filter(isEdgeFunctionFile).length

--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -20,10 +20,10 @@ const getFunctionZips = async ({
   directories,
   functionsConfig,
   manifestPath,
+  rootDir,
   skipFunctionsCache,
   statusCb,
   tmpDir,
-  workingDir,
 }) => {
   statusCb({
     type: 'functions-manifest',
@@ -68,7 +68,7 @@ const getFunctionZips = async ({
   }
 
   return await zipFunctions(directories, tmpDir, {
-    basePath: workingDir,
+    basePath: rootDir,
     configFileDirectories: [getPathInProject([INTERNAL_FUNCTIONS_FOLDER])],
     config: functionsConfig,
   })
@@ -96,6 +96,8 @@ const hashFns = async (
   if (!tmpDir) {
     throw new Error('Missing tmpDir directory for zipping files')
   }
+
+  console.log('---> hashFns', { rootDir })
 
   const functionZips = await getFunctionZips({
     directories,

--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -97,8 +97,6 @@ const hashFns = async (
     throw new Error('Missing tmpDir directory for zipping files')
   }
 
-  console.log('---> hashFns', { rootDir })
-
   const functionZips = await getFunctionZips({
     directories,
     functionsConfig,

--- a/src/utils/functions/functions.mjs
+++ b/src/utils/functions/functions.mjs
@@ -19,15 +19,15 @@ export const SERVE_FUNCTIONS_FOLDER = 'functions-serve'
 export const getFunctionsDir = ({ config, options }, defaultValue) =>
   options.functions || config.dev?.functions || config.functionsDirectory || config.dev?.Functions || defaultValue
 
-export const getFunctionsManifestPath = async ({ base }) => {
-  const path = resolve(base, getPathInProject(['functions', 'manifest.json']))
+export const getFunctionsManifestPath = async ({ base, packagePath = '' }) => {
+  const path = resolve(base, packagePath, getPathInProject(['functions', 'manifest.json']))
   const isFile = await isFileAsync(path)
 
   return isFile ? path : null
 }
 
-export const getFunctionsDistPath = async ({ base }) => {
-  const path = resolve(base, getPathInProject(['functions']))
+export const getFunctionsDistPath = async ({ base, packagePath = '' }) => {
+  const path = resolve(base, packagePath, getPathInProject(['functions']))
   const isDirectory = await isDirectoryAsync(path)
 
   return isDirectory ? path : null
@@ -38,10 +38,11 @@ export const getFunctionsDistPath = async ({ base }) => {
  * @param {object} config
  * @param {string} config.base
  * @param {boolean=} config.ensureExists
+ * @param {string} config.packagePath
  * @returns
  */
-export const getInternalFunctionsDir = async ({ base, ensureExists }) => {
-  const path = resolve(base, getPathInProject([INTERNAL_FUNCTIONS_FOLDER]))
+export const getInternalFunctionsDir = async ({ base, ensureExists, packagePath = '' }) => {
+  const path = resolve(base, packagePath, getPathInProject([INTERNAL_FUNCTIONS_FOLDER]))
 
   if (ensureExists) {
     await fs.mkdir(path, { recursive: true })


### PR DESCRIPTION
#### Summary

The recent monorepo changes were missing the `packagePath` property when computing the internal functions directories, so functions were being placed at the repository root and not in the package path. This broke deployments.