### PR TITLE
feat: functions:serve should announce port via banner

### DIFF
--- a/src/commands/functions/functions-serve.mjs
+++ b/src/commands/functions/functions-serve.mjs
@@ -2,8 +2,10 @@
 import { join } from 'path'
 
 import { startFunctionsServer } from '../../lib/functions/server.mjs'
+import { printBanner } from '../../utils/banner.mjs'
 import { acquirePort, getDotEnvVariables, getSiteInformation, injectEnvVariables } from '../../utils/dev.mjs'
 import { getFunctionsDir } from '../../utils/functions/index.mjs'
+import { getProxyUrl } from '../../utils/proxy.mjs'
 
 const DEFAULT_PORT = 9999
 
@@ -55,6 +57,9 @@ const functionsServe = async (options, command) => {
     state,
     accountId,
   })
+
+  const url = getProxyUrl({ port: functionsPort })
+  printBanner({ url })
 }
 
 /**

--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -658,7 +658,7 @@ const onRequest = async (
 }
 
 /**
- * @param {import('./types.js').ServerSettings} settings
+ * @param {Pick<import('./types.js').ServerSettings, "https" | "port">} settings
  * @returns
  */
 export const getProxyUrl = function (settings) {


### PR DESCRIPTION
While testing around Go functions, I noticed that `netlify functions:serve` doesn't announce the port it's listening on. This PR adds the same banner that we're showing for `netlify dev` and `netlify serve`.