### PR TITLE
feat: show Rust as option in functions:create

### DIFF
--- a/src/commands/functions/functions-create.ts
+++ b/src/commands/functions/functions-create.ts
@@ -31,8 +31,6 @@ const require = createRequire(import.meta.url)
 
 const templatesDir = path.resolve(dirname(fileURLToPath(import.meta.url)), '../../functions-templates')
 
-const showRustTemplates = process.env.NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE === 'true'
-
 /**
  * Ensure that there's a sub-directory in `src/functions-templates` named after
  * each `value` property in this list.
@@ -41,7 +39,7 @@ const languages = [
   { name: 'JavaScript', value: 'javascript' },
   { name: 'TypeScript', value: 'typescript' },
   { name: 'Go', value: 'go' },
-  showRustTemplates && { name: 'Rust', value: 'rust' },
+  { name: 'Rust', value: 'rust' },
 ]
 
 /**
@@ -181,12 +179,11 @@ const pickTemplate = async function ({ language: languageFromFlag }, funcType) {
   if (language === undefined) {
     const langs =
       funcType === 'edge'
-        ? // @ts-expect-error TS(2339) FIXME: Property 'value' does not exist on type 'false | {... Remove this comment to see the full error message
+        ?
           languages.filter((lang) => lang.value === 'javascript' || lang.value === 'typescript')
         : languages.filter(Boolean)
 
     const { language: languageFromPrompt } = await inquirer.prompt({
-      // @ts-expect-error
       choices: langs,
       message: 'Select the language of your function',
       name: 'language',
@@ -239,7 +236,7 @@ const DEFAULT_PRIORITY = 999
 const selectTypeOfFunc = async () => {
   const functionTypes = [
     { name: 'Edge function (Deno)', value: 'edge' },
-    { name: 'Serverless function (Node/Go)', value: 'serverless' },
+    { name: 'Serverless function (Node/Go/Rust)', value: 'serverless' },
   ]
 
   const { functionType } = await inquirer.prompt([
@@ -561,6 +558,15 @@ const scaffoldFromTemplate = async function (command, options, argumentName, fun
 
     await installAddons(command, addons, path.resolve(functionPath))
     await handleOnComplete({ command, onComplete })
+
+    log()
+    log(chalk.greenBright(`Function created!`))
+    
+    if (lang == 'rust') {
+      log(
+        chalk.green(`Please note that Rust functions require setting the NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE environment variable to 'true' on your site.`)
+      )
+    }
   }
 }
 

--- a/src/commands/functions/functions-create.ts
+++ b/src/commands/functions/functions-create.ts
@@ -179,8 +179,7 @@ const pickTemplate = async function ({ language: languageFromFlag }, funcType) {
   if (language === undefined) {
     const langs =
       funcType === 'edge'
-        ?
-          languages.filter((lang) => lang.value === 'javascript' || lang.value === 'typescript')
+        ? languages.filter((lang) => lang.value === 'javascript' || lang.value === 'typescript')
         : languages.filter(Boolean)
 
     const { language: languageFromPrompt } = await inquirer.prompt({
@@ -561,10 +560,12 @@ const scaffoldFromTemplate = async function (command, options, argumentName, fun
 
     log()
     log(chalk.greenBright(`Function created!`))
-    
+
     if (lang == 'rust') {
       log(
-        chalk.green(`Please note that Rust functions require setting the NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE environment variable to 'true' on your site.`)
+        chalk.green(
+          `Please note that Rust functions require setting the NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE environment variable to 'true' on your site.`,
+        ),
       )
     }
   }


### PR DESCRIPTION
#### Summary

Fixes CT-497

We've had Rust support for a while but were not showing it as an option in the `functions:create` list of 'hello world' templates unless the `NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE` environment variable was set on the site.

These changes:
- Show Rust in the list of languages without consideration for the `NETLIFY_EXPERIMENTAL_BUILD_RUST_SOURCE` environment variable
- Update the log output to tell the user to set this environment variable should they decide to use Rust

<img width="1401" alt="CleanShot 2024-01-12 at 12 44 21@2x" src="https://github.com/netlify/cli/assets/5655473/ac655a1e-fc40-44aa-b307-fb2b691af557">


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
