### PR TITLE
fix: do not retry uploads on 4xx errors

### DIFF
--- a/src/utils/deploy/upload-files.ts
+++ b/src/utils/deploy/upload-files.ts
@@ -100,9 +100,15 @@ const retryUpload = (uploadFn, maxRetry) =>
       } catch (error) {
         lastError = error
 
+        // We don't need to retry for 400 or 422 errors
+        // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
+        if (error.status === 400 || error.status === 422) {
+          return reject(error)
+        }
+
         // observed errors: 408, 401 (4** swallowed), 502
         // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-        if (error.status >= 400 || error.name === 'FetchError') {
+        if (error.status > 400 || error.name === 'FetchError') {
           fibonacciBackoff.backoff()
           return
         }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

When uploading a function, a 4xx error code means there's something wrong in the function itself and cannot be uploaded. Currently we keep retrying in all cases, but in some we shouldn't as it won't make a difference. This makes it so we retry only if it's not a 400 or 422.

Part of https://github.com/netlify/functions-origin/issues/358
This is an updated version of https://github.com/netlify/cli/pull/5963

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
