### PR TITLE
fix: streaming response with content-length breaks local dev

### DIFF
--- a/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/stream-with-contentlength.js
+++ b/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/stream-with-contentlength.js
@@ -1,0 +1,1 @@
+export default () => fetch(`https://www.gatsbyjs.com/Gatsby-Logo.svg`)

--- a/tests/integration/commands/dev/v2-api.test.ts
+++ b/tests/integration/commands/dev/v2-api.test.ts
@@ -57,6 +57,11 @@ describe.runIf(gte(version, '18.13.0'))('v2 api', () => {
       expect(thirdChunk.done).toBeTruthy()
     })
 
+    test.only<FixtureTestContext>('supports streamed responses with content-length', async ({ devServer }) => {
+      const response = await fetch(`http://localhost:${devServer.port}/.netlify/functions/stream-with-contentlength`)
+      expect(response.status).toBe(200)
+    })
+
     test<FixtureTestContext>('receives context', async ({ devServer }) => {
       const response = await fetch(`http://localhost:${devServer.port}/.netlify/functions/context`, {
         headers: {


### PR DESCRIPTION
Addresses https://linear.app/netlify/issue/COM-222/local-dev-cli-tries-to-compute-etag-on-streaming-response-breaks