### PR TITLE
fix: don't run form submission logic on paths matching function

### DIFF
--- a/src/lib/functions/form-submissions-handler.mjs
+++ b/src/lib/functions/form-submissions-handler.mjs
@@ -29,7 +29,12 @@ const getFormHandler = function ({ functionsRegistry }) {
 
 export const createFormSubmissionHandler = function ({ functionsRegistry, siteUrl }) {
   return async function formSubmissionHandler(req, res, next) {
-    if (req.url.startsWith('/.netlify/') ||req.method !== 'POST' || (await functionsRegistry.getFunctionForURLPath(req.url, req.method))) return next()
+    if (
+      req.url.startsWith('/.netlify/') ||
+      req.method !== 'POST' ||
+      (await functionsRegistry.getFunctionForURLPath(req.url, req.method))
+    )
+      return next()
 
     const fakeRequest = new Readable({
       read() {

--- a/src/lib/functions/form-submissions-handler.mjs
+++ b/src/lib/functions/form-submissions-handler.mjs
@@ -29,7 +29,7 @@ const getFormHandler = function ({ functionsRegistry }) {
 
 export const createFormSubmissionHandler = function ({ functionsRegistry, siteUrl }) {
   return async function formSubmissionHandler(req, res, next) {
-    if (req.method !== 'POST' || await functionsRegistry.getFunctionForURLPath(req.url, req.method)) return next()
+    if (req.method !== 'POST' || (await functionsRegistry.getFunctionForURLPath(req.url, req.method))) return next()
 
     const fakeRequest = new Readable({
       read() {

--- a/src/lib/functions/form-submissions-handler.mjs
+++ b/src/lib/functions/form-submissions-handler.mjs
@@ -29,7 +29,7 @@ const getFormHandler = function ({ functionsRegistry }) {
 
 export const createFormSubmissionHandler = function ({ functionsRegistry, siteUrl }) {
   return async function formSubmissionHandler(req, res, next) {
-    if (req.method !== 'POST' || (await functionsRegistry.getFunctionForURLPath(req.url, req.method))) return next()
+    if (req.url.startsWith('/.netlify/') ||req.method !== 'POST' || (await functionsRegistry.getFunctionForURLPath(req.url, req.method))) return next()
 
     const fakeRequest = new Readable({
       read() {

--- a/src/lib/functions/form-submissions-handler.mjs
+++ b/src/lib/functions/form-submissions-handler.mjs
@@ -29,7 +29,7 @@ const getFormHandler = function ({ functionsRegistry }) {
 
 export const createFormSubmissionHandler = function ({ functionsRegistry, siteUrl }) {
   return async function formSubmissionHandler(req, res, next) {
-    if (req.url.startsWith('/.netlify/') || req.method !== 'POST') return next()
+    if (req.method !== 'POST' || await functionsRegistry.getFunctionForURLPath(req.url, req.method)) return next()
 
     const fakeRequest = new Readable({
       read() {

--- a/tests/integration/commands/dev/v2-api.test.ts
+++ b/tests/integration/commands/dev/v2-api.test.ts
@@ -112,6 +112,12 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
       expect(await response.text()).toBe(`With literal path: ${url}`)
     })
 
+    test<FixtureTestContext>('doesnt run form logic on paths matching function', async ({ devServer }) => {
+      const url = `http://localhost:${devServer.port}/products`
+      await fetch(url, { method: 'POST' })
+      expect(devServer.output).not.toContain("Missing form submission function handler")
+    })
+
     test<FixtureTestContext>('supports custom URLs with method matching', async ({ devServer }) => {
       const url = `http://localhost:${devServer.port}/products/really-bad-product`
       const response = await fetch(url, { method: 'DELETE' })


### PR DESCRIPTION
Part of https://github.com/netlify/pod-dev-foundations/issues/578. See title.