### PR TITLE
feat: let the --cwd option override the monorepo execution directory

### DIFF
--- a/src/commands/base-command.mjs
+++ b/src/commands/base-command.mjs
@@ -574,7 +574,7 @@ export default class BaseCommand extends Command {
     // configuration file and the API
     // ==================================================
     const cachedConfig = await actionCommand.getConfig({
-      cwd: this.jsWorkspaceRoot || this.workingDir,
+      cwd: flags.cwd ? this.workingDir : this.jsWorkspaceRoot || this.workingDir,
       repositoryRoot: rootDir,
       packagePath: this.workspacePackage,
       // The config flag needs to be resolved from the actual process working directory

--- a/src/utils/run-build.mjs
+++ b/src/utils/run-build.mjs
@@ -80,7 +80,7 @@ export const runNetlifyBuild = async ({ command, env = {}, options, settings, ti
   const devCommand = async (settingsOverrides = {}) => {
     let cwd = command.workingDir
 
-    if (command.project.workspace?.packages.length) {
+    if (!options.cwd && command.project.workspace?.packages.length) {
       cwd = join(command.project.jsWorkspaceRoot, settings.baseDirectory || '')
     }
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Let the `--cwd` option override the default set working directory for execution and picking up files.

This restores in monorepos the previous default behavior of `cd <dir>` into a directory.
With that the execution root is not the jsWorkspace root.

Tested with the `next-runtime` monorepo by running:

```bash
ntl dev --cwd demos/default

# or deploying
ntl deploy --build --cwd demos/default
```

see deployed site: 
https://64ddf2008d235c6837b459e8--lukas-next-runtime-demos-default.netlify.app/

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
