### PR TITLE
fix: [image cdn] Use s resize

### DIFF
--- a/src/lib/images/proxy.mjs
+++ b/src/lib/images/proxy.mjs
@@ -59,14 +59,23 @@ export const isImageRequest = function (req) {
 
 export const transformImageParams = function (query) {
   const params = {}
-  // eslint-disable-next-line id-length
-  params.w = query.w || query.width || null
-  // eslint-disable-next-line id-length
-  params.h = query.h || query.height || null
+
+  if ((query.w || query.width) && (query.h || query.height)) {
+    const width = query.w || query.width
+    const height = query.h || query.height
+    // eslint-disable-next-line id-length
+    params.s = `${width}x${height}`
+  } else {
+    // eslint-disable-next-line id-length
+    params.w = query.w || query.width || null
+    // eslint-disable-next-line id-length
+    params.h = query.h || query.height || null
+  }
+
   params.quality = query.q || query.quality || null
   params.format = query.fm || null
-  params.fit = query.fit || null
   params.position = query.position || null
+  params.fit = query.fit || null
 
   return Object.entries(params)
     .filter(([, value]) => value !== null)
@@ -76,7 +85,6 @@ export const transformImageParams = function (query) {
 
 export const initializeProxy = async function ({ config }) {
   const remoteDomains = await parseRemoteImageDomains({ config })
-
   const ipx = createIPX({
     storage: ipxFSStorage({ dir: config?.build?.publish ?? './public' }),
     httpStorage: ipxHttpStorage({ domains: remoteDomains }),
@@ -89,7 +97,9 @@ export const initializeProxy = async function ({ config }) {
     const { url, ...query } = req.query
     const modifiers = await transformImageParams(query)
     const path = `/${modifiers}/${encodeURIComponent(url)}`
+    console.log(`ipx: ${path}`)
     req.url = path
+    console.log(`ipx2: ${req.url}`)
     handler(req, res)
   })
 

--- a/src/lib/images/proxy.mjs
+++ b/src/lib/images/proxy.mjs
@@ -74,8 +74,8 @@ export const transformImageParams = function (query) {
 
   params.quality = query.q || query.quality || null
   params.format = query.fm || null
-  params.position = query.position || null
   params.fit = query.fit || null
+  params.position = query.position || null
 
   return Object.entries(params)
     .filter(([, value]) => value !== null)
@@ -85,6 +85,7 @@ export const transformImageParams = function (query) {
 
 export const initializeProxy = async function ({ config }) {
   const remoteDomains = await parseRemoteImageDomains({ config })
+
   const ipx = createIPX({
     storage: ipxFSStorage({ dir: config?.build?.publish ?? './public' }),
     httpStorage: ipxHttpStorage({ domains: remoteDomains }),
@@ -97,9 +98,7 @@ export const initializeProxy = async function ({ config }) {
     const { url, ...query } = req.query
     const modifiers = await transformImageParams(query)
     const path = `/${modifiers}/${encodeURIComponent(url)}`
-    console.log(`ipx: ${path}`)
     req.url = path
-    console.log(`ipx2: ${req.url}`)
     handler(req, res)
   })
 

--- a/src/lib/images/proxy.mjs
+++ b/src/lib/images/proxy.mjs
@@ -60,16 +60,17 @@ export const isImageRequest = function (req) {
 export const transformImageParams = function (query) {
   const params = {}
 
-  if ((query.w || query.width) && (query.h || query.height)) {
-    const width = query.w || query.width
-    const height = query.h || query.height
+  const width = query.w || query.width || null
+  const height = query.h || query.height || null
+
+  if (width && height) {
     // eslint-disable-next-line id-length
     params.s = `${width}x${height}`
   } else {
     // eslint-disable-next-line id-length
-    params.w = query.w || query.width || null
+    params.w = width
     // eslint-disable-next-line id-length
-    params.h = query.h || query.height || null
+    params.h = height
   }
 
   params.quality = query.q || query.quality || null

--- a/tests/unit/lib/images/proxy.test.mjs
+++ b/tests/unit/lib/images/proxy.test.mjs
@@ -26,5 +26,5 @@ test('should transform image params correctly', () => {
     position: 'center',
   }
   const result = transformImageParams(query)
-  expect(result).toEqual('s_100x200,quality_80,format_jpg,position_center,fit_cover')
+  expect(result).toEqual('s_100x200,quality_80,format_jpg,fit_cover,position_center')
 })

--- a/tests/unit/lib/images/proxy.test.mjs
+++ b/tests/unit/lib/images/proxy.test.mjs
@@ -26,5 +26,5 @@ test('should transform image params correctly', () => {
     position: 'center',
   }
   const result = transformImageParams(query)
-  expect(result).toEqual('w_100,h_200,quality_80,format_jpg,fit_cover,position_center')
+  expect(result).toEqual('s_100x200,quality_80,format_jpg,position_center,fit_cover')
 })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes [ADN-57](https://linear.app/netlify/issue/ADN-57/local-image-server-generating-incorrect-image-fit)

For the `fit` parameter to render correctly with IPX, the width and height parameters must use `s`.
With this PR, `/fit_cover,w_800,h_600/seed.jpg` becomes `/fit_cover,s_800x600/seed.jpg`

For us to review and ship your PR efficiently, please perform the following steps:

- [X ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [X ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [X ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
