### PR TITLE
fix: fix function URL matching

### DIFF
--- a/src/lib/functions/registry.mjs
+++ b/src/lib/functions/registry.mjs
@@ -227,8 +227,11 @@ export class FunctionsRegistry {
   }
 
   /**
-   * Returns the first function in the registry that matches a given URL path
-   * and an HTTP method. If no match is found, `undefined` is returned.
+   * Looks for the first function that matches a given URL path. If a match is
+   * found, returns an object with the function and the route. If the URL path
+   * matches the default functions URL (i.e. can only be for a function) but no
+   * function with the given name exists, returns an object with the function
+   * and the route set to `null`. Otherwise, `undefined` is returned,
    *
    * @param {string} url
    * @param {string} method
@@ -244,7 +247,7 @@ export class FunctionsRegistry {
       const func = this.get(defaultURLMatch[2])
 
       if (!func) {
-        return
+        return { func: null, route: null }
       }
 
       const { routes = [] } = await func.getBuildData()

--- a/src/utils/proxy.mjs
+++ b/src/utils/proxy.mjs
@@ -343,10 +343,12 @@ const serveRedirect = async function ({ env, functionsRegistry, match, options, 
     }
 
     if (matchingFunction) {
-      const functionHeaders = {
-        [NFFunctionName]: matchingFunction.func.name,
-        [NFFunctionRoute]: matchingFunction.route,
-      }
+      const functionHeaders = matchingFunction.func
+        ? {
+            [NFFunctionName]: matchingFunction.func?.name,
+            [NFFunctionRoute]: matchingFunction.route,
+          }
+        : {}
       const url = reqToURL(req, originalURL)
       req.headers['x-netlify-original-pathname'] = url.pathname
       req.headers['x-netlify-original-search'] = url.search
@@ -604,7 +606,11 @@ const onRequest = async (
     // Setting an internal header with the function name so that we don't
     // have to match the URL again in the functions server.
     /** @type {Record<string, string>} */
-    const headers = { [NFFunctionName]: functionMatch.func.name }
+    const headers = {}
+
+    if (functionMatch.func) {
+      headers[NFFunctionName] = functionMatch.func.name
+    }
 
     if (functionMatch.route) {
       headers[NFFunctionRoute] = functionMatch.route.pattern


### PR DESCRIPTION
#### Summary

In recent changes to how we match URL paths for functions, we started relying solely on `FunctionsRegistry.getFunctionForURLPath`, even for matching paths for the default functions URL (i.e. `/.netlify/functions`).

The problem is that this method is returning `undefined` if there is no matching function, but we also need to know when a URL is definitely for a function (i.e. starts with `/.netlify/functions`) regardless of whether an actual function for that name exists.

This is important so that we handle 404s in the functions server, letting us return the right status code and message. This PR fixes that.