### PR TITLE
fix: decompress body from edge functions errors

### DIFF
--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -544,7 +544,7 @@ const initializeProxy = async function ({ configPath, distDir, env, host, port, 
 
       if (isEdgeFunctionsRequest(req) && isUncaughtError) {
         const acceptsHtml = req.headers && req.headers.accept && req.headers.accept.includes('text/html')
-        const decompressedBody = await decompressResponseBody(responseBody, req.headers['content-encoding'])
+        const decompressedBody = await decompressResponseBody(responseBody, proxyRes.headers['content-encoding'])
         const formattedBody = formatEdgeFunctionError(decompressedBody, acceptsHtml)
         const errorResponse = acceptsHtml
           ? await renderErrorTemplate(formattedBody, './templates/function-error.html', 'edge function')

--- a/tests/integration/__fixtures__/dev-server-with-edge-functions/netlify/edge-functions/uncaught-exception.ts
+++ b/tests/integration/__fixtures__/dev-server-with-edge-functions/netlify/edge-functions/uncaught-exception.ts
@@ -1,0 +1,9 @@
+import { Config, Context } from 'https://edge.netlify.com'
+
+export default (_, context: Context) => {
+  thisWillThrow()
+}
+
+export const config: Config = {
+  path: '/uncaught-exception',
+}

--- a/tests/integration/commands/dev/edge-functions.test.ts
+++ b/tests/integration/commands/dev/edge-functions.test.ts
@@ -77,7 +77,7 @@ describe('edge functions', () => {
       expect(res1.statusCode).toBe(500)
       expect(res1.body).toContain('ReferenceError: thisWillThrow is not defined')
 
-      // Request #1: HTML
+      // Request #2: HTML
       const res2 = await got(`http://localhost:${devServer.port}/uncaught-exception`, {
         method: 'GET',
         headers: {


### PR DESCRIPTION
#### Summary

Right now, if an edge function throws an unhandled exception, the CLI will crash with a cryptic error message:

```
SyntaxError: Unexpected token  in JSON at position 0
    at JSON.parse (<anonymous>)
    at formatEdgeFunctionError (file:///Users/eduardoboucas/Sites/netlify/cli/src/utils/proxy.mjs:65:12)
    at IncomingMessage.onEnd (file:///Users/eduardoboucas/Sites/netlify/cli/src/utils/proxy.mjs:548:31)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This is because the edge function is sending a compressed response which the CLI needs to decompress. We do have some logic for checking whether the body needs to be decompressed, which we've added in https://github.com/netlify/cli/pull/5837, but we're reading the `accept-encoding` header from the incoming request, when we should be reading it from the response we get from the Deno server.