### PR TITLE
chore: convert login command

### DIFF
--- a/src/commands/addons/addons-auth.ts
+++ b/src/commands/addons/addons-auth.ts
@@ -22,7 +22,7 @@ export const addonsAuth = async (addonName: string, options: OptionValues, comma
   log()
   log(addon.auth_url)
   log()
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: any; }' is not assignable... Remove this comment to see the full error message
+
   await openBrowser({ url: addon.auth_url })
   exit()
 }

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -37,6 +37,7 @@ import getGlobalConfig from '../utils/get-global-config.js'
 import { getSiteByName } from '../utils/get-site.js'
 import openBrowser from '../utils/open-browser.js'
 import StateConfig from '../utils/state-config.js'
+import { NetlifyLog, outro } from '../utils/styles/index.js'
 import { identify, reportError, track } from '../utils/telemetry/index.js'
 
 import { type NetlifyOptions } from './types.js'
@@ -393,7 +394,7 @@ export default class BaseCommand extends Command {
 
   async expensivelyAuthenticate() {
     const webUI = process.env.NETLIFY_WEB_UI || 'https://app.netlify.com'
-    log(`Logging into your Netlify account...`)
+    NetlifyLog.step('Logging into your Netlify account...')
 
     // Create ticket for auth
     const ticket = await this.netlify.api.createTicket({
@@ -403,8 +404,7 @@ export default class BaseCommand extends Command {
     // Open browser for authentication
     const authLink = `${webUI}/authorize?response_type=ticket&ticket=${ticket.id}`
 
-    log(`Opening ${authLink}`)
-    // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: string; }' is not assigna... Remove this comment to see the full error message
+    NetlifyLog.step(`Opening ${authLink}`)
     await openBrowser({ url: authLink })
 
     const accessToken = await pollForToken({
@@ -440,14 +440,9 @@ export default class BaseCommand extends Command {
       email,
     })
 
-    // Log success
-    log()
-    log(`${chalk.greenBright('You are now logged into your Netlify account!')}`)
-    log()
-    log(`Run ${chalk.cyanBright('netlify status')} for account details`)
-    log()
-    log(`To see all available commands run: ${chalk.cyanBright('netlify help')}`)
-    log()
+    NetlifyLog.success(`${chalk.greenBright('You are now logged into your Netlify account!')}`)
+    NetlifyLog.info(`Run ${chalk.cyanBright('netlify status')} for account details`)
+    outro({ message: `To see all available commands run: ${chalk.cyanBright('netlify help')}` })
     return accessToken
   }
 

--- a/src/commands/build/build.ts
+++ b/src/commands/build/build.ts
@@ -37,7 +37,6 @@ export const build = async (options: OptionValues, command: BaseCommand) => {
   const { cachedConfig, siteInfo } = command.netlify
   command.setAnalyticsPayload({ dry: options.dry })
   // Retrieve Netlify Build options
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [token] = await getToken()
   const settings = await detectFrameworkSettings(command, 'build')
 

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -366,7 +366,7 @@ const uploadDeployBlobs = async ({
     phase: 'start',
   })
 
-  const [token] = await getToken(false)
+  const [token] = await getToken()
 
   const { success } = await runCoreSteps(['blobs_upload'], {
     ...options,
@@ -535,7 +535,6 @@ const handleBuild = async ({ cachedConfig, currentDir, deployHandler, options, p
   if (!options.build) {
     return {}
   }
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [token] = await getToken()
   const resolvedOptions = await getBuildOptions({
     cachedConfig,
@@ -869,7 +868,7 @@ export const deploy = async (options: OptionValues, command: BaseCommand) => {
   if (options.open) {
     // @ts-expect-error TS(2339) FIXME: Property 'siteUrl' does not exist on type '{}'.
     const urlToOpen = deployToProduction ? results.siteUrl : results.deployUrl
-    // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: any; }' is not assignable... Remove this comment to see the full error message
+
     await openBrowser({ url: urlToOpen })
     exit()
   }

--- a/src/commands/integration/deploy.ts
+++ b/src/commands/integration/deploy.ts
@@ -396,7 +396,6 @@ export const getConfiguration = (workingDir) => {
 export const deploy = async (options: OptionValues, command: BaseCommand) => {
   const { api, cachedConfig, site, siteInfo } = command.netlify
   const { id: siteId } = site
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [token] = await getToken()
   const workingDir = resolve(command.workingDir)
   const buildOptions = await getBuildOptions({

--- a/src/commands/login/login.ts
+++ b/src/commands/login/login.ts
@@ -1,10 +1,10 @@
 import { OptionValues } from 'commander'
 
-import { chalk, exit, getToken, log } from '../../utils/command-helpers.js'
+import { chalk, getToken } from '../../utils/command-helpers.js'
+import { NetlifyLog, intro, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
-// @ts-expect-error TS(7006) FIXME: Parameter 'location' implicitly has an 'any' type.
-const msg = function (location) {
+const msg = function (location: 'env' | 'flag' | 'config') {
   switch (location) {
     case 'env':
       return 'via process.env.NETLIFY_AUTH_TOKEN set in your terminal session'
@@ -18,21 +18,16 @@ const msg = function (location) {
 }
 
 export const login = async (options: OptionValues, command: BaseCommand) => {
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
+  intro('login')
   const [accessToken, location] = await getToken()
 
   command.setAnalyticsPayload({ new: options.new })
 
   if (accessToken && !options.new) {
-    log(`Already logged in ${msg(location)}`)
-    log()
-    log(`Run ${chalk.cyanBright('netlify status')} for account details`)
-    log()
-    log(`or run ${chalk.cyanBright('netlify switch')} to switch accounts`)
-    log()
-    log(`To see all available commands run: ${chalk.cyanBright('netlify help')}`)
-    log()
-    return exit()
+    NetlifyLog.success(`Already logged in ${msg(location)}`)
+    NetlifyLog.message(`Run ${chalk.cyanBright('netlify status')} for account details`)
+    NetlifyLog.message(`or run ${chalk.cyanBright('netlify switch')} to switch accounts`)
+    outro({ message: `To see all available commands run: ${chalk.cyanBright('netlify help')}`, exit: true })
   }
 
   await command.expensivelyAuthenticate()

--- a/src/commands/logout/logout.ts
+++ b/src/commands/logout/logout.ts
@@ -5,7 +5,6 @@ import { track } from '../../utils/telemetry/index.js'
 import BaseCommand from '../base-command.js'
 
 export const logout = async (options: OptionValues, command: BaseCommand) => {
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [accessToken, location] = await getToken()
 
   if (!accessToken) {

--- a/src/commands/open/open-admin.ts
+++ b/src/commands/open/open-admin.ts
@@ -12,7 +12,6 @@ export const openAdmin = async (options: OptionValues, command: BaseCommand) => 
   log(`Opening "${siteInfo.name}" site admin UI:`)
   log(`> ${siteInfo.admin_url}`)
 
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: any; }' is not assignable... Remove this comment to see the full error message
   await openBrowser({ url: siteInfo.admin_url })
   exit()
 }

--- a/src/commands/open/open-site.ts
+++ b/src/commands/open/open-site.ts
@@ -13,7 +13,6 @@ export const openSite = async (options: OptionValues, command: BaseCommand) => {
   log(`Opening "${siteInfo.name}" site url:`)
   log(`> ${url}`)
 
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: any; }' is not assignable... Remove this comment to see the full error message
   await openBrowser({ url })
   exit()
 }

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -8,7 +8,6 @@ import BaseCommand from '../base-command.js'
 export const status = async (options: OptionValues, command: BaseCommand) => {
   const { api, globalConfig, site, siteInfo } = command.netlify
   const current = globalConfig.get('userId')
-  // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
   const [accessToken] = await getToken()
 
   if (!accessToken) {

--- a/src/utils/gh-auth.ts
+++ b/src/utils/gh-auth.ts
@@ -81,7 +81,6 @@ export const authWithNetlify = async () => {
   })
   const url = `${webUI}/cli?${urlParams.toString()}`
 
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ url: string; }' is not assigna... Remove this comment to see the full error message
   await openBrowser({ url })
 
   return deferredPromise

--- a/src/utils/open-browser.ts
+++ b/src/utils/open-browser.ts
@@ -4,26 +4,22 @@ import process from 'process'
 import open from 'better-opn'
 import isDockerContainer from 'is-docker'
 
-import { chalk, log } from './command-helpers.js'
+import { chalk } from './command-helpers.js'
+import { NetlifyLog } from './styles/index.js'
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'message' implicitly has an 'any' ... Remove this comment to see the full error message
-const unableToOpenBrowserMessage = function ({ message, url }) {
-  log('---------------------------')
-  log(chalk.redBright(`Error: Unable to open browser automatically: ${message}`))
-  log(chalk.cyan('Please open your browser and open the URL below:'))
-  log(chalk.bold(url))
-  log('---------------------------')
+const unableToOpenBrowserMessage = function ({ message, url }: { message: string; url: string }) {
+  NetlifyLog.error(chalk.redBright(`Error: Unable to open browser automatically: ${message}`), { exit: false })
+  NetlifyLog.message(chalk.cyan('Please open your browser and open the URL below:'))
+  NetlifyLog.message(chalk.bold(url))
 }
 
-/**
- * Opens a browser and logs a message if it is not possible
- * @param {object} config
- * @param {string} config.url The url to open
- * @param {boolean} [config.silentBrowserNoneError]
- * @returns {Promise<void>}
- */
-// @ts-expect-error TS(7031) FIXME: Binding element 'silentBrowserNoneError' implicitl... Remove this comment to see the full error message
-const openBrowser = async function ({ silentBrowserNoneError, url }) {
+const openBrowser = async function ({
+  silentBrowserNoneError,
+  url,
+}: {
+  silentBrowserNoneError?: boolean
+  url: string
+}) {
   if (isDockerContainer()) {
     unableToOpenBrowserMessage({ url, message: 'Running inside a docker container' })
     return


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes: https://linear.app/netlify/issue/CT-478/convert-login-command-to-clack

This converts the `login` command into using the new NetlifyLog. It is part of a bigger piece of work that can be seen in https://github.com/netlify/cli/pull/6293. This is also the reason why this PR is merged into the branch [CP-101/design-system-clack-implementation](https://github.com/netlify/cli/tree/CP-101/design-system-clack-implementation). It's a way in which I'm trying to keep possible failing tests, but also the review work to a minimum amount of work for those who are reviewing.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
