### PR TITLE
fix: image CDN asset url shouldn't have double slash

### DIFF
--- a/src/lib/images/proxy.ts
+++ b/src/lib/images/proxy.ts
@@ -148,7 +148,7 @@ export const initializeProxy = async function ({
     if (!sourceImagePath.startsWith('http://') && !sourceImagePath.startsWith('https://')) {
       // Construct the full URL for relative paths to request from development server
       const sourceImagePathWithLeadingSlash = sourceImagePath.startsWith('/') ? sourceImagePath : `/${sourceImagePath}`
-      const fullImageUrl = `${devServerUrl}/${encodeURIComponent(sourceImagePathWithLeadingSlash)}`
+      const fullImageUrl = `${devServerUrl}${encodeURIComponent(sourceImagePathWithLeadingSlash)}`
       console.log(`fullImageUrl: ${fullImageUrl}`)
       req.url = `/${modifiers}/${fullImageUrl}`
     } else {

--- a/tests/integration/commands/addons/addons.test.js
+++ b/tests/integration/commands/addons/addons.test.js
@@ -2,7 +2,7 @@ import { describe, test } from 'vitest'
 
 import { callCli } from '../../utils/call-cli.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const siteInfo = {
   account_slug: 'test-account',

--- a/tests/integration/commands/build/build.test.js
+++ b/tests/integration/commands/build/build.test.js
@@ -5,7 +5,7 @@ import { describe, test } from 'vitest'
 
 import { cliPath } from '../../utils/cli-path.js'
 import { withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const defaultEnvs = {
   NETLIFY_AUTH_TOKEN: 'fake-token',

--- a/tests/integration/commands/deploy/deploy.test.js
+++ b/tests/integration/commands/deploy/deploy.test.js
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, test } from 'vitest'
 
 import { callCli } from '../../utils/call-cli.js'
 import { createLiveTestSite, generateSiteName } from '../../utils/create-live-test-site.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/tests/integration/commands/dev/dev-forms-and-redirects.test.js
+++ b/tests/integration/commands/dev/dev-forms-and-redirects.test.js
@@ -7,8 +7,8 @@ import getPort from 'get-port'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withDevServer } from '../../utils/dev-server.ts'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('commands/dev-forms-and-redirects', () => {
   test('should return 404 when redirecting to a non existing function', async (t) => {

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -7,11 +7,11 @@ import jwt from 'jsonwebtoken'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
+import { withDevServer } from '../../utils/dev-server.ts'
 import got from '../../utils/got.js'
 import { withMockApi } from '../../utils/mock-api.js'
 import { pause } from '../../utils/pause.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/tests/integration/commands/dev/dev.config.test.js
+++ b/tests/integration/commands/dev/dev.config.test.js
@@ -6,8 +6,8 @@ import fetch from 'node-fetch'
 import { gte } from 'semver'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withDevServer } from '../../utils/dev-server.ts'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('commands/dev/config', () => {
   test('should use [build.environment] and not [context.production.environment]', async (t) => {

--- a/tests/integration/commands/dev/dev.exec.test.js
+++ b/tests/integration/commands/dev/dev.exec.test.js
@@ -3,7 +3,7 @@ import process from 'process'
 import { test } from 'vitest'
 
 import { callCli } from '../../utils/call-cli.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 test('should pass .env variables to exec command', async (t) => {
   await withSiteBuilder('site-env-file', async (builder) => {

--- a/tests/integration/commands/dev/dev.geo.test.js
+++ b/tests/integration/commands/dev/dev.geo.test.js
@@ -3,7 +3,7 @@ import process from 'process'
 import { test } from 'vitest'
 
 import { callCli } from '../../utils/call-cli.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 test('should throw if invalid country arg is passed', async (t) => {
   await withSiteBuilder('site-env', async (builder) => {

--- a/tests/integration/commands/dev/dev.test.js
+++ b/tests/integration/commands/dev/dev.test.js
@@ -6,10 +6,10 @@ import jwt from 'jsonwebtoken'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
+import { withDevServer } from '../../utils/dev-server.ts'
 import { startExternalServer } from '../../utils/external-server.js'
 import { withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('command/dev', () => {
   test('should return 404.html if exists for non existing routes', async (t) => {

--- a/tests/integration/commands/dev/dev.zisi.test.js
+++ b/tests/integration/commands/dev/dev.zisi.test.js
@@ -10,9 +10,9 @@ import nodeFetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
 import { curl } from '../../utils/curl.js'
-import { withDevServer } from '../../utils/dev-server.js'
+import { withDevServer } from '../../utils/dev-server.ts'
 import { withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/tests/integration/commands/dev/images.test.js
+++ b/tests/integration/commands/dev/images.test.js
@@ -5,7 +5,6 @@ import path from 'path'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { IMAGE_URL_PATTERN } from '../../../../src/lib/images/proxy.js'
 import { withDevServer } from '../../utils/dev-server.js'
 import { withSiteBuilder } from '../../utils/site-builder.js'
 
@@ -38,14 +37,14 @@ describe.concurrent('commands/dev/images', () => {
       await builder.buildAsync()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
-        await fetch(
-          `${server.url}${IMAGE_URL_PATTERN}?url=https://images.unsplash.com/photo-1517849845537-4d257902454a&w=100&h=200&q=80&fm=avif&fit=cover&position=left`,
-          {},
-        ).then((res) => {
-          t.expect(res.status).toEqual(200)
-          t.expect(res.headers.get('content-type')).toEqual('image/avif')
-          return res.buffer()
-        })
+        const res = await fetch(
+          new URL(
+            '.netlify/images?url=https://images.unsplash.com/photo-1517849845537-4d257902454a&w=100&h=200&q=80&fm=avif&fit=cover&position=left',
+            server.url,
+          ),
+        )
+        t.expect(res.status).toEqual(200)
+        t.expect(res.headers.get('content-type')).toEqual('image/avif')
       })
     })
   })
@@ -76,14 +75,11 @@ describe.concurrent('commands/dev/images', () => {
       await builder.buildAsync()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
-        await fetch(
-          `${server.url}${IMAGE_URL_PATTERN}?url=/images/test.jpg&w=100&h=200&q=80&fm=avif&fit=cover&position=left`,
-          {},
-        ).then((res) => {
-          t.expect(res.status).toEqual(200)
-          t.expect(res.headers.get('content-type')).toEqual('image/avif')
-          return res.buffer()
-        })
+        const res = await fetch(
+          new URL('.netlify/images?url=/images/test.jpg&w=100&h=200&q=80&fm=avif&fit=cover&position=left', server.url),
+        )
+        t.expect(res.status).toEqual(200)
+        t.expect(res.headers.get('content-type')).toEqual('image/avif')
       })
     })
   })

--- a/tests/integration/commands/dev/images.test.js
+++ b/tests/integration/commands/dev/images.test.js
@@ -67,6 +67,13 @@ describe.concurrent('commands/dev/images', () => {
           path: 'index.html',
         })
         .withContentFile({
+          content: `
+          export default () => new Response("SSR-Rendered Page")
+          export const config = { path: "/*", preferStatic: true }
+          `,
+          path: '/.netlify/functions-internal/ssr.mjs',
+        })
+        .withContentFile({
           // eslint-disable-next-line no-undef
           content: fs.readFileSync(path.join(__dirname, `/../../__fixtures__/images/test.jpg`)),
           path: '/images/test.jpg',

--- a/tests/integration/commands/dev/images.test.js
+++ b/tests/integration/commands/dev/images.test.js
@@ -34,7 +34,7 @@ describe.concurrent('commands/dev/images', () => {
           path: 'index.html',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const res = await fetch(
@@ -79,7 +79,7 @@ describe.concurrent('commands/dev/images', () => {
           path: '/images/test.jpg',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const res = await fetch(

--- a/tests/integration/commands/dev/images.test.js
+++ b/tests/integration/commands/dev/images.test.js
@@ -5,8 +5,8 @@ import path from 'path'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withDevServer } from '../../utils/dev-server.ts'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('commands/dev/images', () => {
   test(`should support remote image transformations`, async (t) => {

--- a/tests/integration/commands/dev/responses.dev.test.js
+++ b/tests/integration/commands/dev/responses.dev.test.js
@@ -4,8 +4,8 @@ import path from 'path'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { withDevServer } from '../../utils/dev-server.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withDevServer } from '../../utils/dev-server.ts'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('commands/responses.dev', () => {
   test('should return index file when / is accessed', async (t) => {

--- a/tests/integration/commands/dev/v2-api.test.ts
+++ b/tests/integration/commands/dev/v2-api.test.ts
@@ -190,8 +190,8 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
         const url = `http://localhost:${devServer.port}/v2-to-legacy-without-force`
         const response = await fetch(url)
         expect(response.status).toBe(200)
-        const text = await (await response.text()).trim()
-        expect(text).toBe('/v2-to-legacy-without-force from origin')
+        const text = await response.text()
+        expect(text.trim()).toBe('/v2-to-legacy-without-force from origin')
       })
 
       test<FixtureTestContext>('rewrite to custom URL format with `force: true`', async ({ devServer }) => {
@@ -205,8 +205,8 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
         const url = `http://localhost:${devServer.port}/v2-to-custom-without-force`
         const response = await fetch(url)
         expect(response.status).toBe(200)
-        const text = await (await response.text()).trim()
-        expect(text).toBe('/v2-to-custom-without-force from origin')
+        const text = await response.text()
+        expect(text.trim()).toBe('/v2-to-custom-without-force from origin')
       })
     })
 

--- a/tests/integration/commands/env/env.test.js
+++ b/tests/integration/commands/env/env.test.js
@@ -7,7 +7,7 @@ import { callCli } from '../../utils/call-cli.js'
 import { cliPath } from '../../utils/cli-path.js'
 import { CONFIRM, answerWithValue, handleQuestions } from '../../utils/handle-questions.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 import { normalize } from '../../utils/snapshots.js'
 
 const siteInfo = {

--- a/tests/integration/commands/envelope/envelope.test.js
+++ b/tests/integration/commands/envelope/envelope.test.js
@@ -2,7 +2,7 @@ import { test, describe } from 'vitest'
 
 import { callCli } from '../../utils/call-cli.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 import { normalize } from '../../utils/snapshots.js'
 
 const siteInfo = {

--- a/tests/integration/commands/functions-create/functions-create.test.ts
+++ b/tests/integration/commands/functions-create/functions-create.test.ts
@@ -10,7 +10,7 @@ import { cliPath } from '../../utils/cli-path.js'
 import { FixtureTestContext, setupFixtureTests } from '../../utils/fixture'
 import { CONFIRM, DOWN, answerWithValue, handleQuestions } from '../../utils/handle-questions.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('functions:create command', () => {
   const siteInfo = {

--- a/tests/integration/commands/functions-serve/functions-serve.test.js
+++ b/tests/integration/commands/functions-serve/functions-serve.test.js
@@ -6,7 +6,7 @@ import waitPort from 'wait-port'
 
 import { cliPath } from '../../utils/cli-path.js'
 import { killProcess } from '../../utils/process.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const DEFAULT_PORT = 9999
 const SERVE_TIMEOUT = 180_000

--- a/tests/integration/commands/functions-with-args/functions-with-args.test.js
+++ b/tests/integration/commands/functions-with-args/functions-with-args.test.js
@@ -4,10 +4,10 @@ import { fileURLToPath } from 'url'
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { tryAndLogOutput, withDevServer } from '../../utils/dev-server.js'
+import { tryAndLogOutput, withDevServer } from '../../utils/dev-server.ts'
 import got from '../../utils/got.js'
 import { pause } from '../../utils/pause.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/tests/integration/commands/init/init.test.js
+++ b/tests/integration/commands/init/init.test.js
@@ -8,7 +8,7 @@ import { describe, test } from 'vitest'
 import { cliPath } from '../../utils/cli-path.js'
 import { CONFIRM, DOWN, answerWithValue, handleQuestions } from '../../utils/handle-questions.js'
 import { withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 const defaultFunctionsDirectory = 'netlify/functions'
 

--- a/tests/integration/commands/integration/deploy.test.ts
+++ b/tests/integration/commands/integration/deploy.test.ts
@@ -7,7 +7,7 @@ import { deploy as siteDeploy } from '../../../../src/commands/deploy/deploy.js'
 import { areScopesEqual } from '../../../../src/commands/integration/deploy.js'
 import { createIntegrationDeployCommand } from '../../../../src/commands/integration/index.js'
 import { getEnvironmentVariables, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe('integration:deploy areScopesEqual', () => {
   test('it returns false when scopes are not equal', () => {

--- a/tests/integration/commands/link/link.test.ts
+++ b/tests/integration/commands/link/link.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'vitest'
 import { isFileAsync } from '../../../../src/lib/fs.js'
 import { callCli } from '../../utils/call-cli.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe('link command', () => {
   test('should create gitignore in repository root when is root', async () => {

--- a/tests/integration/commands/recipes/recipes.test.js
+++ b/tests/integration/commands/recipes/recipes.test.js
@@ -8,7 +8,7 @@ import { describe, test } from 'vitest'
 import { callCli } from '../../utils/call-cli.js'
 import { cliPath } from '../../utils/cli-path.js'
 import { CONFIRM, NO, answerWithValue, handleQuestions } from '../../utils/handle-questions.js'
-import { withSiteBuilder } from '../../utils/site-builder.js'
+import { withSiteBuilder } from '../../utils/site-builder.ts'
 import { normalize } from '../../utils/snapshots.js'
 
 describe.concurrent('commands/recipes', () => {

--- a/tests/integration/framework-detection.test.js
+++ b/tests/integration/framework-detection.test.js
@@ -3,9 +3,9 @@ import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
 import { cliPath } from './utils/cli-path.js'
-import { getExecaOptions, withDevServer } from './utils/dev-server.js'
+import { getExecaOptions, withDevServer } from './utils/dev-server.ts'
 import { DOWN, answerWithValue, handleQuestions } from './utils/handle-questions.js'
-import { withSiteBuilder } from './utils/site-builder.js'
+import { withSiteBuilder } from './utils/site-builder.ts'
 import { normalize } from './utils/snapshots.js'
 
 const content = 'Hello World!'

--- a/tests/integration/frameworks/eleventy.test.js
+++ b/tests/integration/frameworks/eleventy.test.js
@@ -6,7 +6,7 @@ import fetch from 'node-fetch'
 import { afterAll, beforeAll, describe, test } from 'vitest'
 
 import { clientIP, originalIP } from '../../lib/local-ip.js'
-import { startDevServer } from '../utils/dev-server.js'
+import { startDevServer } from '../utils/dev-server.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 

--- a/tests/integration/rules-proxy.test.ts
+++ b/tests/integration/rules-proxy.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { createRewriter, getWatchers } from '../../src/utils/rules-proxy.js'
 
 import got from './utils/got.js'
-import { createSiteBuilder, SiteBuilder } from './utils/site-builder.js'
+import { createSiteBuilder, SiteBuilder } from './utils/site-builder.ts'
 
 describe('rules-proxy', () => {
   let server: http.Server

--- a/tests/integration/serve/functions-go.test.js
+++ b/tests/integration/serve/functions-go.test.js
@@ -1,10 +1,10 @@
 import fetch from 'node-fetch'
 import { describe, test } from 'vitest'
 
-import { tryAndLogOutput, withDevServer } from '../utils/dev-server.js'
+import { tryAndLogOutput, withDevServer } from '../utils/dev-server.ts'
 import { createMock as createExecaMock } from '../utils/mock-execa.js'
 import { pause } from '../utils/pause.js'
-import { withSiteBuilder } from '../utils/site-builder.js'
+import { withSiteBuilder } from '../utils/site-builder.ts'
 
 const WAIT_WRITE = 1000
 

--- a/tests/integration/serve/functions-rust.test.js
+++ b/tests/integration/serve/functions-rust.test.js
@@ -1,10 +1,10 @@
 import fetch from 'node-fetch'
 import { test } from 'vitest'
 
-import { tryAndLogOutput, withDevServer } from '../utils/dev-server.js'
+import { tryAndLogOutput, withDevServer } from '../utils/dev-server.ts'
 import { createMock as createExecaMock } from '../utils/mock-execa.js'
 import { pause } from '../utils/pause.js'
-import { withSiteBuilder } from '../utils/site-builder.js'
+import { withSiteBuilder } from '../utils/site-builder.ts'
 
 const WAIT_WRITE = 1000
 

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -10,7 +10,7 @@ import { name, version } from '../../package.json'
 import { callCli } from './utils/call-cli.js'
 import { cliPath } from './utils/cli-path.js'
 import { MockApiTestContext, withMockApi } from './utils/mock-api-vitest.js'
-import { withSiteBuilder } from './utils/site-builder.js'
+import { withSiteBuilder } from './utils/site-builder.ts'
 
 const getCLIOptions = (apiUrl): Options => ({
   env: {

--- a/tests/integration/utils/dev-server.ts
+++ b/tests/integration/utils/dev-server.ts
@@ -22,6 +22,33 @@ export const getExecaOptions = ({ cwd, env }) => {
   }
 }
 
+interface DevServer {
+  url: string
+  host: string
+  port: number
+  errorBuffer: any[]
+  outputBuffer: any[]
+  waitForLogMatching(match: string): Promise<void>
+  output: string
+  error: string
+  close(): Promise<void>
+  promptHistory: any[]
+}
+
+type $FIXME = any
+
+interface DevServerOptions {
+  args?: string[]
+  context?: string
+  cwd: string
+  debug?: boolean
+  env?: Record<string, string>
+  expectFailure?: boolean
+  offline?: boolean
+  prompt?: $FIXME[]
+  serve?: boolean
+}
+
 const startServer = async ({
   args = [],
   context = 'dev',
@@ -32,7 +59,7 @@ const startServer = async ({
   offline = true,
   prompt,
   serve = false,
-}) => {
+}: DevServerOptions): Promise<DevServer | { timeout: boolean; output: string }> => {
   const port = await getPort()
   const staticPort = await getPort()
   const host = 'localhost'
@@ -57,11 +84,12 @@ const startServer = async ({
     baseArgs.push('--context', context)
   }
 
+  // @ts-expect-error FIXME
   const ps = execa(cliPath, [...baseArgs, ...args], getExecaOptions({ cwd, env }))
 
   if (process.env.DEBUG_TESTS) {
-    ps.stderr.pipe(process.stderr)
-    ps.stdout.pipe(process.stdout)
+    ps.stderr!.pipe(process.stderr)
+    ps.stdout!.pipe(process.stdout)
   }
 
   const promptHistory = []
@@ -70,14 +98,14 @@ const startServer = async ({
     handleQuestions(ps, prompt, promptHistory)
   }
 
-  const outputBuffer = []
-  const errorBuffer = []
-  const serverPromise = new Promise((resolve, reject) => {
+  const outputBuffer: any[] = []
+  const errorBuffer: any[] = []
+  const serverPromise = new Promise<DevServer>((resolve, reject) => {
     let selfKilled = false
-    ps.stderr.on('data', (data) => {
+    ps.stderr!.on('data', (data) => {
       errorBuffer.push(data)
     })
-    ps.stdout.on('data', (data) => {
+    ps.stdout!.on('data', (data) => {
       outputBuffer.push(data)
       if (!expectFailure && data.includes('Server now ready on')) {
         setImmediate(() =>
@@ -87,16 +115,16 @@ const startServer = async ({
             port,
             errorBuffer,
             outputBuffer,
-            waitForLogMatching(match) {
+            waitForLogMatching(match: string) {
               // eslint-disable-next-line promise/param-names
-              return new Promise((resolveWait) => {
-                const listener = (stdoutData) => {
+              return new Promise<void>((resolveWait) => {
+                const listener = (stdoutData: string) => {
                   if (stdoutData.includes(match)) {
                     ps.removeListener('data', listener)
                     resolveWait()
                   }
                 }
-                ps.stdout.on('data', listener)
+                ps.stdout!.on('data', listener)
               })
             },
             get output() {
@@ -123,16 +151,18 @@ const startServer = async ({
   return await pTimeout(serverPromise, SERVER_START_TIMEOUT, () => ({ timeout: true, output: outputBuffer.join('') }))
 }
 
-export const startDevServer = async (options, expectFailure) => {
+export const startDevServer = async (options: DevServerOptions, expectFailure: boolean): Promise<DevServer> => {
   const maxAttempts = 5
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       // do not use destruction, as we use getters which otherwise would be evaluated here
       const devServer = await startServer({ ...options, expectFailure })
+      // @ts-expect-error FIXME
       if (devServer.timeout) {
         throw new Error(`Timed out starting dev server.\nServer Output:\n${devServer.output}`)
       }
+      // @ts-expect-error FIXME
       return devServer
     } catch (error) {
       if (attempt === maxAttempts || expectFailure) {
@@ -141,13 +171,19 @@ export const startDevServer = async (options, expectFailure) => {
       console.warn('Retrying startDevServer', error)
     }
   }
+
+  throw new Error('this code should be unreachable')
 }
 
 // 240 seconds
 const SERVER_START_TIMEOUT = 24e4
 
-export const withDevServer = async (options, testHandler, expectFailure = false) => {
-  let server
+export const withDevServer = async <T>(
+  options: DevServerOptions,
+  testHandler: (server: DevServer) => Promise<T>,
+  expectFailure = false,
+): Promise<T> => {
+  let server: DevServer | undefined = undefined
   try {
     server = await startDevServer(options, expectFailure)
     return await testHandler(server)

--- a/tests/integration/utils/fixture.ts
+++ b/tests/integration/utils/fixture.ts
@@ -7,9 +7,9 @@ import { temporaryDirectory } from 'tempy'
 import { afterAll, afterEach, beforeAll, beforeEach, describe } from 'vitest'
 
 import { callCli } from './call-cli.js'
-import { startDevServer } from './dev-server.js'
+import { startDevServer } from './dev-server.ts'
 import { MockApi, Route, getCLIOptions, startMockApi } from './mock-api-vitest.js'
-import { SiteBuilder } from './site-builder.js'
+import { SiteBuilder } from './site-builder.ts'
 
 const FIXTURES_DIRECTORY = fileURLToPath(new URL('../__fixtures__/', import.meta.url))
 const HOOK_TIMEOUT = 30_000

--- a/tests/integration/utils/site-builder.ts
+++ b/tests/integration/utils/site-builder.ts
@@ -11,15 +11,14 @@ import { v4 as uuidv4 } from 'uuid'
 
 const ensureDir = (file) => mkdir(file, { recursive: true })
 
+type Task = () => Promise<unknown>
+
 export class SiteBuilder {
-  directory
-  tasks = []
+  tasks: Task[] = []
 
-  constructor(directory) {
-    this.directory = directory
-  }
+  constructor(public readonly directory: string) {}
 
-  ensureDirectoryExists(directory) {
+  ensureDirectoryExists(directory: string) {
     this.tasks.push(async () => ensureDir(directory))
 
     return this
@@ -49,7 +48,7 @@ export class SiteBuilder {
     return this
   }
 
-  withStateFile({ siteId = '' }) {
+  withStateFile({ siteId = '' }: { siteId?: string }) {
     const dest = path.join(this.directory, '.netlify', 'state.json')
     this.tasks.push(async () => {
       const content = `{ "siteId" : "${siteId}" }`
@@ -59,7 +58,7 @@ export class SiteBuilder {
     return this
   }
 
-  withPackageJson({ packageJson, pathPrefix = '' }) {
+  withPackageJson({ packageJson, pathPrefix = '' }: { packageJson: any; pathPrefix?: string }) {
     const dest = path.join(this.directory, pathPrefix, 'package.json')
     this.tasks.push(async () => {
       const content = JSON.stringify(packageJson, null, 2)
@@ -70,7 +69,17 @@ export class SiteBuilder {
     return this
   }
 
-  withFunction({ esm = false, handler, path: filePath, pathPrefix = 'functions' }) {
+  withFunction({
+    esm = false,
+    handler,
+    path: filePath,
+    pathPrefix = 'functions',
+  }: {
+    esm?: boolean
+    handler: any
+    path: string
+    pathPrefix?: string
+  }) {
     const dest = path.join(this.directory, pathPrefix, filePath)
     this.tasks.push(async () => {
       await ensureDir(path.dirname(dest))
@@ -81,12 +90,19 @@ export class SiteBuilder {
     return this
   }
 
-  /**
-   *
-   * @param {{config?:any, handler:any, internal?:boolean, name?:string, pathPrefix?:string}} param0
-   * @returns
-   */
-  withEdgeFunction({ config, handler, internal = false, name = 'function', pathPrefix = '' }) {
+  withEdgeFunction({
+    config,
+    handler,
+    internal = false,
+    name = 'function',
+    pathPrefix = '',
+  }: {
+    config?: any
+    handler: string | Function
+    internal?: boolean
+    name?: string
+    pathPrefix?: string
+  }) {
     const edgeFunctionsDirectory = internal ? '.netlify/edge-functions' : 'netlify/edge-functions'
     const dest = path.join(this.directory, pathPrefix, edgeFunctionsDirectory, `${name}.js`)
     this.tasks.push(async () => {
@@ -103,7 +119,7 @@ export class SiteBuilder {
     return this
   }
 
-  withRedirectsFile({ pathPrefix = '', redirects = [] }) {
+  withRedirectsFile({ pathPrefix = '', redirects = [] }: { pathPrefix?: string; redirects?: any[] }) {
     const dest = path.join(this.directory, pathPrefix, '_redirects')
     this.tasks.push(async () => {
       const content = redirects
@@ -116,7 +132,13 @@ export class SiteBuilder {
     return this
   }
 
-  withHeadersFile({ headers = [], pathPrefix = '' }) {
+  withHeadersFile({
+    headers = [],
+    pathPrefix = '',
+  }: {
+    headers?: { headers: string[]; path: string }[]
+    pathPrefix?: string
+  }) {
     const dest = path.join(this.directory, pathPrefix, '_headers')
     this.tasks.push(async () => {
       const content = headers
@@ -132,7 +154,7 @@ export class SiteBuilder {
     return this
   }
 
-  withContentFile({ content, path: filePath }) {
+  withContentFile({ content, path: filePath }: { content: string; path: string }) {
     const dest = path.join(this.directory, filePath)
     this.tasks.push(async () => {
       await ensureDir(path.dirname(dest))
@@ -142,7 +164,7 @@ export class SiteBuilder {
     return this
   }
 
-  withCopiedFile({ path: filePath, src }) {
+  withCopiedFile({ path: filePath, src }: { path: string; src: string }) {
     const dest = path.join(this.directory, filePath)
     this.tasks.push(async () => {
       await ensureDir(path.dirname(dest))
@@ -152,7 +174,7 @@ export class SiteBuilder {
     return this
   }
 
-  withContentFiles(files) {
+  withContentFiles(files: { content: string; path: string }[]) {
     files.forEach((file) => {
       this.withContentFile(file)
     })
@@ -160,7 +182,15 @@ export class SiteBuilder {
     return this
   }
 
-  withEnvFile({ env = {}, path: filePath = '.env', pathPrefix = '' }) {
+  withEnvFile({
+    env = {},
+    path: filePath = '.env',
+    pathPrefix = '',
+  }: {
+    env?: any
+    path?: string
+    pathPrefix?: string
+  }) {
     const dest = path.join(this.directory, pathPrefix, filePath)
     this.tasks.push(async () => {
       await ensureDir(path.dirname(dest))
@@ -174,7 +204,7 @@ export class SiteBuilder {
     return this
   }
 
-  withGit({ repoUrl = 'git@github.com:owner/repo.git' } = {}) {
+  withGit({ repoUrl = 'git@github.com:owner/repo.git' }: { repoUrl?: string } = {}) {
     this.tasks.push(async () => {
       await execa('git', ['init', '--initial-branch', 'main'], { cwd: this.directory })
       await execa('git', ['remote', 'add', 'origin', repoUrl], { cwd: this.directory })
@@ -183,7 +213,7 @@ export class SiteBuilder {
     return this
   }
 
-  withoutFile({ path: filePath }) {
+  withoutFile({ path: filePath }: { path: string }) {
     const dest = path.join(this.directory, filePath)
     this.tasks.push(async () => {
       await unlink(dest)
@@ -192,7 +222,7 @@ export class SiteBuilder {
     return this
   }
 
-  withBuildPlugin({ name, pathPrefix = 'plugins', plugin }) {
+  withBuildPlugin({ name, pathPrefix = 'plugins', plugin }: { name: string; pathPrefix?: string; plugin: any }) {
     const dest = path.join(this.directory, pathPrefix, `${name}.js`)
     this.tasks.push(async () => {
       await ensureDir(path.dirname(dest))
@@ -205,7 +235,7 @@ export class SiteBuilder {
     return this
   }
 
-  withCommand({ command }) {
+  withCommand({ command }: { command: string[] }) {
     this.tasks.push(async () => {
       const [mainCommand, ...args] = command
 
@@ -250,7 +280,7 @@ export class SiteBuilder {
   }
 }
 
-export const createSiteBuilder = ({ siteName }) => {
+export const createSiteBuilder = ({ siteName }: { siteName: string }) => {
   const directory = path.join(
     tempDirectory,
     `netlify-cli-tests-${process.version}`,
@@ -262,8 +292,11 @@ export const createSiteBuilder = ({ siteName }) => {
   return new SiteBuilder(directory).ensureDirectoryExists(directory)
 }
 
-export const withSiteBuilder = async (siteName, testHandler) => {
-  let builder
+export const withSiteBuilder = async <T>(
+  siteName: string,
+  testHandler: (builder: SiteBuilder) => Promise<T>,
+): Promise<T> => {
+  let builder: SiteBuilder | undefined
   try {
     builder = createSiteBuilder({ siteName })
     return await testHandler(builder)

--- a/tests/unit/utils/deploy/hash-files.test.js
+++ b/tests/unit/utils/deploy/hash-files.test.js
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 import { DEFAULT_CONCURRENT_HASH } from '../../../../src/utils/deploy/constants.js'
 import hashFiles from '../../../../src/utils/deploy/hash-files.js'
-import { withSiteBuilder } from '../../../integration/utils/site-builder.js'
+import { withSiteBuilder } from '../../../integration/utils/site-builder.ts'
 
 test('Hashes files in a folder', async () => {
   await withSiteBuilder('site-with-content', async (builder) => {

--- a/tests/unit/utils/deploy/hash-fns.test.js
+++ b/tests/unit/utils/deploy/hash-fns.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest'
 
 import { DEFAULT_CONCURRENT_HASH } from '../../../../src/utils/deploy/constants.js'
 import hashFns from '../../../../src/utils/deploy/hash-fns.js'
-import { withSiteBuilder } from '../../../integration/utils/site-builder.js'
+import { withSiteBuilder } from '../../../integration/utils/site-builder.ts'
 
 test('Hashes files in a folder', async () => {
   await withSiteBuilder('site-with-functions', async (builder) => {

--- a/tests/unit/utils/dot-env.test.js
+++ b/tests/unit/utils/dot-env.test.js
@@ -3,7 +3,7 @@ import process from 'process'
 import { expect, test } from 'vitest'
 
 import { tryLoadDotEnvFiles } from '../../../src/utils/dot-env.js'
-import { withSiteBuilder } from '../../integration/utils/site-builder.js'
+import { withSiteBuilder } from '../../integration/utils/site-builder.ts'
 
 test('should return an empty array for a site with no .env file', async () => {
   await withSiteBuilder('site-without-env-file', async (builder) => {

--- a/tests/unit/utils/functions/get-functions.test.js
+++ b/tests/unit/utils/functions/get-functions.test.js
@@ -3,7 +3,7 @@ import path from 'path'
 import { describe, expect, test } from 'vitest'
 
 import { getFunctions } from '../../../../src/utils/functions/get-functions.js'
-import { withSiteBuilder } from '../../../integration/utils/site-builder.js'
+import { withSiteBuilder } from '../../../integration/utils/site-builder.ts'
 
 describe('getFunctions', () => {
   test('should return empty object when an empty string is provided', async () => {

--- a/tests/unit/utils/headers.test.js
+++ b/tests/unit/utils/headers.test.js
@@ -3,7 +3,7 @@ import { resolve } from 'path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { headersForPath, parseHeaders } from '../../../src/utils/headers.js'
-import { createSiteBuilder } from '../../integration/utils/site-builder.js'
+import { createSiteBuilder } from '../../integration/utils/site-builder.ts'
 
 vi.mock('../../../src/utils/command-helpers.js', async () => ({
   ...(await vi.importActual('../../../src/utils/command-helpers.js')),

--- a/tests/unit/utils/redirects.test.js
+++ b/tests/unit/utils/redirects.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 
 import { parseRedirects } from '../../../src/utils/redirects.js'
-import { withSiteBuilder } from '../../integration/utils/site-builder.js'
+import { withSiteBuilder } from '../../integration/utils/site-builder.ts'
 
 const defaultConfig = {
   redirects: [


### PR DESCRIPTION
Found one more bug in the Image CDN implementation! The logic to generate the Asset URL had one `/` too much in it, resulting in it matching the wrong resource.

This PR also converts two test files into TypeScript.

Best-reviewed commit by commit - the typescript conversions are pretty big diffs.