### PR TITLE
fix: support Blobs in unlinked sites

### DIFF
--- a/src/lib/blobs/blobs.ts
+++ b/src/lib/blobs/blobs.ts
@@ -28,7 +28,7 @@ const printLocalBlobsNotice = () => {
 }
 
 const startBlobsServer = async (debug: boolean, projectRoot: string, token: string) => {
-  const directory = path.resolve(projectRoot, getPathInProject(['blobs-serves']))
+  const directory = path.resolve(projectRoot, getPathInProject(['blobs-serve']))
   const server = new BlobsServer({
     debug,
     directory,

--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -157,7 +157,7 @@ export const createHandler = function (options) {
       'client-ip': [remoteAddress],
       'x-nf-client-connection-ip': [remoteAddress],
       'x-nf-account-id': [options.accountId],
-      'x-nf-site-id': [options?.siteInfo?.id] ?? 'unlinked',
+      'x-nf-site-id': [options?.siteInfo?.id ?? 'unlinked'],
       [efHeaders.Geo]: Buffer.from(JSON.stringify(geoLocation)).toString('base64'),
     }).reduce((prev, [key, value]) => ({ ...prev, [key]: Array.isArray(value) ? value : [value] }), {})
     const rawQuery = new URLSearchParams(requestQuery).toString()


### PR DESCRIPTION
#### Summary

We want to support Blobs in Netlify Dev even if the site is not linked — this was supposed to be addressed by https://github.com/netlify/cli/pull/6176, but it didn't work properly (I've added more context in a comment). This PR fixes that.

Closes https://linear.app/netlify/issue/COM-211/blobs-possibly-not-working-in-framework-generated-functions.