### PR TITLE
chore: deprecate `lm` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ See the [CLI command line reference](https://cli.netlify.com/commands/) to get s
   - [functions](#functions)
   - [init](#init)
   - [link](#link)
-  - [lm](#lm)
   - [login](#login)
   - [open](#open)
   - [recipes](#recipes)
@@ -169,17 +168,6 @@ Configure continuous deployment for a new or existing site. To create a new site
 ### [link](/docs/commands/link.md)
 
 Link a local repo or project folder to an existing site on Netlify
-
-### [lm](/docs/commands/lm.md)
-
-Handle Netlify Large Media operations
-
-| Subcommand | description  |
-|:--------------------------- |:-----|
-| [`lm:info`](/docs/commands/lm.md#lminfo) | Show large media requirements information.  |
-| [`lm:install`](/docs/commands/lm.md#lminstall) | Configures your computer to use Netlify Large Media  |
-| [`lm:setup`](/docs/commands/lm.md#lmsetup) | Configures your site to use Netlify Large Media  |
-
 
 ### [login](/docs/commands/login.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,17 +119,6 @@ Configure continuous deployment for a new or existing site. To create a new site
 
 Link a local repo or project folder to an existing site on Netlify
 
-### [lm](/docs/commands/lm.md)
-
-Handle Netlify Large Media operations
-
-| Subcommand | description  |
-|:--------------------------- |:-----|
-| [`lm:info`](/docs/commands/lm.md#lminfo) | Show large media requirements information.  |
-| [`lm:install`](/docs/commands/lm.md#lminstall) | Configures your computer to use Netlify Large Media  |
-| [`lm:setup`](/docs/commands/lm.md#lmsetup) | Configures your site to use Netlify Large Media  |
-
-
 ### [login](/docs/commands/login.md)
 
 Login to your Netlify account

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -98,17 +98,6 @@ Configure continuous deployment for a new or existing site. To create a new site
 
 Link a local repo or project folder to an existing site on Netlify
 
-### [lm](/docs/commands/lm.md)
-
-Handle Netlify Large Media operations
-
-| Subcommand | description  |
-|:--------------------------- |:-----|
-| [`lm:info`](/docs/commands/lm.md#lminfo) | Show large media requirements information.  |
-| [`lm:install`](/docs/commands/lm.md#lminstall) | Configures your computer to use Netlify Large Media  |
-| [`lm:setup`](/docs/commands/lm.md#lmsetup) | Configures your site to use Netlify Large Media  |
-
-
 ### [login](/docs/commands/login.md)
 
 Login to your Netlify account

--- a/docs/commands/lm.md
+++ b/docs/commands/lm.md
@@ -6,8 +6,10 @@ title: Netlify CLI lm command
 
 ## About
 
-<!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
+> ⚠️ The Large Media feature was deprecated on September 1st, 2023 and will become unavailable in a future update. [Learn more and discover alternative solutions](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804)
+
 Handle Netlify Large Media operations
+
 The lm command will help you manage large media for a site
 
 **Usage**
@@ -89,5 +91,4 @@ netlify lm:setup
 - `debug` (*boolean*) - Print debugging information
 
 ---
-
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/site/src/_app.js
+++ b/site/src/_app.js
@@ -70,6 +70,7 @@ const pageNames = {
   'netlify-dev': 'Netlify Dev',
   'functions-dev': 'Functions Development',
   vscode: 'Run and debug with VSCode',
+  lm: 'lm (deprecated)',
 }
 
 const sortRoutes = (routes) =>

--- a/src/commands/lm/lm-info.mjs
+++ b/src/commands/lm/lm-info.mjs
@@ -37,4 +37,4 @@ const lmInfo = async () => {
  * @returns
  */
 export const createLmInfoCommand = (program) =>
-  program.command('lm:info').description('Show large media requirements information.').action(lmInfo)
+  program.command('lm:info', { hidden: true }).description('Show large media requirements information.').action(lmInfo)

--- a/src/commands/lm/lm-install.mjs
+++ b/src/commands/lm/lm-install.mjs
@@ -20,7 +20,7 @@ const lmInstall = async ({ force }) => {
  */
 export const createLmInstallCommand = (program) =>
   program
-    .command('lm:install')
+    .command('lm:install', { hidden: true })
     .alias('lm:init')
     .description(
       `Configures your computer to use Netlify Large Media

--- a/src/commands/lm/lm-setup.mjs
+++ b/src/commands/lm/lm-setup.mjs
@@ -1,7 +1,8 @@
 // @ts-check
+import inquirer from 'inquirer'
 import Listr from 'listr'
 
-import { error } from '../../utils/command-helpers.mjs'
+import { error, exit } from '../../utils/command-helpers.mjs'
 import execa from '../../utils/execa.mjs'
 import { installPlatform } from '../../utils/lm/install.mjs'
 import { checkHelperVersion } from '../../utils/lm/requirements.mjs'
@@ -56,6 +57,19 @@ const configureLFSURL = async function (siteId, api) {
  * @param {import('../base-command.mjs').default} command
  */
 const lmSetup = async (options, command) => {
+  if (!options.force && !options.f) {
+    const { wantsToProceed } = await inquirer.prompt({
+      type: 'confirm',
+      name: 'wantsToProceed',
+      message:
+        'Large media is a deprecated feature and will be removed in a future version. Are you sure you want to continue? (to skip this prompt, pass a --force flag)',
+      default: false,
+    })
+    if (!wantsToProceed) {
+      exit()
+    }
+  }
+
   await command.authenticate()
 
   const { api, site } = command.netlify
@@ -97,7 +111,7 @@ const lmSetup = async (options, command) => {
  */
 export const createLmSetupCommand = (program) =>
   program
-    .command('lm:setup')
+    .command('lm:setup', { hidden: true })
     .description('Configures your site to use Netlify Large Media')
     .option('-s, --skip-install', 'Skip the credentials helper installation check')
     .option('-f, --force-install', 'Force the credentials helper installation')

--- a/src/commands/lm/lm.mjs
+++ b/src/commands/lm/lm.mjs
@@ -25,8 +25,10 @@ export const createLmCommand = (program) => {
   createLmUninstallCommand(program)
 
   program
-    .command('lm')
-    .description('Handle Netlify Large Media operations\nThe lm command will help you manage large media for a site')
+    .command('lm', { hidden: true })
+    .description(
+      '[Deprecated and will be removed from future versions] Handle Netlify Large Media operations\nThe lm command will help you manage large media for a site',
+    )
     .addExamples(['netlify lm:info', 'netlify lm:install', 'netlify lm:setup'])
     .action(lm)
 }

--- a/tests/integration/commands/help/__snapshots__/help.test.ts.snap
+++ b/tests/integration/commands/help/__snapshots__/help.test.ts.snap
@@ -23,7 +23,6 @@ COMMANDS
                  sites:create\`
   $ link         Link a local repo or project folder to an existing site on
                  Netlify
-  $ lm           Handle Netlify Large Media operations
   $ login        Login to your Netlify account
   $ open         Open settings for the site linked to the current folder
   $ serve        (Beta) Build the site for production and serve locally. This


### PR DESCRIPTION
#### Summary

The Large Media feature was deprecated on September 1st, 2023 and will become unavailable in a future update. [Learn more and discover alternative solutions](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804)

As a result, we'll hide the `lm` command from the CLI. It will keep working, but we recommend against setting up Large Media on new sites.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![kaeligd_in_the_style_of_an_epic_movie_poster_create_a_picture_o_b78a907e-b673-4017-953a-5ded10e61bf7 (1)](https://github.com/netlify/cli/assets/85783/901b5195-86c3-4d75-9e94-36122e7891d4)

