### PR TITLE
Fix no git path for init command

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -50,15 +50,17 @@ const logExistingAndExit = ({ siteInfo }) => {
  */
 // @ts-expect-error TS(7031) FIXME: Binding element 'command' implicitly has an 'any' ... Remove this comment to see the full error message
 const createNewSiteAndExit = async ({ command, state }) => {
-  const siteInfo = await sitesCreate({}, command)
+  const siteInfo = await sitesCreate({ isChildCommand: true }, command)
 
   // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   NetlifyLog.message(`"${siteInfo.name}" site was created`)
-  NetlifyLog.info(`To deploy to this site. Run your site build and then ${chalk.cyanBright.bold('netlify deploy')}`)
 
   persistState({ state, siteInfo })
 
-  outro({ exit: true })
+  outro({
+    exit: true,
+    message: `To deploy to this site. Run your site build and then ${chalk.cyanBright.bold('netlify deploy')}`,
+  })
 }
 
 const logGitSetupInstructionsAndExit = () => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Ensures clack intro is not repeated during the `init` command, when the site is created when no git remote is found

Before:
![image](https://github.com/netlify/cli/assets/15314252/1340999f-9d70-452b-a09c-cc7faa97de0c)

After:
![image](https://github.com/netlify/cli/assets/15314252/9bb9033e-c7cb-4221-b74c-9fd85d0f8b92)

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
