### PR TITLE
fix(deps): update version of edge functions bootstrap

### DIFF
--- a/src/lib/edge-functions/bootstrap.mjs
+++ b/src/lib/edge-functions/bootstrap.mjs
@@ -1,5 +1,5 @@
 import { env } from 'process'
 
-const latestBootstrapURL = 'https://64f73321fdd56900083fa618--edge.netlify.com/bootstrap/index-combined.ts'
+const latestBootstrapURL = 'https://650bfd807b21ed000893e25c--edge.netlify.com/bootstrap/index-combined.ts'
 
 export const getBootstrapURL = () => env.NETLIFY_EDGE_BOOTSTRAP || latestBootstrapURL

--- a/tests/integration/200.command.dev.test.cjs
+++ b/tests/integration/200.command.dev.test.cjs
@@ -238,11 +238,8 @@ export const handler = async function () {
 
             if (req.url.includes('?ef=fetch')) {
               const url = new URL('/origin', req.url)
-              try {
-                await fetch(url, {})
-              } catch (error) {
-                return new Response(error, { status: 500 })
-              }
+
+              return await fetch(url)
             }
 
             if (req.url.includes('?ef=url')) {
@@ -265,10 +262,7 @@ export const handler = async function () {
         t.deepEqual(await got(`https://localhost:${port}/api/hello`, options).json(), {
           rawUrl: `https://localhost:${port}/api/hello`,
         })
-
-        // the fetch will go against the `https://` url of the dev server, which isn't trusted system-wide.
-        // this is the expected behaviour for fetch, so we shouldn't change anything about it.
-        t.regex(await got(`https://localhost:${port}?ef=fetch`, options).text(), /invalid peer certificate/)
+        t.is(await got(`https://localhost:${port}?ef=fetch`, options).text(), 'origin')
       })
     })
   })


### PR DESCRIPTION
#### Summary

Updates the version of the edge functions bootstrap. Also updates a test to ensure that edge functions can make `fetch()` calls to the incoming URL even when the CLI is running on HTTPS.

Part of https://github.com/netlify/pod-dev-foundations/issues/590.