### PR TITLE
chore: convert log command

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -104,3 +104,26 @@ export const basicCommand = async () => {
   outro()
 }
 ```
+
+## Asking for user input
+
+There are several helpers available for asking the user for input. They are all available in the
+`'./utils/styles/index.js'` file.
+
+### select
+
+The `select` method allows you to ask the user to select an option from a list of options. You can pass a list of
+options to the `select` method and it will return the selected option.
+
+```js
+import { select } from '../../utils/styles/index.js'
+
+const result = await select({
+  message: 'Select an option',
+  maxItems: 7,
+  options: list.map((thing) => ({
+    label: thing.name,
+    value: thing.id,
+  })),
+})
+```

--- a/src/commands/logs/functions.ts
+++ b/src/commands/logs/functions.ts
@@ -100,7 +100,6 @@ export const logsFunction = async (functionName: string | undefined, options: Op
   })
 
   process.on('SIGINT', () => {
-    outro({ message: 'Closing connection' })
-    process.exit()
+    outro({ message: 'Closing connection', exit: true })
   })
 }

--- a/src/commands/open/open-admin.ts
+++ b/src/commands/open/open-admin.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
-import { exit, log } from '../../utils/command-helpers.js'
 import openBrowser from '../../utils/open-browser.js'
+import { NetlifyLog, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 export const openAdmin = async (options: OptionValues, command: BaseCommand) => {
@@ -9,9 +9,9 @@ export const openAdmin = async (options: OptionValues, command: BaseCommand) => 
 
   await command.authenticate()
 
-  log(`Opening "${siteInfo.name}" site admin UI:`)
-  log(`> ${siteInfo.admin_url}`)
+  NetlifyLog.info(`Opening "${siteInfo.name}" site admin UI:`)
+  NetlifyLog.info(`> ${siteInfo.admin_url}`)
 
   await openBrowser({ url: siteInfo.admin_url })
-  exit()
+  outro({ exit: true })
 }

--- a/src/commands/open/open-site.ts
+++ b/src/commands/open/open-site.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
-import { exit, log } from '../../utils/command-helpers.js'
 import openBrowser from '../../utils/open-browser.js'
+import { NetlifyLog, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 export const openSite = async (options: OptionValues, command: BaseCommand) => {
@@ -10,9 +10,9 @@ export const openSite = async (options: OptionValues, command: BaseCommand) => {
   await command.authenticate()
 
   const url = siteInfo.ssl_url || siteInfo.url
-  log(`Opening "${siteInfo.name}" site url:`)
-  log(`> ${url}`)
+  NetlifyLog.info(`Opening "${siteInfo.name}" site url:`)
+  NetlifyLog.info(`> ${url}`)
 
   await openBrowser({ url })
-  exit()
+  outro({ exit: true })
 }

--- a/src/commands/open/open.ts
+++ b/src/commands/open/open.ts
@@ -1,14 +1,15 @@
 import { OptionValues } from 'commander'
 
-import { log } from '../../utils/command-helpers.js'
+import { NetlifyLog, intro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 import { openAdmin } from './open-admin.js'
 import { openSite } from './open-site.js'
 
 export const open = async (options: OptionValues, command: BaseCommand) => {
+  intro('open')
   if (!options.site || !options.admin) {
-    log(command.helpInformation())
+    NetlifyLog.info(command.helpInformation())
   }
 
   if (options.site) {

--- a/src/utils/styles/index.ts
+++ b/src/utils/styles/index.ts
@@ -528,15 +528,21 @@ export type LogMessageOptions = {
   symbol?: string
   error?: boolean
   writeStream?: NodeJS.WriteStream
+  noSpacing?: boolean
 }
 export const NetlifyLog = {
   message: (
     message = '',
-    { error = false, symbol = chalk.gray(symbols.BAR), writeStream = process.stdout }: LogMessageOptions = {},
+    {
+      error = false,
+      noSpacing,
+      symbol = chalk.gray(symbols.BAR),
+      writeStream = process.stdout,
+    }: LogMessageOptions = {},
   ) => {
     if (jsonOnly()) return
 
-    const parts = [`${chalk.gray(symbols.BAR)}`]
+    const parts = noSpacing ? [] : [`${chalk.gray(symbols.BAR)}`]
     if (message) {
       const [firstLine, ...lines] = message.split('\n')
       parts.push(


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes: https://linear.app/netlify/issue/CT-479/convert-logs-command-to-clack

This converts the `logs` command into using the new NetlifyLog. It is part of a bigger piece of work that can be seen in https://github.com/netlify/cli/pull/6293. This is also the reason why this PR is merged into the branch [CP-101/design-system-clack-implementation](https://github.com/netlify/cli/tree/CP-101/design-system-clack-implementation). It's a way in which I'm trying to keep possible failing tests, but also the review work to a minimum amount of work for those who are reviewing.
![CleanShot 2024-01-17 at 16 39 44](https://github.com/netlify/cli/assets/30577427/8100c958-fe59-4446-9530-7299be2bda7a)

https://github.com/netlify/cli/pull/6325 was also merged into this branch which converts the open command to clack

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
