### PR TITLE
feat: update Rust template

### DIFF
--- a/src/functions-templates/rust/hello-world/src/main.rs
+++ b/src/functions-templates/rust/hello-world/src/main.rs
@@ -1,7 +1,7 @@
 use aws_lambda_events::event::apigw::{ApiGatewayProxyRequest, ApiGatewayProxyResponse};
 use aws_lambda_events::encodings::Body;
 use http::header::HeaderMap;
-use lambda_runtime::{handler_fn, Context, Error};
+use lambda_runtime::{service_fn, Error, LambdaEvent};
 use log::LevelFilter;
 use simple_logger::SimpleLogger;
 
@@ -9,13 +9,13 @@ use simple_logger::SimpleLogger;
 async fn main() -> Result<(), Error> {
     SimpleLogger::new().with_utc_timestamps().with_level(LevelFilter::Info).init().unwrap();
 
-    let func = handler_fn(my_handler);
+    let func = service_fn(my_handler);
     lambda_runtime::run(func).await?;
     Ok(())
 }
 
-pub(crate) async fn my_handler(event: ApiGatewayProxyRequest, _ctx: Context) -> Result<ApiGatewayProxyResponse, Error> {
-    let path = event.path.unwrap();
+pub(crate) async fn my_handler(event: LambdaEvent<ApiGatewayProxyRequest>) -> Result<ApiGatewayProxyResponse, Error> {
+    let path = event.payload.path.unwrap();
 
     let resp = ApiGatewayProxyResponse {
         status_code: 200,


### PR DESCRIPTION
The `handler_fn` function was deprecated in 0.5.0 of the lambda_runtime in favour of the `service_fn`.

Although removed from the function signature, the `Context` object is still available on the `Event` as a property (`event.context`)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
