### PR TITLE
fix: set `invocationMode` on deployed functions

### DIFF
--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -106,7 +106,7 @@ const hashFns = async (
     statusCb,
     tmpDir,
   })
-  const fileObjs = functionZips.map(({ displayName, generator, path: functionPath, runtime }) => ({
+  const fileObjs = functionZips.map(({ displayName, generator, invocationMode, path: functionPath, runtime }) => ({
     filepath: functionPath,
     root: tmpDir,
     relname: path.relative(tmpDir, functionPath),
@@ -118,6 +118,7 @@ const hashFns = async (
     runtime,
     displayName,
     generator,
+    invocationMode,
   }))
   const fnConfig = functionZips
     .filter((func) => Boolean(func.displayName || func.generator))

--- a/src/utils/deploy/upload-files.mjs
+++ b/src/utils/deploy/upload-files.mjs
@@ -14,7 +14,7 @@ const uploadFiles = async (api, deployId, uploadList, { concurrentUpload, maxRet
   })
 
   const uploadFile = async (fileObj, index) => {
-    const { assetType, filepath, normalizedPath, runtime } = fileObj
+    const { assetType, filepath, invocationMode, normalizedPath, runtime } = fileObj
     const readStreamCtor = () => fs.createReadStream(filepath)
 
     statusCb({
@@ -41,6 +41,7 @@ const uploadFiles = async (api, deployId, uploadList, { concurrentUpload, maxRet
           const params = {
             body: readStreamCtor,
             deployId,
+            invocationMode,
             name: encodeURI(normalizedPath),
             runtime,
           }

--- a/tests/integration/210.command.deploy.test.cjs
+++ b/tests/integration/210.command.deploy.test.cjs
@@ -475,6 +475,10 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
             body: 'Internal 3',
           }),
         })
+        .withContentFile({
+          content: `export default async () => new Response("Internal V2 API")`,
+          path: '.netlify/functions-internal/func-4.mjs',
+        })
         .buildAsync()
 
       const { deploy_url: deployUrl } = await callCli(
@@ -489,6 +493,7 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
       t.is(await got(`${deployUrl}/.netlify/functions/func-1`).text(), 'User 1')
       t.is(await got(`${deployUrl}/.netlify/functions/func-2`).text(), 'User 2')
       t.is(await got(`${deployUrl}/.netlify/functions/func-3`).text(), 'Internal 3')
+      t.is(await got(`${deployUrl}/.netlify/functions/func-4`).text(), 'Internal V2 API')
     })
   })
 


### PR DESCRIPTION
#### Summary

We've added an `invocationMode` property to functions in https://github.com/netlify/zip-it-and-ship-it/pull/1421, but we've never added it to the API call to [the `uploadDeployFunction` endpoint](https://open-api.netlify.com/#tag/function/operation/uploadDeployFunction) made from the CLI.

This PR addresses that.