### PR TITLE
feat: add MSW and update `telemetry.test.ts` to start using it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,7 @@
         "ini": "2.0.0",
         "is-ci": "3.0.1",
         "mock-fs": "5.2.0",
+        "msw": "^2.0.2",
         "nock": "13.3.2",
         "p-timeout": "4.1.0",
         "serialize-javascript": "6.0.1",
@@ -831,6 +832,33 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
       "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "dependencies": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -2260,6 +2288,32 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mswjs/cookies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
+      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
+      "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/binary-info": {
@@ -6674,6 +6728,28 @@
         "@octokit/openapi-types": "^13.11.0"
       }
     },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
@@ -8115,6 +8191,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -8183,6 +8265,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.2.tgz",
+      "integrity": "sha512-/NCbMABw2uacuyE16Iwka1EzREDD50/W2ggRBad0y1WHBvAkvR9OEINxModVY7D428gXBe0igeVX7bUc9GaslQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -8311,6 +8399,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.3.tgz",
+      "integrity": "sha512-NwCYScf83RIwCyi5/9cXocrJB//xrqMh5PMw3mYTSFGaI3DuVjBLfO/PCk7QVAC3Da8b9NjxNmTO9Aj9T3rl/Q==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -10262,6 +10356,17 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blueimp-md5": {
@@ -15347,6 +15452,28 @@
         "node": ">= 14.17"
       }
     },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -15870,6 +15997,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/graphviz": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
@@ -16159,6 +16295,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "node_modules/hexer": {
       "version": "1.5.0",
@@ -17083,6 +17225,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "node_modules/is-npm": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
@@ -17536,6 +17684,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-string-escape": {
@@ -19447,6 +19604,329 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/msw": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
+      "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.0.0",
+        "@mswjs/interceptors": "^0.25.1",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.4.2",
+        "formdata-node": "4.4.1",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.2.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/msw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/msw/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/multiparty": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.3.tgz",
@@ -20562,6 +21042,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -23354,6 +23840,12 @@
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -26148,6 +26640,33 @@
       "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
       "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
+    "@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "requires": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "requires": {
+        "statuses": "^2.0.1"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -27119,6 +27638,26 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
+      }
+    },
+    "@mswjs/cookies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
+      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
+      "dev": true
+    },
+    "@mswjs/interceptors": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
+      "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
       }
     },
     "@netlify/binary-info": {
@@ -29688,6 +30227,28 @@
         "@octokit/openapi-types": "^13.11.0"
       }
     },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
+    },
     "@opentelemetry/api": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
@@ -30693,6 +31254,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -30761,6 +31328,12 @@
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.2.tgz",
+      "integrity": "sha512-/NCbMABw2uacuyE16Iwka1EzREDD50/W2ggRBad0y1WHBvAkvR9OEINxModVY7D428gXBe0igeVX7bUc9GaslQ==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -30889,6 +31462,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/statuses": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.3.tgz",
+      "integrity": "sha512-NwCYScf83RIwCyi5/9cXocrJB//xrqMh5PMw3mYTSFGaI3DuVjBLfO/PCk7QVAC3Da8b9NjxNmTO9Aj9T3rl/Q==",
+      "dev": true
     },
     "@types/unist": {
       "version": "2.0.6",
@@ -32259,6 +32838,17 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "blueimp-md5": {
@@ -35993,6 +36583,24 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.3.tgz",
       "integrity": "sha512-KqU0nnPMgIJcCOFTNJFEA8epcseEaoox4XZffTgy8jlI6pL/5EFyR54NRG7CnCJN0biY7q52DO3MH6/sJ/TKlQ=="
     },
+    "formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+          "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+          "dev": true
+        }
+      }
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -36390,6 +36998,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true
+    },
     "graphviz": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
@@ -36595,6 +37209,12 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "hexer": {
       "version": "1.5.0",
@@ -37227,6 +37847,12 @@
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-npm": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
@@ -37544,6 +38170,12 @@
           }
         }
       }
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -38978,6 +39610,239 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "msw": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
+      "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+      "dev": true,
+      "requires": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.0.0",
+        "@mswjs/interceptors": "^0.25.1",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.4.2",
+        "formdata-node": "4.4.1",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.21.3",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+              "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+              "dev": true
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "cli-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "8.2.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+          "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.1.1",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^3.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "0.0.8",
+            "ora": "^5.4.1",
+            "run-async": "^2.4.0",
+            "rxjs": "^7.5.5",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6",
+            "wrap-ansi": "^6.0.1"
+          }
+        },
+        "is-interactive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+          "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+          "dev": true
+        },
+        "is-unicode-supported": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+          "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "ora": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+          "dev": true,
+          "requires": {
+            "bl": "^4.1.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "path-to-regexp": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "multiparty": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.3.tgz",
@@ -39789,6 +40654,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true
     },
     "p-cancelable": {
       "version": "2.1.1",
@@ -41857,6 +42728,12 @@
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "ini": "2.0.0",
     "is-ci": "3.0.1",
     "mock-fs": "5.2.0",
+    "msw": "^2.0.2",
     "nock": "13.3.2",
     "p-timeout": "4.1.0",
     "serialize-javascript": "6.0.1",

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -34,18 +34,34 @@ const routes = [
 ]
 
 describe('telemetry', async () => {
-  beforeAll(() => {
-    server.events.on('request:start', ({ request }) => {
-      console.log('Outgoing request:', request.method, request.url)
-    })
-    // Erica todo: figure out how to throw an error on an 
-    // unhandled request
-    server.events.on('request:unhandled', ({request}) => {
-      throw new Error(`Must handle request: ${request.method} ${request.url}`)
-    })
+  let unhandledRequestMade = false
+  let unhandledRequest = {
+    url: '',
+    method: ''
+  }
+  
+  beforeEach(() => {
+    unhandledRequestMade = false
+    unhandledRequest = {
+      method: '',
+      url: ''
+    }
+    server.use(
+      http.post(`*`, ({ request }) => {
+        unhandledRequestMade = true
+        unhandledRequest = {
+          url: request.url,
+          method: request.method,
+        }
+        return HttpResponse.json({}, { status: 500 })
+      })
+    )
   })
 
   afterEach(() => {
+    if (unhandledRequestMade) {
+      throw new Error(`Unhandled request was made: ${JSON.stringify(unhandledRequest)}}`)
+    }
     server.resetHandlers()
   })
 

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -3,7 +3,9 @@ import { env as _env, version as nodejsVersion } from 'process'
 import type { Options } from 'execa'
 import execa from 'execa'
 import { version as uuidVersion } from 'uuid'
-import { expect, test } from 'vitest'
+import { beforeEach, expect, test, afterEach, beforeAll, describe } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../mswServer.ts'
 
 import { name, version } from '../../package.json'
 
@@ -31,97 +33,129 @@ const routes = [
   { path: 'accounts', response: [] },
 ]
 
-await withMockApi(routes, async () => {
-  test<MockApiTestContext>('should not track --telemetry-disable', async ({ apiUrl, requests }) => {
-    await callCli(['--telemetry-disable'], getCLIOptions(apiUrl))
-    expect(requests).toEqual([])
-  })
-
-  const UUID_VERSION = 4
-
-  test<MockApiTestContext>('should track --telemetry-enable', async ({ apiUrl, requests }) => {
-    await callCli(['--telemetry-enable'], getCLIOptions(apiUrl))
-    expect(requests.length).toBe(1)
-    expect(requests[0].method).toBe('POST')
-    expect(requests[0].path).toBe('/api/v1/track')
-    expect(requests[0].headers['user-agent']).toBe(`${name}/${version}`)
-    expect(requests[0].body.event).toBe('cli:user_telemetryEnabled')
-    expect(uuidVersion(requests[0].body.anonymousId)).toBe(UUID_VERSION)
-    expect(requests[0].body.properties).toEqual({ cliVersion: version, nodejsVersion })
-  })
-
-  test<MockApiTestContext>('should send netlify-cli/<version> user-agent', async ({ apiUrl, requests }) => {
-    await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
-    const request = requests.find(({ path }) => path === '/api/v1/track')
-    expect(request).toBeDefined()
-    // example: netlify-cli/6.14.25 darwin-x64 node-v16.13.0
-    const userAgent = request.headers['user-agent']
-    expect(userAgent.startsWith(`${name}/${version}`)).toBe(true)
-  })
-
-  test<MockApiTestContext>('should send correct command on success', async ({ apiUrl, requests }) => {
-    await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
-    const request = requests.find(({ path }) => path === '/api/v1/track')
-    expect(request).toBeDefined()
-
-    expect(typeof request.body.anonymousId).toBe('string')
-    expect(Number.isInteger(request.body.duration)).toBe(true)
-    expect(request.body.event).toBe('cli:command')
-    expect(request.body.status).toBe('success')
-    expect(request.body.properties).toEqual({
-      buildSystem: [],
-      cliVersion: version,
-      command: 'api',
-      monorepo: false,
-      nodejsVersion,
-      packageManager: 'npm',
+describe('telemetry', async () => {
+  beforeAll(() => {
+    server.events.on('request:start', ({ request }) => {
+      console.log('Outgoing request:', request.method, request.url)
+    })
+    // Erica todo: figure out how to throw an error on an 
+    // unhandled request
+    server.events.on('request:unhandled', ({request}) => {
+      throw new Error(`Must handle request: ${request.method} ${request.url}`)
     })
   })
 
-  test<MockApiTestContext>('should send correct command on failure', async ({ apiUrl, requests }) => {
-    await expect(callCli(['dev:exec', 'exit 1'], getCLIOptions(apiUrl))).rejects.toThrowError()
-    const request = requests.find(({ path }) => path === '/api/v1/track')
-    expect(request).toBeDefined()
-
-    expect(typeof request.body.anonymousId).toBe('string')
-    expect(Number.isInteger(request.body.duration)).toBe(true)
-    expect(request.body.event).toBe('cli:command')
-    expect(request.body.status).toBe('error')
-    expect(request.body.properties).toEqual({
-      buildSystem: [],
-      cliVersion: version,
-      command: 'dev:exec',
-      monorepo: false,
-      nodejsVersion,
-      packageManager: 'npm',
-    })
+  afterEach(() => {
+    server.resetHandlers()
   })
 
-  test('should add frameworks, buildSystem, and packageManager', async ({ apiUrl, requests }) => {
-    await withSiteBuilder('nextjs-site', async (builder) => {
-      await builder.withPackageJson({ packageJson: { dependencies: { next: '^12.13.0' } } }).buildAsync()
+  await withMockApi(routes, async () => {
+    test<MockApiTestContext>('should not track --telemetry-disable', async ({ apiUrl, requests }) => {
+      let requestWasMade = false
+      server.use(
+        http.post(`http://localhost/api/v1/track`, () => {
+          requestWasMade = true
+          return HttpResponse.json({}, { status: 200 })
+        })
+      )
 
-      await execa(cliPath, ['api', 'listSites'], {
-        cwd: builder.directory,
-        ...getCLIOptions(apiUrl),
-      })
-
-      const request = requests.find(({ path }) => path === '/api/v1/track')
-      expect(request).toBeDefined()
-
-      expect(typeof request.body.anonymousId).toBe('string')
-      expect(Number.isInteger(request.body.duration)).toBe(true)
-      expect(request.body.event).toBe('cli:command')
-      expect(request.body.status).toBe('success')
-      expect(request.body.properties).toEqual({
-        frameworks: ['next'],
-        buildSystem: [],
-        cliVersion: version,
-        command: 'api',
-        monorepo: false,
-        nodejsVersion,
-        packageManager: 'npm',
-      })
+      await callCli(['--telemetry-disable'], getCLIOptions(apiUrl))
+      expect(requestWasMade).toEqual(false)
     })
   })
 })
+
+// await withMockApi(routes, async () => {
+//   test<MockApiTestContext>('should not track --telemetry-disable', async ({ apiUrl, requests }) => {
+//     await callCli(['--telemetry-disable'], getCLIOptions(apiUrl))
+//     expect(requests).toEqual([])
+//   })
+
+//   const UUID_VERSION = 4
+
+//   test<MockApiTestContext>('should track --telemetry-enable', async ({ apiUrl, requests }) => {
+//     await callCli(['--telemetry-enable'], getCLIOptions(apiUrl))
+//     expect(requests.length).toBe(1)
+//     expect(requests[0].method).toBe('POST')
+//     expect(requests[0].path).toBe('/api/v1/track')
+//     expect(requests[0].headers['user-agent']).toBe(`${name}/${version}`)
+//     expect(requests[0].body.event).toBe('cli:user_telemetryEnabled')
+//     expect(uuidVersion(requests[0].body.anonymousId)).toBe(UUID_VERSION)
+//     expect(requests[0].body.properties).toEqual({ cliVersion: version, nodejsVersion })
+//   })
+
+//   test<MockApiTestContext>('should send netlify-cli/<version> user-agent', async ({ apiUrl, requests }) => {
+//     await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
+//     const request = requests.find(({ path }) => path === '/api/v1/track')
+//     expect(request).toBeDefined()
+//     // example: netlify-cli/6.14.25 darwin-x64 node-v16.13.0
+//     const userAgent = request.headers['user-agent']
+//     expect(userAgent.startsWith(`${name}/${version}`)).toBe(true)
+//   })
+
+//   test<MockApiTestContext>('should send correct command on success', async ({ apiUrl, requests }) => {
+//     await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
+//     const request = requests.find(({ path }) => path === '/api/v1/track')
+//     expect(request).toBeDefined()
+
+//     expect(typeof request.body.anonymousId).toBe('string')
+//     expect(Number.isInteger(request.body.duration)).toBe(true)
+//     expect(request.body.event).toBe('cli:command')
+//     expect(request.body.status).toBe('success')
+//     expect(request.body.properties).toEqual({
+//       buildSystem: [],
+//       cliVersion: version,
+//       command: 'api',
+//       monorepo: false,
+//       nodejsVersion,
+//       packageManager: 'npm',
+//     })
+//   })
+
+//   test<MockApiTestContext>('should send correct command on failure', async ({ apiUrl, requests }) => {
+//     await expect(callCli(['dev:exec', 'exit 1'], getCLIOptions(apiUrl))).rejects.toThrowError()
+//     const request = requests.find(({ path }) => path === '/api/v1/track')
+//     expect(request).toBeDefined()
+
+//     expect(typeof request.body.anonymousId).toBe('string')
+//     expect(Number.isInteger(request.body.duration)).toBe(true)
+//     expect(request.body.event).toBe('cli:command')
+//     expect(request.body.status).toBe('error')
+//     expect(request.body.properties).toEqual({
+//       buildSystem: [],
+//       cliVersion: version,
+//       command: 'dev:exec',
+//       monorepo: false,
+//       nodejsVersion,
+//       packageManager: 'npm',
+//     })
+//   })
+
+//   test('should add frameworks, buildSystem, and packageManager', async ({ apiUrl, requests }) => {
+//     await withSiteBuilder('nextjs-site', async (builder) => {
+//       await builder.withPackageJson({ packageJson: { dependencies: { next: '^12.13.0' } } }).buildAsync()
+
+//       await execa(cliPath, ['api', 'listSites'], {
+//         cwd: builder.directory,
+//         ...getCLIOptions(apiUrl),
+//       })
+
+//       const request = requests.find(({ path }) => path === '/api/v1/track')
+//       expect(request).toBeDefined()
+
+//       expect(typeof request.body.anonymousId).toBe('string')
+//       expect(Number.isInteger(request.body.duration)).toBe(true)
+//       expect(request.body.event).toBe('cli:command')
+//       expect(request.body.status).toBe('success')
+//       expect(request.body.properties).toEqual({
+//         frameworks: ['next'],
+//         buildSystem: [],
+//         cliVersion: version,
+//         command: 'api',
+//         monorepo: false,
+//         nodejsVersion,
+//         packageManager: 'npm',
+//       })
+//     })
+//   })
+// })

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -50,7 +50,7 @@ describe('telemetry', async () => {
     }
 
     server.use(
-      http.post(`*`, ({ request }) => {
+      http.all(`*`, ({ request }) => {
         unhandledRequestMade = true
         unhandledRequest = {
           url: request.url,
@@ -61,7 +61,7 @@ describe('telemetry', async () => {
     )
 
     server.use(
-      http.post(`http://localhost/api/v1/track`, ({request}) => {
+      http.post(`http://localhost/api/v1/track`, ({ request }) => {
         requestMade = request
         return HttpResponse.json({}, { status: 200 })
       })
@@ -108,81 +108,111 @@ describe('telemetry', async () => {
           return HttpResponse.json({}, { status: 200 })
         })
       )
-  
+
       await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
-      
+
       expect(requestMade).toBeDefined()
       // example: netlify-cli/6.14.25 darwin-x64 node-v16.13.0
       const userAgent = requestMade.headers.get('user-agent')
       expect(userAgent.startsWith(`${name}/${version}`)).toEqual(true)
     })
+
+    test<MockApiTestContext>('should send correct command on success', async ({ apiUrl }) => {
+      server.use(
+        http.get(`http://localhost/api/v1/accounts`, () => {
+          return HttpResponse.json({}, { status: 200 })
+        })
+      )
+      server.use(
+        http.get(`http://localhost/api/v1/sites`, () => {
+          return HttpResponse.json({}, { status: 200 })
+        })
+      )
+
+      await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
+      expect(requestMade).toBeDefined()
+
+      const body = await requestMade.json()
+
+      expect(typeof body.anonymousId).toBe('string')
+      expect(Number.isInteger(body.duration)).toBe(true)
+      expect(body.event).toBe('cli:command')
+      expect(body.status).toBe('success')
+      expect(body.properties).toStrictEqual({
+        buildSystem: [],
+        cliVersion: version,
+        command: 'api',
+        monorepo: false,
+        nodejsVersion,
+        packageManager: 'npm',
+      })
+    })
+  })
+
+  test<MockApiTestContext>('should send correct command on failure', async ({ apiUrl }) => {
+    server.use(
+      http.get(`http://localhost/api/v1/accounts`, () => {
+        return HttpResponse.json({}, { status: 200 })
+      })
+    )
+
+    await expect(callCli(['dev:exec', 'exit 1'], getCLIOptions(apiUrl))).rejects.toThrowError()
+    expect(requestMade).toBeDefined()
+
+    const body = await requestMade.json()
+
+    expect(typeof body.anonymousId).toBe('string')
+    expect(Number.isInteger(body.duration)).toBe(true)
+    expect(body.event).toBe('cli:command')
+    expect(body.status).toBe('error')
+    expect(body.properties).toStrictEqual({
+      buildSystem: [],
+      cliVersion: version,
+      command: 'dev:exec',
+      monorepo: false,
+      nodejsVersion,
+      packageManager: 'npm',
+    })
+  })
+
+  test('should add frameworks, buildSystem, and packageManager', async ({ apiUrl }) => {
+    server.use(
+      http.get(`http://localhost/api/v1/accounts`, () => {
+        return HttpResponse.json({}, { status: 200 })
+      })
+    )
+    
+    server.use(
+      http.get(`http://localhost/api/v1/sites`, () => {
+        return HttpResponse.json({}, { status: 200 })
+      })
+    )
+    
+    await withSiteBuilder('nextjs-site', async (builder) => {
+      await builder.withPackageJson({ packageJson: { dependencies: { next: '^12.13.0' } } }).buildAsync()
+
+      await execa(cliPath, ['api', 'listSites'], {
+        cwd: builder.directory,
+        ...getCLIOptions(apiUrl),
+      })
+
+      expect(requestMade).toBeDefined()
+
+      const body = await requestMade.json()
+  
+      expect(typeof body.anonymousId).toBe('string')
+      expect(Number.isInteger(body.duration)).toBe(true)
+      expect(body.event).toBe('cli:command')
+      expect(body.status).toBe('success')
+      expect(body.properties).toStrictEqual({
+        frameworks: ['next'],
+        buildSystem: [],
+        cliVersion: version,
+        command: 'api',
+        monorepo: false,
+        nodejsVersion,
+        packageManager: 'npm',
+      })
+    })
   })
 })
-
-
-//   test<MockApiTestContext>('should send correct command on success', async ({ apiUrl, requests }) => {
-//     await callCli(['api', 'listSites'], getCLIOptions(apiUrl))
-//     const request = requests.find(({ path }) => path === '/api/v1/track')
-//     expect(request).toBeDefined()
-
-//     expect(typeof request.body.anonymousId).toBe('string')
-//     expect(Number.isInteger(request.body.duration)).toBe(true)
-//     expect(request.body.event).toBe('cli:command')
-//     expect(request.body.status).toBe('success')
-//     expect(request.body.properties).toEqual({
-//       buildSystem: [],
-//       cliVersion: version,
-//       command: 'api',
-//       monorepo: false,
-//       nodejsVersion,
-//       packageManager: 'npm',
-//     })
-//   })
-
-//   test<MockApiTestContext>('should send correct command on failure', async ({ apiUrl, requests }) => {
-//     await expect(callCli(['dev:exec', 'exit 1'], getCLIOptions(apiUrl))).rejects.toThrowError()
-//     const request = requests.find(({ path }) => path === '/api/v1/track')
-//     expect(request).toBeDefined()
-
-//     expect(typeof request.body.anonymousId).toBe('string')
-//     expect(Number.isInteger(request.body.duration)).toBe(true)
-//     expect(request.body.event).toBe('cli:command')
-//     expect(request.body.status).toBe('error')
-//     expect(request.body.properties).toEqual({
-//       buildSystem: [],
-//       cliVersion: version,
-//       command: 'dev:exec',
-//       monorepo: false,
-//       nodejsVersion,
-//       packageManager: 'npm',
-//     })
-//   })
-
-//   test('should add frameworks, buildSystem, and packageManager', async ({ apiUrl, requests }) => {
-//     await withSiteBuilder('nextjs-site', async (builder) => {
-//       await builder.withPackageJson({ packageJson: { dependencies: { next: '^12.13.0' } } }).buildAsync()
-
-//       await execa(cliPath, ['api', 'listSites'], {
-//         cwd: builder.directory,
-//         ...getCLIOptions(apiUrl),
-//       })
-
-//       const request = requests.find(({ path }) => path === '/api/v1/track')
-//       expect(request).toBeDefined()
-
-//       expect(typeof request.body.anonymousId).toBe('string')
-//       expect(Number.isInteger(request.body.duration)).toBe(true)
-//       expect(request.body.event).toBe('cli:command')
-//       expect(request.body.status).toBe('success')
-//       expect(request.body.properties).toEqual({
-//         frameworks: ['next'],
-//         buildSystem: [],
-//         cliVersion: version,
-//         command: 'api',
-//         monorepo: false,
-//         nodejsVersion,
-//         packageManager: 'npm',
-//       })
-//     })
-//   })
-// })

--- a/tests/integration/utils/mock-api-vitest.ts
+++ b/tests/integration/utils/mock-api-vitest.ts
@@ -70,16 +70,18 @@ export const startMockApi = ({ routes, silent }: MockApiOptions): Promise<MockAp
     Object.entries(req.headers).map(([key, value]) => {test[key] = value})
     const headers: HeadersInit = new Headers(test);
 
+    const body = req.method != 'GET' && req.method != 'HEAD' ? JSON.stringify(req.body) : undefined
+    
     await fetch(`http://localhost${req.url}`, {
       method: req.method,
       headers,
-      body: JSON.stringify(req.body),
+      body,
     }).then((response) => {
       res.status(response.status)
       res.json(response)
     }).catch((err) => {
       res.status(500)
-      res.json({ message: err })
+      res.json({ message: `Error making request from mock API: ${err}` })
     })
   })
 

--- a/tests/integration/utils/mock-api-vitest.ts
+++ b/tests/integration/utils/mock-api-vitest.ts
@@ -66,9 +66,13 @@ export const startMockApi = ({ routes, silent }: MockApiOptions): Promise<MockAp
   app.use(raw())
 
   app.all('*', async function onRequest(req, res) {
-    // Erica todo: Add headers back in
+    const test = {}
+    Object.entries(req.headers).map(([key, value]) => {test[key] = value})
+    const headers: HeadersInit = new Headers(test);
+
     await fetch(`http://localhost${req.url}`, {
       method: req.method,
+      headers,
       body: req.body,
     }).then((response) => {
       res.status(response.status)

--- a/tests/integration/utils/mock-api-vitest.ts
+++ b/tests/integration/utils/mock-api-vitest.ts
@@ -73,7 +73,7 @@ export const startMockApi = ({ routes, silent }: MockApiOptions): Promise<MockAp
     await fetch(`http://localhost${req.url}`, {
       method: req.method,
       headers,
-      body: req.body,
+      body: JSON.stringify(req.body),
     }).then((response) => {
       res.status(response.status)
       res.json(response)

--- a/tests/mswServer.ts
+++ b/tests/mswServer.ts
@@ -1,0 +1,3 @@
+import { setupServer } from 'msw/node'
+
+export const server = setupServer()

--- a/tests/testSetup.ts
+++ b/tests/testSetup.ts
@@ -1,0 +1,5 @@
+import { server } from "./mswServer"
+import {beforeAll, afterAll} from 'vitest'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterAll(() => server.close())

--- a/tests/testSetup.ts
+++ b/tests/testSetup.ts
@@ -1,5 +1,5 @@
 import { server } from "./mswServer"
 import {beforeAll, afterAll} from 'vitest'
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
 afterAll(() => server.close())

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
     },
+    setupFiles: [ './tests/testSetup.ts' ],
   },
 })


### PR DESCRIPTION
#### Summary

Adds MSW and updates the `telemetry.test.ts` file to start using it.

Some things to note about the changes here:
* The approach of proxying requests through the express app was taken because MSW only intercepts requests that happen in the same thread. This means that we can't remove the use of the express app because just using `execa` to call the CLI without a mock API/server spawns a child thread whose requests won't be intercepted by MSW.
* MSW recommends against inspecting/asserting against the requests themselves. That being said, sending analytics is one of those use cases where the maintainer sees it as being ok to do request assertions which is why they're being done here.
* MSW doesn't have a convenient way of failing tests if an unhandled request is made which is why there is the possibility of throwing an error in the `afterEach` clause of the tests. See [this discussion](https://github.com/mswjs/msw/discussions/821) for the full context but the short of it is that this incorporates one of the suggested workarounds. We will want to look into how we can do these fallback routes automatically so they're not accidentally missed in test suites as if they are the tests will still pass even though there will be messages saying that there was a request made that had no backing handler defined on MSW.
* While MSW suggests setting the server up on the global level, the setup of globals via [`globalSetup`](https://vitest.dev/config/#globalsetup) sets up those globals in a different global scope than what the tests have access to. This meant that in order to set up the MSW server at as high a level as possible while still giving tests access to the server, we needed to set up the MSW server using the [`setups`](https://vitest.dev/config/#setupfiles) property
