### PR TITLE
chore: codeowners update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*                @netlify/ecosystem-pod-developer-foundations
-docs/            @netlify/ecosystem-pod-developer-foundations @netlify/department-docs
-site/            @netlify/ecosystem-pod-developer-foundations @netlify/department-docs
+*                @netlify/ecosystem-pod-composable-tooling
+docs/            @netlify/ecosystem-pod-composable-tooling @netlify/department-docs
+site/            @netlify/ecosystem-pod-composable-tooling @netlify/department-docs


### PR DESCRIPTION
#### Summary

Makes `@netlify/ecosystem-pod-composable-tooling` codeowners