### PR TITLE
docs: adds deprecation notice to register add on page

### DIFF
--- a/site/src/register-addon-thanks.md
+++ b/site/src/register-addon-thanks.md
@@ -7,7 +7,3 @@ hidePagination: true
 # Thanks for reaching out!
 
 We will get back with you shortly about your Netlify addon request.
-
-In the meantime, you can check out the implementation docs for creating a Netlify addon here:
-
-[https://github.com/netlify/addon-integration-examples/](https://github.com/netlify/addon-integration-examples/)

--- a/site/src/register-addon.md
+++ b/site/src/register-addon.md
@@ -7,6 +7,8 @@ hidePagination: true
 
 # Netlify addons
 
+> ⚠️ The addons command is [deprecated](https://docs.netlify.com/platform/release-phases/#deprecated) and will become unavailable in a future update.
+
 A Netlify addon is a way for Netlify users to extend their sites.
 
 For example a user can provision additional functionality on their site by running:


### PR DESCRIPTION
#### Summary

Fixes [#CT-298](https://linear.app/netlify/issue/CT-298/add-deprecation-notice-to-the-register-add-on-docs-page) by adding a deprecation note to the "register add ons" page, as [discussed on Slack](https://netlify.slack.com/archives/C043UGRAC3F/p1699976455996849?thread_ts=1699271734.943139&cid=C043UGRAC3F). It uses the same language we used on the [`addons` command](https://deploy-preview-6155--cli.netlify.com/commands/addons) page.

I also removed the broken link to https://github.com/netlify/addon-integration-examples/ from the success page.
