### PR TITLE
feat: speed up `netlify status` by removing extra api call

### DIFF
--- a/src/commands/status/status.mts
+++ b/src/commands/status/status.mts
@@ -12,7 +12,7 @@ import { createStatusHooksCommand } from './status-hooks.mjs'
  */
 // @ts-expect-error TS(7006) FIXME: Parameter 'options' implicitly has an 'any' type.
 const status = async (options, command) => {
-  const { api, globalConfig, site } = command.netlify
+  const { api, globalConfig, site, siteInfo } = command.netlify
   const current = globalConfig.get('userId')
   // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [accessToken] = await getToken()
@@ -34,6 +34,7 @@ const status = async (options, command) => {
   let user
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;[accounts, user] = await Promise.all([api.listAccountsForUser(), api.getCurrentUser()])
   } catch (error_) {
     // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
@@ -68,23 +69,9 @@ const status = async (options, command) => {
     warn('Did you run `netlify link` yet?')
     error(`You don't appear to be in a folder that is linked to a site`)
   }
-  let siteData
-  try {
-    siteData = await api.getSite({ siteId })
-  } catch (error_) {
-    // unauthorized
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (error_.status === 401) {
-      warn(`Log in with a different account or re-link to a site you have permission for`)
-      error(`Not authorized to view the currently linked site (${siteId})`)
-    }
-    // missing
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (error_.status === 404) {
-      error(`The site this folder is linked to can't be found`)
-    }
-    // @ts-expect-error TS(2345) FIXME: Argument of type 'unknown' is not assignable to pa... Remove this comment to see the full error message
-    error(error_)
+
+  if (!siteInfo) {
+    error(`No site info found for site ${siteId}`)
   }
 
   // Json only logs out if --json flag is passed
@@ -92,11 +79,11 @@ const status = async (options, command) => {
     logJson({
       account: cleanAccountData,
       siteData: {
-        'site-name': `${siteData.name}`,
+        'site-name': `${siteInfo.name}`,
         'config-path': site.configPath,
-        'admin-url': siteData.admin_url,
-        'site-url': siteData.ssl_url || siteData.url,
-        'site-id': siteData.id,
+        'admin-url': siteInfo.admin_url,
+        'site-url': siteInfo.ssl_url || siteInfo.url,
+        'site-id': siteInfo.id,
       },
     })
   }
@@ -106,11 +93,11 @@ const status = async (options, command) => {
 ────────────────────┘`)
   log(
     prettyjson.render({
-      'Current site': `${siteData.name}`,
+      'Current site': `${siteInfo.name}`,
       'Netlify TOML': site.configPath,
-      'Admin URL': chalk.magentaBright(siteData.admin_url),
-      'Site URL': chalk.cyanBright(siteData.ssl_url || siteData.url),
-      'Site Id': chalk.yellowBright(siteData.id),
+      'Admin URL': chalk.magentaBright(siteInfo.admin_url),
+      'Site URL': chalk.cyanBright(siteInfo.ssl_url || siteInfo.url),
+      'Site Id': chalk.yellowBright(siteInfo.id),
     }),
   )
   log()


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Removes a second run of `getSite` from the `netlify status` command as we already have that data when `base-command` runs first.

This makes this command a bit faster at the cost of losing errors based on error code (401, 404) but I think this a reasonable tradeoff.


|  Before |  After  |
|---|---|
| Between 3.6 and 5.1 seconds <img width="623" alt="Screenshot 2023-11-16 at 5 22 42 PM" src="https://github.com/netlify/cli/assets/4700602/ef2d1497-067f-44fa-92c2-387a20c243cb"> |  Between 3.2 and 3.7 seconds <img width="605" alt="Screenshot 2023-11-16 at 5 23 39 PM" src="https://github.com/netlify/cli/assets/4700602/f16e6d0c-fa00-4ee8-b7f3-b1a7d848a16f"> |

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
