### PR TITLE
feat: set Netlify environment variables in edge functions

### DIFF
--- a/src/lib/edge-functions/bootstrap.ts
+++ b/src/lib/edge-functions/bootstrap.ts
@@ -1,5 +1,5 @@
 import { env } from 'process'
 
-const latestBootstrapURL = 'https://65437779a0c9990008b54abe--edge.netlify.com/bootstrap/index-combined.ts'
+const latestBootstrapURL = 'https://656703bb61f20c00084a3479--edge.netlify.com/bootstrap/index-combined.ts'
 
 export const getBootstrapURL = () => env.NETLIFY_EDGE_BOOTSTRAP || latestBootstrapURL

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -146,7 +146,6 @@ export const initializeProxy = async ({
     edge_functions_npm_modules: true,
   }
   const runtimeFeatureFlags = ['edge_functions_bootstrap_failure_mode', 'edge_functions_bootstrap_populate_environment']
-  const localURL = `http://${LOCAL_HOST}:${mainPort}`
 
   // Initializes the server, bootstrapping the Deno CLI and downloading it from
   // the network if needed. We don't want to wait for that to be completed, or
@@ -185,7 +184,7 @@ export const initializeProxy = async ({
     // Setting header with geolocation and site info.
     req.headers[headers.Geo] = Buffer.from(JSON.stringify(geoLocation)).toString('base64')
     req.headers[headers.DeployID] = '0'
-    req.headers[headers.Site] = createSiteInfoHeader(siteInfo, localURL)
+    req.headers[headers.Site] = createSiteInfoHeader(siteInfo, `http://localhost:${mainPort}`)
     req.headers[headers.Account] = createAccountInfoHeader({ id: accountId })
 
     if (blobsContext?.edgeURL && blobsContext?.token) {
@@ -196,7 +195,7 @@ export const initializeProxy = async ({
 
     await registry.initialize()
 
-    const url = new URL(req.url, localURL)
+    const url = new URL(req.url, `http://${LOCAL_HOST}:${mainPort}`)
     const { functionNames, invocationMetadata } = registry.matchURLPath(url.pathname, req.method)
 
     if (functionNames.length === 0) {

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -146,6 +146,7 @@ export const initializeProxy = async ({
     edge_functions_npm_modules: true,
   }
   const runtimeFeatureFlags = ['edge_functions_bootstrap_failure_mode', 'edge_functions_bootstrap_populate_environment']
+  const protocol = settings.https ? 'https' : 'http'
 
   // Initializes the server, bootstrapping the Deno CLI and downloading it from
   // the network if needed. We don't want to wait for that to be completed, or
@@ -184,7 +185,7 @@ export const initializeProxy = async ({
     // Setting header with geolocation and site info.
     req.headers[headers.Geo] = Buffer.from(JSON.stringify(geoLocation)).toString('base64')
     req.headers[headers.DeployID] = '0'
-    req.headers[headers.Site] = createSiteInfoHeader(siteInfo, `http://localhost:${mainPort}`)
+    req.headers[headers.Site] = createSiteInfoHeader(siteInfo, `${protocol}://localhost:${mainPort}`)
     req.headers[headers.Account] = createAccountInfoHeader({ id: accountId })
 
     if (blobsContext?.edgeURL && blobsContext?.token) {
@@ -204,7 +205,7 @@ export const initializeProxy = async ({
 
     req[headersSymbol] = {
       [headers.FeatureFlags]: getFeatureFlagsHeader(runtimeFeatureFlags),
-      [headers.ForwardedProtocol]: settings.https ? 'https:' : 'http:',
+      [headers.ForwardedProtocol]: `${protocol}:`,
       [headers.Functions]: functionNames.join(','),
       [headers.InvocationMetadata]: getInvocationMetadataHeader(invocationMetadata),
       [headers.IP]: LOCAL_HOST,

--- a/tests/integration/__fixtures__/dev-server-with-edge-functions/netlify/edge-functions/echo-env.ts
+++ b/tests/integration/__fixtures__/dev-server-with-edge-functions/netlify/edge-functions/echo-env.ts
@@ -1,0 +1,7 @@
+import { Config, Context } from 'https://edge.netlify.com'
+
+export default (_, context: Context) => Response.json(Netlify.env.toObject())
+
+export const config: Config = {
+  path: '/echo-env',
+}

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -386,7 +386,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             t.expect(response.status).toBe(200)
             t.expect(JSON.parse(await response.text())).toStrictEqual({
               deploy: { id: '0' },
-              site: { id: 'site_id', name: 'site-name', url: 'site-url' },
+              site: { id: 'site_id', name: 'site-name', url: server.url },
             })
           },
         )

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -1110,7 +1110,10 @@ describe.concurrent('commands/dev-miscellaneous', () => {
               t.expect(bucketKeys.includes('DENO_DEPLOYMENT_ID')).toBe(false)
               t.expect(bucketKeys.includes('NODE_ENV')).toBe(false)
               t.expect(bucketKeys.includes('DEPLOY_URL')).toBe(false)
-              t.expect(bucketKeys.includes('URL')).toBe(false)
+
+              t.expect(bucketKeys.includes('URL')).toBe(true)
+              t.expect(bucketKeys.includes('SITE_ID')).toBe(true)
+              t.expect(bucketKeys.includes('SITE_NAME')).toBe(true)
             })
           },
         )

--- a/tests/integration/commands/dev/edge-functions.test.ts
+++ b/tests/integration/commands/dev/edge-functions.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(isWindows)('edge functions', () => {
       expect(params).toEqual({})
       expectTypeOf(requestId).toBeString()
       expect(server).toEqual({ region: 'local' })
-      expect(site).toEqual({ id: 'foo', name: 'site-name', url: `http://127.0.0.1:${devServer.port}` })
+      expect(site).toEqual({ id: 'foo', name: 'site-name', url: `http://localhost:${devServer.port}` })
     })
 
     test<FixtureTestContext>('should expose URL parameters', async ({ devServer }) => {
@@ -146,7 +146,7 @@ describe.skipIf(isWindows)('edge functions', () => {
 
       expect(body.SITE_ID).toBe('foo')
       expect(body.SITE_NAME).toBe('site-name')
-      expect(body.URL).toBe(`http://127.0.0.1:${devServer.port}`)
+      expect(body.URL).toBe(`http://localhost:${devServer.port}`)
     })
   })
 

--- a/tests/integration/commands/dev/edge-functions.test.ts
+++ b/tests/integration/commands/dev/edge-functions.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(isWindows)('edge functions', () => {
       expect(params).toEqual({})
       expectTypeOf(requestId).toBeString()
       expect(server).toEqual({ region: 'local' })
-      expect(site).toEqual({ id: 'foo', name: 'site-name' })
+      expect(site).toEqual({ id: 'foo', name: 'site-name', url: `http://127.0.0.1:${devServer.port}` })
     })
 
     test<FixtureTestContext>('should expose URL parameters', async ({ devServer }) => {
@@ -134,6 +134,19 @@ describe.skipIf(isWindows)('edge functions', () => {
       })
 
       expect(res2.body).toContain('<p>An unhandled error in the function code triggered the following message:</p>')
+    })
+
+    test<FixtureTestContext>('should set the `URL`, `SITE_ID`, and `SITE_NAME` environment variables', async ({
+      devServer,
+    }) => {
+      const body = (await got(`http://localhost:${devServer.port}/echo-env`, {
+        throwHttpErrors: false,
+        retry: { limit: 0 },
+      }).json()) as Record<string, string>
+
+      expect(body.SITE_ID).toBe('foo')
+      expect(body.SITE_NAME).toBe('site-name')
+      expect(body.URL).toBe(`http://127.0.0.1:${devServer.port}`)
     })
   })
 


### PR DESCRIPTION
#### Summary

Sets the `URL`, `SITE_ID`, and `SITE_NAME` environment variables when running edge functions locally.

Part of https://linear.app/netlify/issue/COM-149/edge-functions-are-missing-the-url-environment-variable.