### PR TITLE
fix: remove beta tag from commands that are no longer in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Open settings for the site linked to the current folder
 
 ### [recipes](/docs/commands/recipes.md)
 
-(Beta) Create and modify files in a project using pre-defined recipes
+Create and modify files in a project using pre-defined recipes
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Create and modify files in a project using pre-defined recipes
 
 ### [serve](/docs/commands/serve.md)
 
-(Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
+Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
 
 ### [sites](/docs/commands/sites.md)
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Create and modify files in a project using pre-defined recipes
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | (Beta) List the recipes available to create and modify files in a project  |
+| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | List the recipes available to create and modify files in a project  |
 
 
 ### [serve](/docs/commands/serve.md)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Run any Netlify API method
 
 ### [build](/docs/commands/build.md)
 
-(Beta) Build on your local machine
+Build on your local machine
 
 ### [completion](/docs/commands/completion.md)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Build on your local machine
 
 ### [completion](/docs/commands/completion.md)
 
-(Beta) Generate shell completion script
+Generate shell completion script
 
 | Subcommand | description  |
 |:--------------------------- |:-----|

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,11 +60,11 @@ Run any Netlify API method
 
 ### [build](/docs/commands/build.md)
 
-(Beta) Build on your local machine
+Build on your local machine
 
 ### [completion](/docs/commands/completion.md)
 
-(Beta) Generate shell completion script
+Generate shell completion script
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -144,16 +144,16 @@ Open settings for the site linked to the current folder
 
 ### [recipes](/docs/commands/recipes.md)
 
-(Beta) Create and modify files in a project using pre-defined recipes
+Create and modify files in a project using pre-defined recipes
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | (Beta) List the recipes available to create and modify files in a project  |
+| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | List the recipes available to create and modify files in a project  |
 
 
 ### [serve](/docs/commands/serve.md)
 
-(Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
+Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
 
 ### [sites](/docs/commands/sites.md)
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -5,7 +5,7 @@ title: Netlify CLI build command
 # `build`
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
-(Beta) Build on your local machine
+Build on your local machine
 
 **Usage**
 

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -6,7 +6,7 @@ description: Shell completion script for netlify CLI
 # `completion`
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
-(Beta) Generate shell completion script
+Generate shell completion script
 Run this command to see instructions for your shell.
 
 **Usage**

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -39,11 +39,11 @@ Run any Netlify API method
 
 ### [build](/docs/commands/build.md)
 
-(Beta) Build on your local machine
+Build on your local machine
 
 ### [completion](/docs/commands/completion.md)
 
-(Beta) Generate shell completion script
+Generate shell completion script
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -123,16 +123,16 @@ Open settings for the site linked to the current folder
 
 ### [recipes](/docs/commands/recipes.md)
 
-(Beta) Create and modify files in a project using pre-defined recipes
+Create and modify files in a project using pre-defined recipes
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | (Beta) List the recipes available to create and modify files in a project  |
+| [`recipes:list`](/docs/commands/recipes.md#recipeslist) | List the recipes available to create and modify files in a project  |
 
 
 ### [serve](/docs/commands/serve.md)
 
-(Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
+Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
 
 ### [sites](/docs/commands/sites.md)
 

--- a/docs/commands/serve.md
+++ b/docs/commands/serve.md
@@ -6,7 +6,7 @@ description: (Beta) Build the site for production and serve locally. This does n
 # `serve`
 
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
-(Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
+Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
 
 **Usage**
 

--- a/src/commands/build/build.mjs
+++ b/src/commands/build/build.mjs
@@ -74,7 +74,7 @@ const build = async (options, command) => {
 export const createBuildCommand = (program) =>
   program
     .command('build')
-    .description('(Beta) Build on your local machine')
+    .description('Build on your local machine')
     .option(
       '--context <context>',
       'Specify a build context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev")',

--- a/src/commands/completion/completion.mjs
+++ b/src/commands/completion/completion.mjs
@@ -50,7 +50,7 @@ export const createCompletionCommand = (program) => {
 
   return program
     .command('completion')
-    .description('(Beta) Generate shell completion script\nRun this command to see instructions for your shell.')
+    .description('Generate shell completion script\nRun this command to see instructions for your shell.')
     .addExamples(['netlify completion:install'])
     .action((options, command) => {
       command.help()

--- a/src/commands/recipes/recipes-list.mjs
+++ b/src/commands/recipes/recipes-list.mjs
@@ -27,6 +27,6 @@ const recipesListCommand = async () => {
 export const createRecipesListCommand = (program) =>
   program
     .command('recipes:list')
-    .description(`(Beta) List the recipes available to create and modify files in a project`)
+    .description(`List the recipes available to create and modify files in a project`)
     .addExamples(['netlify recipes:list'])
     .action(recipesListCommand)

--- a/src/commands/recipes/recipes.mjs
+++ b/src/commands/recipes/recipes.mjs
@@ -81,7 +81,7 @@ export const createRecipesCommand = (program) => {
   program
     .command('recipes')
     .argument('[name]', 'name of the recipe')
-    .description(`(Beta) Create and modify files in a project using pre-defined recipes`)
+    .description(`Create and modify files in a project using pre-defined recipes`)
     .option('-n, --name <name>', 'recipe name to use')
     .addExamples(['netlify recipes my-recipe', 'netlify recipes --name my-recipe'])
     .action(recipesCommand)

--- a/src/commands/serve/serve.mjs
+++ b/src/commands/serve/serve.mjs
@@ -167,7 +167,7 @@ export const createServeCommand = (program) =>
   program
     .command('serve')
     .description(
-      '(Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.',
+      'Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.',
     )
     .option(
       '--context <context>',


### PR DESCRIPTION
#### Summary

Fixes #3661

These commands/features are no longer in beta and the documentation needs to be updated to reflect that