### PR TITLE
fix: include `routes` in functions config on deploy

### DIFF
--- a/src/utils/deploy/hash-fns.mjs
+++ b/src/utils/deploy/hash-fns.mjs
@@ -123,9 +123,12 @@ const hashFns = async (
     }),
   )
   const fnConfig = functionZips
-    .filter((func) => Boolean(func.displayName || func.generator))
+    .filter((func) => Boolean(func.displayName || func.generator || func.routes))
     .reduce(
-      (funcs, curr) => ({ ...funcs, [curr.name]: { display_name: curr.displayName, generator: curr.generator } }),
+      (funcs, curr) => ({
+        ...funcs,
+        [curr.name]: { display_name: curr.displayName, generator: curr.generator, routes: curr.routes },
+      }),
       {},
     )
   const functionSchedules = functionZips

--- a/tests/integration/210.command.deploy.test.cjs
+++ b/tests/integration/210.command.deploy.test.cjs
@@ -437,7 +437,7 @@ if (process.env.NETLIFY_TEST_DISABLE_LIVE !== 'true') {
     })
   })
 
-  test.only('should deploy functions from internal functions directory', async (t) => {
+  test.serial('should deploy functions from internal functions directory', async (t) => {
     await withSiteBuilder('site-with-internal-functions', async (builder) => {
       await builder
         .withNetlifyToml({

--- a/tests/integration/210.command.deploy.test.cjs
+++ b/tests/integration/210.command.deploy.test.cjs
@@ -2,7 +2,7 @@ const { join } = require('path')
 const process = require('process')
 
 const test = require('ava')
-const { Response } = require('node-fetch')
+const { Response, default: fetch } = require('node-fetch')
 
 const callCli = require('./utils/call-cli.cjs')
 const { createLiveTestSite, generateSiteName } = require('./utils/create-live-test-site.cjs')


### PR DESCRIPTION
We weren't including `routes` in the `functions_config` parameter we're sending to the API, so custom v2 routes didn't work properly. This PR fixes that.