### PR TITLE
fix: make lm:setup test pass

### DIFF
--- a/src/commands/lm/lm-setup.mjs
+++ b/src/commands/lm/lm-setup.mjs
@@ -57,7 +57,7 @@ const configureLFSURL = async function (siteId, api) {
  * @param {import('../base-command.mjs').default} command
  */
 const lmSetup = async (options, command) => {
-  if (!options.force && !options.f) {
+  if (!options.force) {
     const { wantsToProceed } = await inquirer.prompt({
       type: 'confirm',
       name: 'wantsToProceed',
@@ -115,5 +115,6 @@ export const createLmSetupCommand = (program) =>
     .description('Configures your site to use Netlify Large Media')
     .option('-s, --skip-install', 'Skip the credentials helper installation check')
     .option('-f, --force-install', 'Force the credentials helper installation')
+    .option('--force', 'Skip deprecation check')
     .addHelpText('after', 'It runs the install command if you have not installed the dependencies yet.')
     .action(lmSetup)

--- a/tests/integration/commands/lm/lm.test.ts
+++ b/tests/integration/commands/lm/lm.test.ts
@@ -91,7 +91,7 @@ describe('lm command', () => {
     })
 
     test<FixtureTestContext>('netlify lm:setup', async ({ fixture }) => {
-      const cliResponse = await fixture.callCli(['lm:setup'], { offline: false, execOptions })
+      const cliResponse = await fixture.callCli(['lm:setup', '--force'], { offline: false, execOptions })
       expect(cliResponse).toContain('Provisioning Netlify Large Media [started]')
       expect(cliResponse).toContain('Provisioning Netlify Large Media [completed]')
       expect(cliResponse).toContain('Configuring Git LFS for this site [started]')


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Follow-up to https://github.com/netlify/cli/pull/5975. It broke the `lm:setup` test, which is currently blocking `main`. Unsure why it didn't break in the PR's test run 🤔 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
