### PR TITLE
fix: use correct file extensions for transpilation

### DIFF
--- a/src/lib/functions/netlify-function.ts
+++ b/src/lib/functions/netlify-function.ts
@@ -121,7 +121,7 @@ export default class NetlifyFunction {
     }
 
     if (extension === '.js') {
-      return '.js'
+      return '.mjs'
     }
   }
 

--- a/src/lib/functions/runtimes/js/builders/zisi.ts
+++ b/src/lib/functions/runtimes/js/builders/zisi.ts
@@ -175,7 +175,7 @@ export default async function handler({ config, directory, errorExit, func, meta
     featureFlags.zisi_pure_esm_mjs = true
   } else {
     // We must use esbuild for certain file extensions.
-    const mustTranspile = ['.js', '.ts', '.mts', '.cts'].includes(path.extname(func.mainFile))
+    const mustTranspile = ['.mjs', '.ts', '.mts', '.cts'].includes(path.extname(func.mainFile))
     const mustUseEsbuild = hasTypeModule || mustTranspile
 
     if (mustUseEsbuild && !functionsConfig['*'].nodeBundler) {

--- a/tests/integration/commands/deploy/deploy.test.js
+++ b/tests/integration/commands/deploy/deploy.test.js
@@ -495,7 +495,7 @@ describe.skipIf(process.env.NETLIFY_TEST_DISABLE_LIVE === 'true').concurrent('co
           export default async () => new Response("Internal V2 API")
           export const config = { path: "/internal-v2-func" }
           `,
-          path: '.netlify/functions-internal/func-4.js',
+          path: '.netlify/functions-internal/func-4.mjs',
         })
         .buildAsync()
 

--- a/tests/integration/commands/functions-with-args/functions-with-args.test.js
+++ b/tests/integration/commands/functions-with-args/functions-with-args.test.js
@@ -610,7 +610,7 @@ exports.handler = async () => ({
     })
   })
 
-  test('Serves functions with a `.js` extension', async (t) => {
+  test('Serves functions with a `.mjs` extension', async (t) => {
     await withSiteBuilder('function-mjs', async (builder) => {
       const bundlerConfig = args.includes('esbuild') ? { node_bundler: 'esbuild' } : {}
 
@@ -623,7 +623,7 @@ exports.handler = async () => ({
           },
         })
         .withContentFile({
-          path: 'functions/hello.js',
+          path: 'functions/hello.mjs',
           content: `
   const handler = async () => {
     return {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

When we did the mass `.m(ts|js)` -> `.(js|ts)` extension change these got caught up. This effected the function transpillation process as it was parsing the wrong file types, creating a nested `functions-serve` directory which borked the gatsby plugin

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
