### PR TITLE
feat: show warning for npm modules with extraneous files

### DIFF
--- a/src/lib/edge-functions/consts.mjs
+++ b/src/lib/edge-functions/consts.mjs
@@ -8,5 +8,6 @@ export const PUBLIC_URL_PATH = '.netlify/internal/edge-functions'
 // Netlify Build.
 export const featureFlags = {
   edge_functions_config_export: true,
+  edge_functions_npm_modules: true,
   edge_functions_read_deno_config: true,
 }

--- a/src/lib/edge-functions/proxy.mjs
+++ b/src/lib/edge-functions/proxy.mjs
@@ -8,7 +8,6 @@ import * as bundler from '@netlify/edge-bundler'
 import getAvailablePort from 'get-port'
 
 import { NETLIFYDEVERR, NETLIFYDEVWARN, chalk, error as printError, log } from '../../utils/command-helpers.mjs'
-import { isFeatureFlagEnabled } from '../../utils/feature-flags.mjs'
 import { getGeoLocation } from '../geo-location.mjs'
 import { getPathInProject } from '../settings.mjs'
 import { startSpinner, stopSpinner } from '../spinner.mjs'
@@ -110,7 +109,7 @@ export const initializeProxy = async ({
   const userFunctionsPath = config.build.edge_functions
   const isolatePort = await getAvailablePort()
   const buildFeatureFlags = {
-    edge_functions_npm_modules: isFeatureFlagEnabled('edge_functions_npm_modules', siteInfo),
+    edge_functions_npm_modules: true,
   }
   const runtimeFeatureFlags = ['edge_functions_bootstrap_failure_mode']
 

--- a/src/lib/edge-functions/registry.mjs
+++ b/src/lib/edge-functions/registry.mjs
@@ -40,9 +40,6 @@ export class EdgeFunctionsRegistry {
   /** @type {RunIsolate} */
   #runIsolate
 
-  /** @type {boolean} */
-  #hasShownNPMWarning = false
-
   /** @type {Error | null} */
   #buildError = null
 
@@ -167,22 +164,13 @@ export class EdgeFunctionsRegistry {
    */
   async #build() {
     try {
-      const {
-        features = {},
-        functionsConfig,
-        graph,
-        success,
-      } = await this.#runIsolate(this.#functions, this.#env, {
-        getFunctionsConfig: true,
-      })
-
-      if (features.npmModules && !this.#hasShownNPMWarning) {
-        log(
-          `${NETLIFYDEVWARN} Support for npm modules in edge functions is an experimental feature. To learn more about the current state of this capability or to report a problem, refer to https://ntl.fyi/edge-functions-npm.`,
-        )
-
-        this.#hasShownNPMWarning = true
-      }
+      const { functionsConfig, graph, npmSpecifiersWithExtraneousFiles, success } = await this.#runIsolate(
+        this.#functions,
+        this.#env,
+        {
+          getFunctionsConfig: true,
+        },
+      )
 
       if (!success) {
         throw new Error('Build error')
@@ -207,6 +195,14 @@ export class EdgeFunctionsRegistry {
       )
 
       this.#processGraph(graph)
+
+      if (npmSpecifiersWithExtraneousFiles.length !== 0) {
+        const modules = npmSpecifiersWithExtraneousFiles.map((name) => chalk.yellow(name)).join(', ')
+
+        log(
+          `${NETLIFYDEVWARN} The following npm modules, which are directly or indirectly imported by an edge function, may not be supported: ${modules}. For more information, visit https://ntl.fyi/edge-npm.`,
+        )
+      }
     } catch (error) {
       this.#buildError = error
 


### PR DESCRIPTION
#### Summary

Show warning when edge functions import npm modules that contain extraneous files.