### PR TITLE
fix: use only pathname when matching function URLs

### DIFF
--- a/src/lib/functions/registry.mjs
+++ b/src/lib/functions/registry.mjs
@@ -123,7 +123,11 @@ export class FunctionsRegistry {
     return this.functions.get(name)
   }
 
-  async getFunctionForURLPath(urlPath, method) {
+  async getFunctionForURLPath(url, method) {
+    // We're constructing a URL object just so that we can extract the path from
+    // the incoming URL. It doesn't really matter that we don't have the actual
+    // local URL with the correct port.
+    const urlPath = new URL(url, 'http://localhost').pathname
     const defaultURLMatch = urlPath.match(DEFAULT_URL_EXPRESSION)
 
     if (defaultURLMatch) {


### PR DESCRIPTION
#### Summary

Fixes a regression in https://github.com/netlify/cli/pull/5998. When `getFunctionForURLPath` receives a URL, it can contain query parameters. When matching function routes, we want to match only the pathname, so we must parse the URL.