### PR TITLE
feat: miscellaneous Blobs improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@bugsnag/js": "7.20.2",
         "@fastify/static": "6.10.2",
-        "@netlify/blobs": "6.2.0",
+        "@netlify/blobs": "^6.3.0",
         "@netlify/build": "29.26.6",
         "@netlify/build-info": "7.11.1",
         "@netlify/config": "20.10.0",
@@ -134,6 +134,7 @@
         "@types/node": "20.9.0",
         "@types/prettyjson": "0.0.30",
         "@types/semver": "7.5.0",
+        "@types/uuid": "^9.0.7",
         "@vitest/coverage-v8": "1.0.0-beta.4",
         "c8": "7.14.0",
         "eslint-plugin-sort-destructure-keys": "1.5.0",
@@ -2276,9 +2277,9 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "node_modules/@netlify/blobs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.2.0.tgz",
-      "integrity": "sha512-eeOA5et1mdyZu/DlbyocDULH7HUjzrLQfznBnkta8El1Ls8hcjADs7y7H+mkx1nAW8ZR9KbBDt92QloZ6J2uWw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.3.0.tgz",
+      "integrity": "sha512-EcgttqwH7kmK5B9RO8hRwAx/pkO9RwfFoRl+B38UNiFN6L4T46Q9Vhxnp3EzXQxn7Le1RpwFnXhd+UAhyZod+g==",
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
       }
@@ -7046,6 +7047,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "node_modules/@types/yargs-parser": {
@@ -26350,9 +26357,9 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
     "@netlify/blobs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.2.0.tgz",
-      "integrity": "sha512-eeOA5et1mdyZu/DlbyocDULH7HUjzrLQfznBnkta8El1Ls8hcjADs7y7H+mkx1nAW8ZR9KbBDt92QloZ6J2uWw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.3.0.tgz",
+      "integrity": "sha512-EcgttqwH7kmK5B9RO8hRwAx/pkO9RwfFoRl+B38UNiFN6L4T46Q9Vhxnp3EzXQxn7Le1RpwFnXhd+UAhyZod+g=="
     },
     "@netlify/build": {
       "version": "29.26.6",
@@ -29413,6 +29420,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "@types/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@bugsnag/js": "7.20.2",
     "@fastify/static": "6.10.2",
-    "@netlify/blobs": "6.2.0",
+    "@netlify/blobs": "^6.3.0",
     "@netlify/build": "29.26.6",
     "@netlify/build-info": "7.11.1",
     "@netlify/config": "20.10.0",
@@ -198,6 +198,7 @@
     "@types/node": "20.9.0",
     "@types/prettyjson": "0.0.30",
     "@types/semver": "7.5.0",
+    "@types/uuid": "^9.0.7",
     "@vitest/coverage-v8": "1.0.0-beta.4",
     "c8": "7.14.0",
     "eslint-plugin-sort-destructure-keys": "1.5.0",

--- a/src/lib/blobs/blobs.mts
+++ b/src/lib/blobs/blobs.mts
@@ -1,35 +1,61 @@
 import path from 'path'
 
 import { BlobsServer } from '@netlify/blobs'
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
 import { v4 as uuidv4 } from 'uuid'
 
+import { log, NETLIFYDEVLOG } from '../../utils/command-helpers.mjs'
 import { getPathInProject } from '../settings.mjs'
 
-/**
- * @typedef BlobsContext
- * @type {object}
- * @property {string} edgeURL
- * @property {string} deployID
- * @property {string} siteID
- * @property {string} token
- */
+let hasPrintedLocalBlobsNotice = false
+
+interface BlobsContext {
+  deployID: string
+  edgeURL: string
+  siteID: string
+  token: string
+}
+
+const printLocalBlobsNotice = () => {
+  if (hasPrintedLocalBlobsNotice) {
+    return
+  }
+
+  hasPrintedLocalBlobsNotice = true
+
+  log(
+    `${NETLIFYDEVLOG} Netlify Blobs running in sandbox mode for local development. Refer to https://ntl.fyi/local-blobs for more information.`,
+  )
+}
+
+const startBlobsServer = async (debug: boolean, projectRoot: string, token: string) => {
+  const directory = path.resolve(projectRoot, getPathInProject(['blobs-serves']))
+  const server = new BlobsServer({
+    debug,
+    directory,
+    onRequest: () => {
+      printLocalBlobsNotice()
+    },
+    token,
+  })
+  const { port } = await server.start()
+
+  return { port }
+}
+
+interface GetBlobsContextOptions {
+  debug: boolean
+  projectRoot: string
+  siteID: string
+}
 
 /**
  * Starts a local Blobs server and returns a context object that lets functions
  * connect to it.
- *
- * @param {object} options
- * @param {boolean} options.debug
- * @param {string} options.projectRoot
- * @param {string} options.siteID
- * @returns {Promise<BlobsContext>}
  */
-// @ts-expect-error TS(7031) FIXME: Binding element 'debug' implicitly has an 'any' ty... Remove this comment to see the full error message
-export const getBlobsContext = async ({ debug, projectRoot, siteID }) => {
+export const getBlobsContext = async ({ debug, projectRoot, siteID }: GetBlobsContextOptions) => {
   const token = uuidv4()
-  const { port } = await startBlobsServer({ debug, projectRoot, token })
-  const context = {
+  const { port } = await startBlobsServer(debug, projectRoot, token)
+  const context: BlobsContext = {
     deployID: '0',
     edgeURL: `http://localhost:${port}`,
     siteID,
@@ -37,17 +63,4 @@ export const getBlobsContext = async ({ debug, projectRoot, siteID }) => {
   }
 
   return context
-}
-
-// @ts-expect-error TS(7031) FIXME: Binding element 'debug' implicitly has an 'any' ty... Remove this comment to see the full error message
-const startBlobsServer = async ({ debug, projectRoot, token }) => {
-  const directory = path.resolve(projectRoot, getPathInProject(['blobs']))
-  const server = new BlobsServer({
-    debug,
-    directory,
-    token,
-  })
-  const { port } = await server.start()
-
-  return { port }
 }

--- a/src/lib/functions/server.mts
+++ b/src/lib/functions/server.mts
@@ -143,7 +143,7 @@ export const createHandler = function (options) {
       'client-ip': [remoteAddress],
       'x-nf-client-connection-ip': [remoteAddress],
       'x-nf-account-id': [options.accountId],
-      'x-nf-site-id': [options?.siteInfo?.id],
+      'x-nf-site-id': [options?.siteInfo?.id] ?? 'unlinked',
       [efHeaders.Geo]: Buffer.from(JSON.stringify(geoLocation)).toString('base64'),
     }).reduce((prev, [key, value]) => ({ ...prev, [key]: Array.isArray(value) ? value : [value] }), {})
     const rawQuery = new URLSearchParams(requestQuery).toString()

--- a/src/utils/get-global-config.mts
+++ b/src/utils/get-global-config.mts
@@ -2,7 +2,6 @@ import { readFile } from 'fs/promises'
 
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'conf... Remove this comment to see the full error message
 import Configstore from 'configstore'
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
 import { v4 as uuidv4 } from 'uuid'
 
 import { getLegacyPathInHome, getPathInHome } from '../lib/settings.mjs'

--- a/src/utils/live-tunnel.mts
+++ b/src/utils/live-tunnel.mts
@@ -1,10 +1,8 @@
- 
 import process from 'process'
 
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'node... Remove this comment to see the full error message
 import fetch from 'node-fetch'
 import pWaitFor from 'p-wait-for'
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
 import { v4 as uuidv4 } from 'uuid'
 
 import { fetchLatestVersion, shouldFetchLatestVersion } from '../lib/exec-fetcher.mjs'


### PR DESCRIPTION
#### Summary

- Uses a default site ID when running Netlify Dev with an unlinked site. This makes it possible to use Blobs even if the site is not linked.
- When the first request is made to the local blobs server, a message is printed to the console telling people that Blobs is running in sandbox mode for local development, including a link to the docs
- Updates `@netlify/blobs` to the latest version