### PR TITLE
fix: decode identity jwt inside try block

### DIFF
--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -46,17 +46,17 @@ const buildClientContext = function (headers) {
     // }
   }
 
-  // This data is available on both the context root and under custom.netlify for retro-compatibility.
-  // In the future it will only be available in custom.netlify.
-  // @ts-expect-error
-  const user = jwtDecode(parts[1])
-
-  const netlifyContext = JSON.stringify({
-    identity: identity,
-    user: user,
-  })
-
   try {
+    // This data is available on both the context root and under custom.netlify for retro-compatibility.
+    // In the future it will only be available in custom.netlify.
+    // @ts-expect-error
+    const user = jwtDecode(parts[1])
+
+    const netlifyContext = JSON.stringify({
+      identity: identity,
+      user: user,
+    })
+
     return {
       identity: identity,
       user: user,

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -173,6 +173,10 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           },
         }).then((res) => res.json())
 
+        t.expect(response.clientContext.identity.url).toEqual(
+          'https://netlify-dev-locally-emulated-identity.netlify.com/.netlify/identity',
+        )
+
         const netlifyContext = Buffer.from(response.clientContext.custom.netlify, 'base64').toString()
         t.expect(JSON.parse(netlifyContext).identity.url).toEqual(
           'https://netlify-dev-locally-emulated-identity.netlify.com/.netlify/identity',


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Follow up to https://github.com/netlify/cli/pull/6277

The JWT decoding step can fail, and I've mistakenly took it out of the try block on the last PR. This fixes that.