### PR TITLE
chore: site builder should infer directory name from tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
         "@babel/preset-react": "7.22.5",
         "@netlify/eslint-config-node": "7.0.0",
         "@netlify/functions": "2.4.0",
+        "@sindresorhus/slugify": "^2.2.1",
         "@types/fs-extra": "11.0.4",
         "@types/inquirer": "9.0.7",
         "@types/node": "20.9.0",
@@ -6695,9 +6696,9 @@
       }
     },
     "node_modules/@sindresorhus/slugify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.1.1.tgz",
-      "integrity": "sha512-XokPHZ+q6FtQGEi1hnfvARVJJVPEhwHQTPHPPuNHaN6zcHjzYNynhhHMopa1wNPqLAFOwpsbintunEqWecXJMg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
       "dependencies": {
         "@sindresorhus/transliterate": "^1.0.0",
         "escape-string-regexp": "^5.0.0"
@@ -29150,9 +29151,9 @@
       "dev": true
     },
     "@sindresorhus/slugify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.1.1.tgz",
-      "integrity": "sha512-XokPHZ+q6FtQGEi1hnfvARVJJVPEhwHQTPHPPuNHaN6zcHjzYNynhhHMopa1wNPqLAFOwpsbintunEqWecXJMg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
       "requires": {
         "@sindresorhus/transliterate": "^1.0.0",
         "escape-string-regexp": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "@babel/preset-react": "7.22.5",
     "@netlify/eslint-config-node": "7.0.0",
     "@netlify/functions": "2.4.0",
+    "@sindresorhus/slugify": "^2.2.1",
     "@types/fs-extra": "11.0.4",
     "@types/inquirer": "9.0.7",
     "@types/node": "20.9.0",

--- a/tests/integration/commands/addons/addons.test.js
+++ b/tests/integration/commands/addons/addons.test.js
@@ -19,7 +19,7 @@ const routes = [
 ]
 describe.concurrent('command-addons', () => {
   test('netlify addons:list', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -30,7 +30,7 @@ describe.concurrent('command-addons', () => {
   })
 
   test('netlify addons:list --json', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -43,7 +43,7 @@ describe.concurrent('command-addons', () => {
   })
 
   test('netlify addons:create demo', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const createRoutes = [
@@ -68,7 +68,7 @@ describe.concurrent('command-addons', () => {
   })
 
   test('After creation netlify addons:list --json', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const withExistingAddon = [
@@ -94,7 +94,7 @@ describe.concurrent('command-addons', () => {
   })
 
   test('netlify addons:config demo', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const configRoutes = [
@@ -128,7 +128,7 @@ describe.concurrent('command-addons', () => {
   })
 
   test('netlify addon:delete demo', async (t) => {
-    await withSiteBuilder('site-with-addons', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const deleteRoutes = [

--- a/tests/integration/commands/build/build.test.js
+++ b/tests/integration/commands/build/build.test.js
@@ -67,7 +67,7 @@ routesWithCommand.splice(0, 1, { path: 'sites/site_id', response: siteInfoWithCo
 
 describe.concurrent('command/build', () => {
   test('should use build command from UI', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: {} }).withStateFile({ siteId: siteInfo.id })
 
       await builder.buildAsync()
@@ -78,7 +78,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should use build command from UI with build plugin', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({
           config: {
@@ -113,7 +113,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should print output for a successful command', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
         .withStateFile({ siteId: siteInfo.id })
@@ -127,7 +127,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should print output for a failed command', async (t) => {
-    await withSiteBuilder('failure-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { build: { command: 'doesNotExist' } } }).withStateFile({ siteId: siteInfo.id })
 
       await builder.buildAsync()
@@ -139,7 +139,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should run in dry mode when the --dry flag is set', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
         .withStateFile({ siteId: siteInfo.id })
@@ -153,7 +153,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should run the production context when context is not defined', async (t) => {
-    await withSiteBuilder('context-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({
         config: {
           build: { command: 'echo testCommand' },
@@ -168,7 +168,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should run the staging context command when the --context option is set to staging', async (t) => {
-    await withSiteBuilder('context-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({
         config: {
           build: { command: 'echo testCommand' },
@@ -183,7 +183,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should run the staging context command when the context env variable is set', async (t) => {
-    await withSiteBuilder('context-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({
         config: {
           build: { command: 'echo testCommand' },
@@ -202,7 +202,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should print debug information when the --debug flag is set', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
         .withStateFile({ siteId: siteInfo.id })
@@ -216,7 +216,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should use root directory netlify.toml when runs in subdirectory', async (t) => {
-    await withSiteBuilder('subdir-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
         .withStateFile({ siteId: siteInfo.id })
@@ -231,7 +231,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should error when using invalid netlify.toml', async (t) => {
-    await withSiteBuilder('wrong-config-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { build: { command: false } } })
 
       await builder.buildAsync()
@@ -243,7 +243,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should error when a site id is missing', async (t) => {
-    await withSiteBuilder('no-site-id-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } })
 
       await builder.buildAsync()
@@ -260,7 +260,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should not require a linked site when offline flag is set', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } }).buildAsync()
 
       await runBuildCommand(t, builder.directory, {
@@ -272,7 +272,7 @@ describe.concurrent('command/build', () => {
   })
 
   test('should not send network requests when offline flag is set', async (t) => {
-    await withSiteBuilder('success-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.withNetlifyToml({ config: { build: { command: 'echo testCommand' } } }).buildAsync()
 
       await withMockApi(routes, async ({ apiUrl, requests }) => {

--- a/tests/integration/commands/dev/dev.geo.test.js
+++ b/tests/integration/commands/dev/dev.geo.test.js
@@ -6,8 +6,8 @@ import { callCli } from '../../utils/call-cli.js'
 import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 test('should throw if invalid country arg is passed', async (t) => {
-  await withSiteBuilder('site-env', async (builder) => {
-    await builder.buildAsync()
+  await withSiteBuilder(t, async (builder) => {
+    await builder.build()
 
     const options = {
       cwd: builder.directory,

--- a/tests/integration/commands/dev/images.test.js
+++ b/tests/integration/commands/dev/images.test.js
@@ -10,7 +10,7 @@ import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe.concurrent('commands/dev/images', () => {
   test(`should support remote image transformations`, async (t) => {
-    await withSiteBuilder('site-with-image-transformations', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({
           config: {
@@ -50,7 +50,7 @@ describe.concurrent('commands/dev/images', () => {
   })
 
   test(`should support local image transformations for relative paths`, async (t) => {
-    await withSiteBuilder('site-with-image-transformations', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withContentFile({
           content: `

--- a/tests/integration/commands/env/env.test.js
+++ b/tests/integration/commands/env/env.test.js
@@ -26,7 +26,7 @@ const routes = [
 
 describe('commands/env', () => {
   test('env:get --json should return empty object if var not set', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -38,7 +38,7 @@ describe('commands/env', () => {
   })
 
   test('env:get --context should log an error message', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -53,7 +53,7 @@ describe('commands/env', () => {
   })
 
   test('env:get --scope should log an error message', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -68,7 +68,7 @@ describe('commands/env', () => {
   })
 
   test('env:set --json should create and return new var', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const newBuildSettings = { env: { SOME_VAR1: 'FOO' } }
@@ -105,7 +105,7 @@ describe('commands/env', () => {
   })
 
   test('env:set --json should update existing var', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const newBuildSettings = { env: { existing_env: 'new_value' } }
@@ -142,7 +142,7 @@ describe('commands/env', () => {
   })
 
   test('env:get --json should return value of existing var', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const getRoutes = [
@@ -170,7 +170,7 @@ describe('commands/env', () => {
   })
 
   test('env:import should throw error if file not exists', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -180,7 +180,7 @@ describe('commands/env', () => {
   })
 
   test('env:import --json should import new vars and override existing vars', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withEnvFile({
           path: '.env',
@@ -224,7 +224,7 @@ describe('commands/env', () => {
   })
 
   test('env:get --json should return value of var from netlify.toml', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({
           config: {
@@ -248,7 +248,7 @@ describe('commands/env', () => {
   })
 
   test('env:list --json should return empty object if no vars set', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -260,7 +260,7 @@ describe('commands/env', () => {
   })
 
   test('env:list --context should log an error message', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -275,7 +275,7 @@ describe('commands/env', () => {
   })
 
   test('env:list --scope should log an error message', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -290,7 +290,7 @@ describe('commands/env', () => {
   })
 
   test('env:list --json should return list of vars with netlify.toml taking priority', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({
           config: {
@@ -319,7 +319,7 @@ describe('commands/env', () => {
   })
 
   test('env:list should hide variables values and prompt to show', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const questions = [
@@ -364,7 +364,7 @@ describe('commands/env', () => {
   })
 
   test('env:list should hide variables values and show on confirm', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const questions = [
@@ -409,7 +409,7 @@ describe('commands/env', () => {
   })
 
   test('env:list should not prompt on CI', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const envListRoutes = [
@@ -433,7 +433,7 @@ describe('commands/env', () => {
   })
 
   test('env:set --json should be able to set var with empty value', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const newBuildSettings = { env: { empty: '' } }
@@ -466,7 +466,7 @@ describe('commands/env', () => {
   })
 
   test('env:unset --json should remove existing variable', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const newBuildSettings = { env: {} }
@@ -503,7 +503,7 @@ describe('commands/env', () => {
   })
 
   test('env:import --json --replace-existing should replace all existing vars and return imported', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withEnvFile({
           path: '.env',
@@ -550,7 +550,7 @@ describe('commands/env', () => {
   })
 
   test("env:clone should return without clone if there's no env in source site", async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       const createRoutes = [
         { path: 'sites/site_id', response: { ...siteInfo, build_settings: { env: {} } } },
@@ -565,7 +565,7 @@ describe('commands/env', () => {
   })
 
   test("env:clone should print error if --to site doesn't exist", async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       const createRoutes = [{ path: 'sites/site_id', response: { ...siteInfo, build_settings: { env: {} } } }]
       await withMockApi(createRoutes, async ({ apiUrl }) => {
@@ -580,7 +580,7 @@ describe('commands/env', () => {
   })
 
   test("env:clone should print error if --from site doesn't exist", async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       await withMockApi([], async ({ apiUrl }) => {
         const { stderr: cliResponse } = await callCli(
@@ -594,7 +594,7 @@ describe('commands/env', () => {
   })
 
   test('env:clone should exit if the folder is not linked to a site, and --from is not provided', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const cliResponse = await callCli(['env:clone', '--to', 'site_id_a'], {
@@ -649,7 +649,7 @@ describe('commands/env', () => {
       expectedPatchRequest,
     ]
 
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       await withMockApi(cloneRoutes, async ({ apiUrl, requests }) => {
         const cliResponse = await callCli(['env:clone', '--to', 'site_id_a'], getCLIOptions({ apiUrl, builder }))

--- a/tests/integration/commands/envelope/envelope.test.js
+++ b/tests/integration/commands/envelope/envelope.test.js
@@ -110,7 +110,7 @@ const routes = [
 
 describe.concurrent('command/envelope', () => {
   test('env:import should throw error if file not exists', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -120,7 +120,7 @@ describe.concurrent('command/envelope', () => {
   })
 
   test('env:import --json should import new vars and override existing vars', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const finalEnv = {
         EXISTING_VAR: 'from-dotenv',
         OTHER_VAR: 'envelope-all-value',
@@ -146,7 +146,7 @@ describe.concurrent('command/envelope', () => {
   })
 
   test('env:import --json --replace-existing should replace all existing vars and return imported', async (t) => {
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const finalEnv = {
         EXISTING_VAR: 'from-dotenv',
         NEW_VAR: 'from-dotenv',
@@ -219,7 +219,7 @@ describe.concurrent('command/envelope', () => {
       },
     ]
 
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       await withMockApi(cloneRoutes, async ({ apiUrl, requests }) => {
         const cliResponse = await callCli(
@@ -291,7 +291,7 @@ describe.concurrent('command/envelope', () => {
       },
     ]
 
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       await withMockApi(cloneRoutes, async ({ apiUrl, requests }) => {
         const cliResponse = await callCli(
@@ -353,7 +353,7 @@ describe.concurrent('command/envelope', () => {
       },
     ]
 
-    await withSiteBuilder('site-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
       await withMockApi(cloneRoutes, async ({ apiUrl, requests }) => {
         const cliResponse = await callCli(

--- a/tests/integration/commands/init/init.test.js
+++ b/tests/integration/commands/init/init.test.js
@@ -90,7 +90,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.withGit().buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -187,7 +187,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.withGit().buildAsync()
 
       await withMockApi(routes, async ({ apiUrl }) => {
@@ -288,7 +288,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withGit()
         .withPackageJson({ packageJson: { dependencies: { next: '^10.0.0' } } })
@@ -391,7 +391,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withGit()
         .withPackageJson({ packageJson: { dependencies: { next: '^10.0.0' } } })
@@ -413,7 +413,7 @@ describe.concurrent('commands/init', () => {
     })
   })
 
-  test('netlify init existing Next.js site with existing plugins', async () => {
+  test('netlify init existing Next.js site with existing plugins', async (t) => {
     const [command, publish] = ['custom-build-command', 'custom-publish', 'custom-functions']
     const initQuestions = [
       {
@@ -480,7 +480,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withGit()
         .withPackageJson({ packageJson: { dependencies: { next: '^10.0.0' } } })
@@ -583,7 +583,7 @@ describe.concurrent('commands/init', () => {
       },
     ]
 
-    await withSiteBuilder('new-site', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withGit()
         .withContentFile({

--- a/tests/integration/commands/link/link.test.ts
+++ b/tests/integration/commands/link/link.test.ts
@@ -9,8 +9,8 @@ import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
 import { withSiteBuilder } from '../../utils/site-builder.ts'
 
 describe('link command', () => {
-  test('should create gitignore in repository root when is root', async () => {
-    await withSiteBuilder('repo', async (builder) => {
+  test('should create gitignore in repository root when is root', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.withGit().buildAsync()
 
       await withMockApi(
@@ -28,7 +28,7 @@ describe('link command', () => {
   test.skipIf(process.platform === 'win32')(
     'should create gitignore in repository root when cwd is subdirectory',
     async () => {
-      await withSiteBuilder('monorepo', async (builder) => {
+      await withSiteBuilder(t, async (builder) => {
         const projectPath = join('projects', 'project1')
         await builder.withGit().withNetlifyToml({ config: {}, pathPrefix: projectPath }).buildAsync()
 

--- a/tests/integration/commands/link/link.test.ts
+++ b/tests/integration/commands/link/link.test.ts
@@ -11,7 +11,7 @@ import { withSiteBuilder } from '../../utils/site-builder.ts'
 describe('link command', () => {
   test('should create gitignore in repository root when is root', async (t) => {
     await withSiteBuilder(t, async (builder) => {
-      await builder.withGit().buildAsync()
+      await builder.withGit().build()
 
       await withMockApi(
         [],
@@ -27,10 +27,10 @@ describe('link command', () => {
 
   test.skipIf(process.platform === 'win32')(
     'should create gitignore in repository root when cwd is subdirectory',
-    async () => {
+    async (t) => {
       await withSiteBuilder(t, async (builder) => {
         const projectPath = join('projects', 'project1')
-        await builder.withGit().withNetlifyToml({ config: {}, pathPrefix: projectPath }).buildAsync()
+        await builder.withGit().withNetlifyToml({ config: {}, pathPrefix: projectPath }).build()
 
         await withMockApi(
           [],

--- a/tests/integration/commands/recipes/recipes.test.js
+++ b/tests/integration/commands/recipes/recipes.test.js
@@ -19,7 +19,7 @@ describe.concurrent('commands/recipes', () => {
   })
 
   test('Generates a new VS Code settings file if one does not exist', async (t) => {
-    await withSiteBuilder('repo', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
@@ -45,7 +45,7 @@ describe.concurrent('commands/recipes', () => {
   })
 
   test('Updates an existing VS Code settings file', async (t) => {
-    await withSiteBuilder('repo', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withContentFile({
           path: '.vscode/settings.json',
@@ -77,7 +77,7 @@ describe.concurrent('commands/recipes', () => {
   })
 
   test('Does not generate a new VS Code settings file if the user does not confirm the prompt', async (t) => {
-    await withSiteBuilder('repo', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.buildAsync()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
@@ -100,7 +100,7 @@ describe.concurrent('commands/recipes', () => {
   })
 
   test('Handles JSON with comments', async (t) => {
-    await withSiteBuilder('repo', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const comment = '// sets value for someSetting'
       await builder
         .withContentFile({

--- a/tests/integration/commands/recipes/recipes.test.js
+++ b/tests/integration/commands/recipes/recipes.test.js
@@ -20,7 +20,7 @@ describe.concurrent('commands/recipes', () => {
 
   test('Generates a new VS Code settings file if one does not exist', async (t) => {
     await withSiteBuilder(t, async (builder) => {
-      await builder.buildAsync()
+      await builder.build()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
         cwd: builder.directory,
@@ -51,7 +51,7 @@ describe.concurrent('commands/recipes', () => {
           path: '.vscode/settings.json',
           content: JSON.stringify({ 'deno.enablePaths': ['/some/path'], someSetting: 'value' }),
         })
-        .buildAsync()
+        .build()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
         cwd: builder.directory,
@@ -78,7 +78,7 @@ describe.concurrent('commands/recipes', () => {
 
   test('Does not generate a new VS Code settings file if the user does not confirm the prompt', async (t) => {
     await withSiteBuilder(t, async (builder) => {
-      await builder.buildAsync()
+      await builder.build()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
         cwd: builder.directory,
@@ -110,7 +110,7 @@ describe.concurrent('commands/recipes', () => {
           "someSetting":"value" ${comment}
         }`,
         })
-        .buildAsync()
+        .build()
 
       const childProcess = execa(cliPath, ['recipes', 'vscode'], {
         cwd: builder.directory,

--- a/tests/integration/utils/site-builder.ts
+++ b/tests/integration/utils/site-builder.ts
@@ -3,11 +3,13 @@ import os from 'os'
 import path from 'path'
 import process from 'process'
 
+import slugify from '@sindresorhus/slugify'
 import execa from 'execa'
 import serializeJS from 'serialize-javascript'
 import tempDirectory from 'temp-dir'
 import tomlify from 'tomlify-j0.4'
 import { v4 as uuidv4 } from 'uuid'
+import type { TaskContext } from 'vitest'
 
 const ensureDir = (file) => mkdir(file, { recursive: true })
 
@@ -293,11 +295,13 @@ export const createSiteBuilder = ({ siteName }: { siteName: string }) => {
 }
 
 export const withSiteBuilder = async <T>(
-  siteName: string,
+  siteNameOrTaskContext: string | TaskContext,
   testHandler: (builder: SiteBuilder) => Promise<T>,
 ): Promise<T> => {
   let builder: SiteBuilder | undefined
   try {
+    const siteName =
+      typeof siteNameOrTaskContext === 'string' ? siteNameOrTaskContext : slugify(siteNameOrTaskContext.task.name)
     builder = createSiteBuilder({ siteName })
     return await testHandler(builder)
   } finally {

--- a/tests/integration/utils/site-builder.ts
+++ b/tests/integration/utils/site-builder.ts
@@ -294,10 +294,21 @@ export const createSiteBuilder = ({ siteName }: { siteName: string }) => {
   return new SiteBuilder(directory).ensureDirectoryExists(directory)
 }
 
-export const withSiteBuilder = async <T>(
+/**
+ * @deprecated use the task-based signature instead
+ */
+export function withSiteBuilder<T>(siteName: string, testHandler: (builder: SiteBuilder) => Promise<T>): Promise<T>
+/**
+ * @param taskContext used to infer directory name from test name
+ */
+export function withSiteBuilder<T>(
+  taskContext: TaskContext,
+  testHandler: (builder: SiteBuilder) => Promise<T>,
+): Promise<T>
+export async function withSiteBuilder<T>(
   siteNameOrTaskContext: string | TaskContext,
   testHandler: (builder: SiteBuilder) => Promise<T>,
-): Promise<T> => {
+): Promise<T> {
   let builder: SiteBuilder | undefined
   try {
     const siteName =

--- a/tests/unit/utils/functions/get-functions.test.js
+++ b/tests/unit/utils/functions/get-functions.test.js
@@ -11,17 +11,17 @@ describe('getFunctions', () => {
     expect(funcs).toEqual([])
   })
 
-  test('should return an empty object for a directory with no js files', async () => {
-    await withSiteBuilder('site-without-functions', async (builder) => {
-      await builder.buildAsync()
+  test('should return an empty object for a directory with no js files', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
 
       const funcs = await getFunctions(builder.directory)
       expect(funcs).toEqual([])
     })
   })
 
-  test('should return object with function details for a directory with js files', async () => {
-    await withSiteBuilder('site-without-functions', async (builder) => {
+  test('should return object with function details for a directory with js files', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withFunction({
         path: 'index.js',
         handler: '',

--- a/tests/unit/utils/functions/get-functions.test.js
+++ b/tests/unit/utils/functions/get-functions.test.js
@@ -26,7 +26,7 @@ describe('getFunctions', () => {
         path: 'index.js',
         handler: '',
       })
-      await builder.buildAsync()
+      await builder.build()
 
       const functions = path.join(builder.directory, 'functions')
       const funcs = await getFunctions(functions)
@@ -54,7 +54,7 @@ describe('getFunctions', () => {
           path: 'bar-background/bar-background.js',
           handler: '',
         })
-      await builder.buildAsync()
+      await builder.build()
 
       const functions = path.join(builder.directory, 'functions')
       const funcs = await getFunctions(functions)


### PR DESCRIPTION
Lots of our tests use `withSiteBuilder`. I noticed that on Windows, we're seeing a lot of "Resource Busy or locked" exceptions when the site builder tries to clean up the directory it created. The resources are "busy", because we re-used the same sitename between a lot of our tests, so they ended up using the same directories - possibly a race condition. I'm assuming this comes from copy&paste.

This PR adds a new signature to `withSiteBuilder` that infers the site name based on the test name. Since we always adapt test names, this should work way better! Some of the usage i've already transitioned. To encourage folks to transition the rest as well, i've marked the old signature as deprecated.