### PR TITLE
fix: `ntl serve` for v2 functions, follow-ups

### DIFF
--- a/src/lib/functions/registry.ts
+++ b/src/lib/functions/registry.ts
@@ -466,11 +466,11 @@ export class FunctionsRegistry {
       }
 
       // When we look at an unzipped function, we don't know whether it uses
-      // the legacy entry file format (i.e. `[function name].js`) or the new
-      // one (i.e. `___netlify-entry-point.js`). Let's look for the new one
+      // the legacy entry file format (i.e. `[function name].mjs`) or the new
+      // one (i.e. `___netlify-entry-point.mjs`). Let's look for the new one
       // and use it if it exists, otherwise use the old one.
       try {
-        const v2EntryPointPath = join(unzippedDirectory, '___netlify-entry-point.js')
+        const v2EntryPointPath = join(unzippedDirectory, '___netlify-entry-point.mjs')
 
         await stat(v2EntryPointPath)
 

--- a/src/lib/functions/registry.ts
+++ b/src/lib/functions/registry.ts
@@ -460,7 +460,10 @@ export class FunctionsRegistry {
       // @ts-expect-error TS(2339) FIXME: Property 'manifest' does not exist on type 'Functi... Remove this comment to see the full error message
       const manifestEntry = (this.manifest?.functions || []).find((manifestFunc) => manifestFunc.name === func.name)
 
-      func.buildData = manifestEntry?.buildData || {}
+      func.buildData = {
+        ...manifestEntry?.buildData,
+        routes: manifestEntry.routes,
+      }
 
       // When we look at an unzipped function, we don't know whether it uses
       // the legacy entry file format (i.e. `[function name].js`) or the new


### PR DESCRIPTION
Contains two follow-ups to https://github.com/netlify/cli/pull/6076, that were discovered while working on the Astro adapter.

1. `ntl serve` should pick up `routes` from `manifest.json`
2. `__netlify-entrypoint.js` is the wrong extension, it needs to be `.mjs` - see https://github.com/netlify/zip-it-and-ship-it/blame/f5fb309109408d25544fe34bdee77f917ff679e7/src/runtimes/node/utils/entry_file.ts#L150