### PR TITLE
fix: don't show warning when there are no ef

### DIFF
--- a/src/lib/edge-functions/registry.ts
+++ b/src/lib/edge-functions/registry.ts
@@ -126,10 +126,6 @@ export class EdgeFunctionsRegistry {
         throw new Error('Build error')
       }
 
-      if (this.functions.length === 0) {
-        return { warnings }
-      }
-
       this.buildError = null
 
       // We use one index to loop over both internal and user function, because we know that this.#functions has internalFunctions first.
@@ -408,7 +404,9 @@ export class EdgeFunctionsRegistry {
    */
   private processGraph(graph: ModuleGraph | undefined) {
     if (!graph) {
-      warn('Could not process edge functions dependency graph. Live reload will not be available.')
+      if (this.functions.length !== 0) {
+        warn('Could not process edge functions dependency graph. Live reload will not be available.')
+      }
 
       return
     }

--- a/src/lib/edge-functions/registry.ts
+++ b/src/lib/edge-functions/registry.ts
@@ -126,6 +126,10 @@ export class EdgeFunctionsRegistry {
         throw new Error('Build error')
       }
 
+      if (this.functions.length === 0) {
+        return { warnings }
+      }
+
       this.buildError = null
 
       // We use one index to loop over both internal and user function, because we know that this.#functions has internalFunctions first.


### PR DESCRIPTION
We're currently showing this warning when there's dependency graph:

https://github.com/netlify/cli/blob/dbd6066a69bc273846c640b8e5ca090695bde3c9/src/lib/edge-functions/registry.ts#L411

One case where there's no dependency graph is when there's no functions:

https://github.com/netlify/cli/blob/dbd6066a69bc273846c640b8e5ca090695bde3c9/src/lib/edge-functions/registry.ts#L467-L473

We shouldn't be showing the warning in that case. This PR adds an early-return that does that.