### PR TITLE
Feat: Don't retry function uploads on status 400 or 422

### DIFF
--- a/src/utils/deploy/upload-files.mjs
+++ b/src/utils/deploy/upload-files.mjs
@@ -90,7 +90,6 @@ const retryUpload = (uploadFn, maxRetry) =>
       } catch (error) {
         lastError = error
 
-
         // We don't need to retry for 400 or 422 errors
         if (error.status === 400 || error.status === 422) {
           return reject(error)

--- a/src/utils/deploy/upload-files.mjs
+++ b/src/utils/deploy/upload-files.mjs
@@ -91,7 +91,10 @@ const retryUpload = (uploadFn, maxRetry) =>
         lastError = error
 
         // observed errors: 408, 401 (4** swallowed), 502
-        if (error.status >= 400 || error.name === 'FetchError') {
+        // We don't need to retry for 400 or 422 errors
+        if (error.status == 400 || error.status == 422) {
+          return reject(error)
+        } else if (error.status > 400 || error.name === 'FetchError') {
           fibonacciBackoff.backoff()
           return
         }

--- a/src/utils/deploy/upload-files.mjs
+++ b/src/utils/deploy/upload-files.mjs
@@ -90,11 +90,14 @@ const retryUpload = (uploadFn, maxRetry) =>
       } catch (error) {
         lastError = error
 
-        // observed errors: 408, 401 (4** swallowed), 502
+
         // We don't need to retry for 400 or 422 errors
-        if (error.status == 400 || error.status == 422) {
+        if (error.status === 400 || error.status === 422) {
           return reject(error)
-        } else if (error.status > 400 || error.name === 'FetchError') {
+        }
+
+        // observed errors: 408, 401 (4** swallowed), 502
+        if (error.status > 400 || error.name === 'FetchError') {
           fibonacciBackoff.backoff()
           return
         }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes CLI portion of https://github.com/netlify/functions-origin/issues/358

We don't need to retry function uploads when the status code is 400 or 422.

WIP: this change should be wrapped in a feature flag for now, which has not been implemented yet.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

