### PR TITLE
refactor: type cachedConfig.env

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -26,7 +26,7 @@ import {
   exit,
   getToken,
   log,
-  netlifyCliVersion,
+  version,
   normalizeConfig,
   padLeft,
   pollForToken,
@@ -548,7 +548,7 @@ export default class BaseCommand extends Command {
       ...apiUrlOpts,
     })
     const { buildDir, config, configPath, env, repositoryRoot, siteInfo } = cachedConfig
-    env.NETLIFY_CLI_VERSION = { sources: ['internal'], value: netlifyCliVersion }
+    env.NETLIFY_CLI_VERSION = { sources: ['internal'], value: version }
     const normalizedConfig = normalizeConfig(config)
     const agent = await getAgent({
       httpProxy: flags.httpProxy,

--- a/src/commands/env/env-list.ts
+++ b/src/commands/env/env-list.ts
@@ -8,14 +8,22 @@ import logUpdate from 'log-update'
 import { chalk, error, log, logJson } from '../../utils/command-helpers.js'
 import { AVAILABLE_CONTEXTS, getEnvelopeEnv, getHumanReadableScopes } from '../../utils/env/index.js'
 import BaseCommand from '../base-command.js'
+import { EnvironmentVariables } from '../types.js'
 
 const MASK_LENGTH = 50
 const MASK = '*'.repeat(MASK_LENGTH)
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'environment' implicitly has an 'a... Remove this comment to see the full error message
-const getTable = ({ environment, hideValues, scopesColumn }) => {
+const getTable = ({
+  environment,
+  hideValues,
+  scopesColumn,
+}: {
+  environment: EnvironmentVariables
+  hideValues: boolean
+  scopesColumn: boolean
+}) => {
   const table = new AsciiTable(`Environment variables`)
-  const headings = ['Key', 'Value', scopesColumn && 'Scope'].filter(Boolean)
+  const headings = ['Key', 'Value', scopesColumn && 'Scope'].filter(Boolean) as string[]
   table.setHeading(...headings)
   table.addRowMatrix(
     Object.entries(environment).map(([key, variable]) =>
@@ -23,10 +31,8 @@ const getTable = ({ environment, hideValues, scopesColumn }) => {
         // Key
         key,
         // Value
-        // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
         hideValues ? MASK : variable.value || ' ',
         // Scope
-        // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
         scopesColumn && getHumanReadableScopes(variable.scopes),
       ].filter(Boolean),
     ),
@@ -62,7 +68,6 @@ export const envList = async (options: OptionValues, command: BaseCommand) => {
   // filter out general sources
   environment = Object.fromEntries(
     Object.entries(environment).filter(
-      // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
       ([, variable]) => variable.sources[0] !== 'general' && variable.sources[0] !== 'internal',
     ),
   )
@@ -70,7 +75,6 @@ export const envList = async (options: OptionValues, command: BaseCommand) => {
   // Return json response for piping commands
   if (options.json) {
     const envDictionary = Object.fromEntries(
-      // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
       Object.entries(environment).map(([key, variable]) => [key, variable.value]),
     )
     logJson(envDictionary)
@@ -79,7 +83,6 @@ export const envList = async (options: OptionValues, command: BaseCommand) => {
 
   if (options.plain) {
     const plaintext = Object.entries(environment)
-      // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
       .map(([key, variable]) => `${key}=${variable.value}`)
       .join('\n')
     log(plaintext)

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -24,7 +24,10 @@ type PatchedConfig = NetlifyTOML & {
   }
 }
 
-export type EnvironmentVariables = Record<string, { sources: string[], value: string; scopes?: string[] }>
+type EnvironmentVariableScope = 'builds' | 'functions' | 'runtime' | 'post_processing'
+type EnvironmentVariableSource = 'account' | 'addons' | 'configFile' | 'general' |  'internal' | 'ui'
+
+export type EnvironmentVariables = Record<string, { sources: EnvironmentVariableSource[], value: string; scopes?: EnvironmentVariableScope[] }>
 
 /**
  * The netlify object inside each command with the state

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -24,6 +24,8 @@ type PatchedConfig = NetlifyTOML & {
   }
 }
 
+export type EnvironmentVariables = Record<string, { sources: string[], value: string; scopes?: string[] }>
+
 /**
  * The netlify object inside each command with the state
  */
@@ -39,7 +41,7 @@ export type NetlifyOptions = {
   site: NetlifySite
   siteInfo: $TSFixMe
   config: PatchedConfig
-  cachedConfig: Record<string, $TSFixMe>
+  cachedConfig: Record<string, $TSFixMe> & { env: EnvironmentVariables }
   globalConfig: $TSFixMe
   state: StateConfig
 }

--- a/src/utils/command-helpers.ts
+++ b/src/utils/command-helpers.ts
@@ -48,10 +48,10 @@ export const padLeft = (str, count, filler = ' ') => str.padStart(str.length + c
 const platform = WSL ? 'wsl' : os.platform()
 const arch = os.arch() === 'ia32' ? 'x86' : os.arch()
 
-const { name, version } = await getPackageJson()
+const { name, version: packageVersion } = await getPackageJson()
 
-export const netlifyCliVersion = version
-export const USER_AGENT = `${name}/${netlifyCliVersion} ${platform}-${arch} node-${process.version}`
+export const version = packageVersion
+export const USER_AGENT = `${name}/${version} ${platform}-${arch} node-${process.version}`
 
 /** A list of base command flags that needs to be sorted down on documentation and on help pages */
 const BASE_FLAGS = new Set(['--debug', '--httpProxy', '--httpProxyCertificateFilename'])

--- a/tests/integration/commands/dev/dev.config.test.js
+++ b/tests/integration/commands/dev/dev.config.test.js
@@ -5,6 +5,7 @@ import FormData from 'form-data'
 import fetch from 'node-fetch'
 import { gte } from 'semver'
 import { describe, test } from 'vitest'
+import getPort from 'get-port'
 
 import { withDevServer } from '../../utils/dev-server.ts'
 import { withSiteBuilder } from '../../utils/site-builder.ts'
@@ -144,6 +145,8 @@ describe.concurrent('commands/dev/config', () => {
 
   test('should provide CLI version in env var', async (t) => {
     await withSiteBuilder('site-with-netlify-version-env-var', async (builder) => {
+      const port = await getPort()
+
       await builder
         .withContentFile({
           content: `
@@ -154,7 +157,7 @@ describe.concurrent('commands/dev/config', () => {
               NETLIFY_CLI_VERSION: process.env.NETLIFY_CLI_VERSION,
             }))
             res.end()
-          }).listen(1234);
+          }).listen(${port});
           `,
           path: 'devserver.mjs',
         })
@@ -163,7 +166,7 @@ describe.concurrent('commands/dev/config', () => {
             dev: {
               framework: '#custom',
               command: 'node devserver.mjs',
-              targetPort: 1234,
+              targetPort: port,
             },
           },
         })


### PR DESCRIPTION
Follow-up to https://github.com/netlify/cli/pull/6226#discussion_r1444364865. Adds typescript types to `cachedConfig.env`!