### PR TITLE
chore: convert api command to use clack

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,61 @@
+# Styleguide (WIP)
+
+This is a simple overview of different conventions we want to follow for commands in the Netlify CLI. This document will
+start simple and grow over time.
+
+## Starting your command
+
+Each command starts by using the `intro` method. You can import it like this:
+
+```js
+import { intro } from '../../utils/styles/index.js'
+
+export const basicCommand = () => {
+  intro('basic command')
+  // do stuff
+}
+```
+
+Pass the name of the command to the `intro` method.
+
+## Finishing your command
+
+Each command should end by using the `outro` method to create a clear visual end for your command. You can import it
+like this:
+
+```js
+import { intro, outro } from '../../utils/styles/index.js'
+
+export const basicCommand = () => {
+  intro('basic command')
+  // do stuff
+  outro()
+}
+```
+
+You don't need to call `outro` if your command throws an error, as `NetlifyLog.error()` automatically creates a clear
+visual end for your command already.
+
+## Other content
+
+Any content that is logged to the console using `NetlifyLog` between the `intro` and `outro` methods will be visually
+grouped together so it is clear that they all belong to the same command.
+
+## Log to the console using `NetlifyLog`
+
+Use our custom logger to log messages to the console. This will ensure that the CLI is consistent in its output and that
+we can easily change the output format in the future. To do this, import `NetlifyLog` like this:
+
+```js
+import { NetlifyLog } from '../../utils/styles/index.js'
+```
+
+### Messages
+
+For a normal message to the console use the `NetlifyLog.message()` method. This will log a clean message.
+
+### Errors
+
+If your command throws an error, it should use the `NetlifyLog.error()` method. This will ensure that the error is
+logged to the console and that the CLI exits with a non-zero exit code. When you throw an error you don't have to also
+call `outro()`.

--- a/src/commands/api/api.ts
+++ b/src/commands/api/api.ts
@@ -2,32 +2,36 @@ import AsciiTable from 'ascii-table'
 import { OptionValues } from 'commander'
 import { methods } from 'netlify'
 
-import { chalk, error, exit, log, logJson } from '../../utils/command-helpers.js'
+import { chalk, exit, logJson } from '../../utils/command-helpers.js'
+import { NetlifyLog, intro, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 export const apiCommand = async (apiMethod: string, options: OptionValues, command: BaseCommand) => {
   const { api } = command.netlify
 
   if (options.list) {
+    intro('api')
     const table = new AsciiTable(`Netlify API Methods`)
     table.setHeading('API Method', 'Docs Link')
     methods.forEach((method) => {
       const { operationId } = method
       table.addRow(operationId, `https://open-api.netlify.com/#operation/${operationId}`)
     })
-    log(table.toString())
-    log()
-    log('Above is a list of available API methods')
-    log(`To run a method use "${chalk.cyanBright('netlify api methodName')}"`)
+    NetlifyLog.message(table.toString())
+    NetlifyLog.message(
+      `Above is a list of available API methods. To run a method use "${chalk.cyanBright('netlify api methodName')}"`,
+    )
+
+    outro()
     exit()
   }
 
   if (!apiMethod) {
-    error(`You must provide an API method. Run "netlify api --list" to see available methods`)
+    NetlifyLog.error(`You must provide an API method. Run "netlify api --list" to see available methods`)
   }
 
   if (!api[apiMethod] || typeof api[apiMethod] !== 'function') {
-    error(`"${apiMethod}"" is not a valid api method. Run "netlify api --list" to see available methods`)
+    NetlifyLog.error(`"${apiMethod}"" is not a valid api method. Run "netlify api --list" to see available methods`)
   }
 
   let payload
@@ -39,8 +43,11 @@ export const apiCommand = async (apiMethod: string, options: OptionValues, comma
   try {
     const apiResponse = await api[apiMethod](payload)
     logJson(apiResponse)
-  } catch (error_) {
-    // @ts-expect-error TS(2345) FIXME: Argument of type 'unknown' is not assignable to pa... Remove this comment to see the full error message
-    error(error_)
+  } catch (error) {
+    if (error instanceof Error || typeof error === 'string') {
+      NetlifyLog.error(error)
+    } else {
+      NetlifyLog.error('An unknown error occurred')
+    }
   }
 }

--- a/src/utils/styles/index.ts
+++ b/src/utils/styles/index.ts
@@ -516,17 +516,18 @@ export const outro = (message = '') => {
 
 export type LogMessageOptions = {
   symbol?: string
+  error?: boolean
   writeStream?: NodeJS.WriteStream
 }
 export const NetlifyLog = {
   message: (
     message = '',
-    { symbol = chalk.gray(symbols.BAR), writeStream = process.stdout }: LogMessageOptions = {},
+    { error = false, symbol = chalk.gray(symbols.BAR), writeStream = process.stdout }: LogMessageOptions = {},
   ) => {
     const parts = [`${chalk.gray(symbols.BAR)}`]
     if (message) {
       const [firstLine, ...lines] = message.split('\n')
-      parts.push(`${symbol}  ${firstLine}`, ...lines.map((ln) => `${chalk.gray(symbols.BAR)}  ${ln}`))
+      parts.push(`${symbol}  ${firstLine}`, ...lines.map((ln) => (error ? ln : `${chalk.gray(symbols.BAR)}  ${ln}`)))
     }
     writeStream.write(`${parts.join('\n')}\n`)
   },
@@ -565,12 +566,18 @@ export const NetlifyLog = {
         NetlifyLog.message(`${chalk.red(`${err.name}:`)} ${err.message}\n`, {
           symbol: chalk.red(symbols.ERROR),
           writeStream: process.stderr,
+          error: true,
         })
       }
     } else {
       reportError(err, { severity: 'error' })
-      throw err
+      NetlifyLog.message(`${chalk.red(`${err.name}:`)} ${err.message}\n`, {
+        symbol: chalk.red(symbols.ERROR),
+        writeStream: process.stderr,
+        error: true,
+      })
     }
+    process.exit(1)
   },
 }
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This converts the `api` command into using the new `NetlifyLog`. It is part of a bigger piece of work that can be seen in https://github.com/netlify/cli/pull/6293. This is also the reason why this PR is merged into the branch [CP-101/design-system-clack-implementation](https://github.com/netlify/cli/tree/CP-101/design-system-clack-implementation). It's a way in which I'm trying to keep possible failing tests, but also the review work to a minimum amount of work for those who are reviewing.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->
### Before
![CleanShot 2024-01-10 at 10 30 08](https://github.com/netlify/cli/assets/30577427/89484d51-b470-4317-96cf-2104c401ebdd)

### After
![CleanShot 2024-01-10 at 10 28 07](https://github.com/netlify/cli/assets/30577427/1b774ade-02f8-4836-b057-6c39913cc928)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
