### PR TITLE
Pass functions manifest `runtimeVersion` to api when uploading functions

### DIFF
--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -106,7 +106,7 @@ const hashFns = async (
     statusCb,
     tmpDir,
   })
-  const fileObjs = functionZips.map(({ displayName, generator, invocationMode, path: functionPath, runtime }) => ({
+  const fileObjs = functionZips.map(({ displayName, generator, invocationMode, path: functionPath, runtime, runtimeVersion }) => ({
     filepath: functionPath,
     root: tmpDir,
     relname: path.relative(tmpDir, functionPath),
@@ -115,7 +115,7 @@ const hashFns = async (
     type: 'file',
     assetType: 'function',
     normalizedPath: path.basename(functionPath, path.extname(functionPath)),
-    runtime,
+    runtime: runtimeVersion ?? runtime,
     displayName,
     generator,
     invocationMode,

--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -106,20 +106,22 @@ const hashFns = async (
     statusCb,
     tmpDir,
   })
-  const fileObjs = functionZips.map(({ displayName, generator, invocationMode, path: functionPath, runtime, runtimeVersion }) => ({
-    filepath: functionPath,
-    root: tmpDir,
-    relname: path.relative(tmpDir, functionPath),
-    basename: path.basename(functionPath),
-    extname: path.extname(functionPath),
-    type: 'file',
-    assetType: 'function',
-    normalizedPath: path.basename(functionPath, path.extname(functionPath)),
-    runtime: runtimeVersion ?? runtime,
-    displayName,
-    generator,
-    invocationMode,
-  }))
+  const fileObjs = functionZips.map(
+    ({ displayName, generator, invocationMode, path: functionPath, runtime, runtimeVersion }) => ({
+      filepath: functionPath,
+      root: tmpDir,
+      relname: path.relative(tmpDir, functionPath),
+      basename: path.basename(functionPath),
+      extname: path.extname(functionPath),
+      type: 'file',
+      assetType: 'function',
+      normalizedPath: path.basename(functionPath, path.extname(functionPath)),
+      runtime: runtimeVersion ?? runtime,
+      displayName,
+      generator,
+      invocationMode,
+    }),
+  )
   const fnConfig = functionZips
     .filter((func) => Boolean(func.displayName || func.generator))
     .reduce(


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

When uploading functions from `netlify deploy`, we need to ensure that we're passing the right `runtime` parameter to our API. In open-api, we read the `runtimeVersion` field from the manifest, and if it exists we use it instead of the `runtime` field that contains the language. We should have the same behaviour in the CLI, so that the `runtimeVersion` field is respected.

Part of https://github.com/netlify/pod-dev-foundations/issues/581

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
