### PR TITLE
feat: expose site feature flags to EF registry

### DIFF
--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -7,6 +7,7 @@ import * as bundler from '@netlify/edge-bundler'
 import getAvailablePort from 'get-port'
 
 import { NETLIFYDEVERR, chalk, error as printError } from '../../utils/command-helpers.js'
+import { getFeatureFlagsFromSiteInfo } from '../../utils/feature-flags.js'
 import { getGeoLocation } from '../geo-location.js'
 import { getPathInProject } from '../settings.js'
 import { startSpinner, stopSpinner } from '../spinner.js'
@@ -136,11 +137,9 @@ export const initializeProxy = async ({
 }) => {
   const userFunctionsPath = config.build.edge_functions
   const isolatePort = await getAvailablePort()
-  const buildFeatureFlags = {
-    edge_functions_npm_modules: true,
-  }
   const runtimeFeatureFlags = ['edge_functions_bootstrap_failure_mode', 'edge_functions_bootstrap_populate_environment']
   const protocol = settings.https ? 'https' : 'http'
+  const buildFeatureFlags = { ...getFeatureFlagsFromSiteInfo(siteInfo), edge_functions_npm_modules: true }
 
   // Initializes the server, bootstrapping the Deno CLI and downloading it from
   // the network if needed. We don't want to wait for that to be completed, or
@@ -268,6 +267,7 @@ const prepareServer = async ({
       debug,
       directories: [directory].filter(Boolean),
       env: configEnv,
+      featureFlags,
       getUpdatedConfig,
       importMapFromTOML: config.functions['*'].deno_import_map,
       projectDir,

--- a/src/lib/functions/runtimes/js/index.ts
+++ b/src/lib/functions/runtimes/js/index.ts
@@ -60,7 +60,7 @@ const workerURL = new URL('worker.js', import.meta.url)
 
 // @ts-expect-error TS(7031) FIXME: Binding element 'context' implicitly has an 'any' ... Remove this comment to see the full error message
 export const invokeFunction = async ({ context, environment, event, func, timeout }) => {
-  if (func.buildData.runtimeAPIVersion !== 2) {
+  if (func.buildData?.runtimeAPIVersion !== 2) {
     return await invokeFunctionDirectly({ context, event, func, timeout })
   }
 

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -19,8 +19,10 @@ export const isFeatureFlagEnabled = (flagName: string, siteInfo): boolean =>
  */
 export const getFeatureFlagsFromSiteInfo = (siteInfo: {
   feature_flags?: Record<string, boolean | string | number>
-}): Record<string, boolean | string | number> => ({
+}): FeatureFlags => ({
   ...(siteInfo.feature_flags || {}),
   // see https://github.com/netlify/pod-dev-foundations/issues/581#issuecomment-1731022753
   zisi_golang_use_al2: isFeatureFlagEnabled('cli_golang_use_al2', siteInfo),
 })
+
+export type FeatureFlags = Record<string, boolean | string | number>


### PR DESCRIPTION
#### Summary

Feature flags coming from the site info are not being surfaced to the edge functions registry. This PR fixes that.