### PR TITLE
chore: convert open command

### DIFF
--- a/src/commands/open/open-admin.ts
+++ b/src/commands/open/open-admin.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
-import { exit, log } from '../../utils/command-helpers.js'
 import openBrowser from '../../utils/open-browser.js'
+import { NetlifyLog, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 export const openAdmin = async (options: OptionValues, command: BaseCommand) => {
@@ -9,9 +9,9 @@ export const openAdmin = async (options: OptionValues, command: BaseCommand) => 
 
   await command.authenticate()
 
-  log(`Opening "${siteInfo.name}" site admin UI:`)
-  log(`> ${siteInfo.admin_url}`)
+  NetlifyLog.info(`Opening "${siteInfo.name}" site admin UI:`)
+  NetlifyLog.info(`> ${siteInfo.admin_url}`)
 
   await openBrowser({ url: siteInfo.admin_url })
-  exit()
+  outro({ exit: true })
 }

--- a/src/commands/open/open-site.ts
+++ b/src/commands/open/open-site.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
-import { exit, log } from '../../utils/command-helpers.js'
 import openBrowser from '../../utils/open-browser.js'
+import { NetlifyLog, outro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 export const openSite = async (options: OptionValues, command: BaseCommand) => {
@@ -10,9 +10,9 @@ export const openSite = async (options: OptionValues, command: BaseCommand) => {
   await command.authenticate()
 
   const url = siteInfo.ssl_url || siteInfo.url
-  log(`Opening "${siteInfo.name}" site url:`)
-  log(`> ${url}`)
+  NetlifyLog.info(`Opening "${siteInfo.name}" site url:`)
+  NetlifyLog.info(`> ${url}`)
 
   await openBrowser({ url })
-  exit()
+  outro({ exit: true })
 }

--- a/src/commands/open/open.ts
+++ b/src/commands/open/open.ts
@@ -1,14 +1,15 @@
 import { OptionValues } from 'commander'
 
-import { log } from '../../utils/command-helpers.js'
+import { NetlifyLog, intro } from '../../utils/styles/index.js'
 import BaseCommand from '../base-command.js'
 
 import { openAdmin } from './open-admin.js'
 import { openSite } from './open-site.js'
 
 export const open = async (options: OptionValues, command: BaseCommand) => {
+  intro('open')
   if (!options.site || !options.admin) {
-    log(command.helpInformation())
+    NetlifyLog.info(command.helpInformation())
   }
 
   if (options.site) {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://linear.app/netlify/issue/CT-480/convert-open-command-to-clack

This converts the`open` command into using the new NetlifyLog. It is part of a bigger piece of work that can be seen in https://github.com/netlify/cli/pull/6293. This is also the reason why this PR is merged into the branch [CP-101/design-system-clack-implementation](https://github.com/netlify/cli/tree/CP-101/design-system-clack-implementation). It's a way in which I'm trying to keep possible failing tests, but also the review work to a minimum amount of work for those who are reviewing.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
