### PR TITLE
fix: add flag that allows us to control al2 rollout independent of buildbot

### DIFF
--- a/src/lib/build.mjs
+++ b/src/lib/build.mjs
@@ -45,10 +45,20 @@ export const getBuildOptions = ({
   cwd,
   featureFlags: {
     ...edgeFunctionsFeatureFlags,
-    ...cachedConfig.siteInfo.feature_flags,
+    ...getFeatureFlagsFromSiteInfo(cachedConfig.siteInfo),
     functionsBundlingManifest: true,
   },
   edgeFunctionsBootstrapURL: getBootstrapURL(),
+})
+
+/**
+ * @param {*} siteInfo
+ * @returns {Record<string, any>}
+ */
+const getFeatureFlagsFromSiteInfo = (siteInfo) => ({
+  ...siteInfo.feature_flags,
+  // see https://github.com/netlify/pod-dev-foundations/issues/581#issuecomment-1731022753
+  zisi_golang_use_al2: siteInfo.featureFlags?.cli_golang_use_al2,
 })
 
 /**


### PR DESCRIPTION
#### Summary

As explained in https://github.com/netlify/pod-dev-foundations/issues/581#issuecomment-1731022753, enabling the `zisi_golang_use_al2` flag will lead to failures in versions of the CLI that don't have the https://github.com/netlify/cli/pull/6020 patch. That means we need to decouple the rollout of `zisi_golang_use_al2` in buildbot (where @netlify/build is always up-to-date) from the rollout in the CLI, where the flag also affects versions with broken behaviour. That's why this PR adds a second flag, which we can use to control the CLI rollout independently.

Part of https://github.com/netlify/pod-dev-foundations/issues/581

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
