### PR TITLE
chore: convert logout command

### DIFF
--- a/src/commands/logout/logout.ts
+++ b/src/commands/logout/logout.ts
@@ -1,17 +1,17 @@
 import { OptionValues } from 'commander'
 
-import { exit, getToken, log } from '../../utils/command-helpers.js'
+import { getToken } from '../../utils/command-helpers.js'
+import { NetlifyLog, intro, outro } from '../../utils/styles/index.js'
 import { track } from '../../utils/telemetry/index.js'
 import BaseCommand from '../base-command.js'
 
 export const logout = async (options: OptionValues, command: BaseCommand) => {
+  intro('logout')
   const [accessToken, location] = await getToken()
 
   if (!accessToken) {
-    log(`Already logged out`)
-    log()
-    log('To login run "netlify login"')
-    exit()
+    NetlifyLog.info(`You are already logged out`)
+    outro({ message: 'To login run "netlify login"', exit: true })
   }
 
   await track('user_logout')
@@ -20,12 +20,10 @@ export const logout = async (options: OptionValues, command: BaseCommand) => {
   command.netlify.globalConfig.set('userId', null)
 
   if (location === 'env') {
-    log('The "process.env.NETLIFY_AUTH_TOKEN" is still set in your terminal session')
-    log()
-    log('To logout completely, unset the environment variable')
-    log()
-    exit()
+    NetlifyLog.warn('The "process.env.NETLIFY_AUTH_TOKEN" is still set in your terminal session')
+    outro({ message: 'To logout completely, unset the environment variable', exit: true })
   }
 
-  log(`Logging you out of Netlify. Come back soon!`)
+  NetlifyLog.success('Logged you out of Netlify.')
+  outro({ message: 'Come back soon!' })
 }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes: https://linear.app/netlify/issue/CT-501/convert-logout-command-to-clack

This converts the `logout` command into using the new NetlifyLog. It is part of a bigger piece of work that can be seen in https://github.com/netlify/cli/pull/6293. This is also the reason why this PR is merged into the branch [CP-101/design-system-clack-implementation](https://github.com/netlify/cli/tree/CP-101/design-system-clack-implementation). It's a way in which I'm trying to keep possible failing tests, but also the review work to a minimum amount of work for those who are reviewing.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
