### PR TITLE
fix: fix use headers/redirects that are set via the onPreDev of a plugin

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -1,6 +1,8 @@
 import process from 'process'
 
 import { OptionValues, Option } from 'commander'
+// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module '@net... Remove this comment to see the full error message
+import { applyMutations } from '@netlify/config'
 
 import { BLOBS_CONTEXT_VARIABLE, encodeBlobsContext, getBlobsContext } from '../../lib/blobs/blobs.js'
 import { promptEditorHelper } from '../../lib/edge-functions/editor-helper.js'
@@ -153,7 +155,7 @@ export const dev = async (options: OptionValues, command: BaseCommand) => {
 
   log(`${NETLIFYDEVWARN} Setting up local development server`)
 
-  const { configPath: configPathOverride } = await runDevTimeline({
+  const { configMutations, configPath: configPathOverride } = await runDevTimeline({
     command,
     options,
     settings,
@@ -163,10 +165,12 @@ export const dev = async (options: OptionValues, command: BaseCommand) => {
     },
   })
 
+  const mutatedConfig = applyMutations(config, configMutations)
+
   const functionsRegistry = await startFunctionsServer({
     blobsContext,
     command,
-    config,
+    config: mutatedConfig,
     debug: options.debug,
     settings,
     site,
@@ -205,7 +209,7 @@ export const dev = async (options: OptionValues, command: BaseCommand) => {
   await startProxyServer({
     addonsUrls,
     blobsContext,
-    config,
+    config: mutatedConfig,
     configPath: configPathOverride,
     debug: options.debug,
     projectDir: command.workingDir,

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -27,11 +27,12 @@ const getHeaderValues = function ({ values }) {
 }
 
 // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
-export const parseHeaders = async function ({ configPath, headersFiles }): Promise<Header[]> {
+export const parseHeaders = async function ({ config, configPath, headersFiles }): Promise<Header[]> {
   const { errors, headers } = await parseAllHeaders({
     headersFiles,
     netlifyConfigPath: configPath,
     minimal: false,
+    configHeaders: config?.headers || [],
   })
   handleHeadersErrors(errors)
   return headers

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -875,6 +875,7 @@ export const startProxy = async function ({
   })
 
   const rewriter = await createRewriter({
+    config,
     distDir: settings.dist,
     projectDir,
     jwtSecret: settings.jwtSecret,

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -424,7 +424,7 @@ const reqToURL = function (req, pathname) {
 const MILLISEC_TO_SEC = 1e3
 
 // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
-const initializeProxy = async function ({ configPath, distDir, env, host, imageProxy, port, projectDir, siteInfo }) {
+const initializeProxy = async function ({ configPath, distDir, env, host, imageProxy, port, projectDir, siteInfo, config }) {
   const proxy = httpProxy.createProxyServer({
     selfHandleResponse: true,
     target: {
@@ -434,7 +434,7 @@ const initializeProxy = async function ({ configPath, distDir, env, host, imageP
   })
   const headersFiles = [...new Set([path.resolve(projectDir, '_headers'), path.resolve(distDir, '_headers')])]
 
-  let headers = await parseHeaders({ headersFiles, configPath })
+  let headers = await parseHeaders({ headersFiles, configPath, config })
 
   const watchedHeadersFiles = configPath === undefined ? headersFiles : [...headersFiles, configPath]
   onChanges(watchedHeadersFiles, async () => {
@@ -443,7 +443,7 @@ const initializeProxy = async function ({ configPath, distDir, env, host, imageP
       `${NETLIFYDEVLOG} Reloading headers files from`,
       existingHeadersFiles.map((headerFile) => path.relative(projectDir, headerFile)),
     )
-    headers = await parseHeaders({ headersFiles, configPath })
+    headers = await parseHeaders({ headersFiles, configPath, config })
   })
 
   // @ts-expect-error TS(2339) FIXME: Property 'before' does not exist on type 'Server'.
@@ -853,6 +853,7 @@ export const startProxy = async function ({
     configPath,
     siteInfo,
     imageProxy,
+    config,
   })
 
   const rewriter = await createRewriter({

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -423,16 +423,24 @@ const reqToURL = function (req, pathname) {
 
 const MILLISEC_TO_SEC = 1e3
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
 const initializeProxy = async function ({
+  // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'any... Remove this comment to see the full error message
   configPath,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'distDir' implicitly has an 'any... Remove this comment to see the full error message
   distDir,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'env' implicitly has an 'any... Remove this comment to see the full error message
   env,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'host' implicitly has an 'any... Remove this comment to see the full error message
   host,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'imageProxy' implicitly has an 'any... Remove this comment to see the full error message
   imageProxy,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'port' implicitly has an 'any... Remove this comment to see the full error message
   port,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'projectDir' implicitly has an 'any... Remove this comment to see the full error message
   projectDir,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'siteInfo' implicitly has an 'any... Remove this comment to see the full error message
   siteInfo,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any... Remove this comment to see the full error message
   config,
 }) {
   const proxy = httpProxy.createProxyServer({

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -424,7 +424,17 @@ const reqToURL = function (req, pathname) {
 const MILLISEC_TO_SEC = 1e3
 
 // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
-const initializeProxy = async function ({ configPath, distDir, env, host, imageProxy, port, projectDir, siteInfo, config }) {
+const initializeProxy = async function ({
+  configPath,
+  distDir,
+  env,
+  host,
+  imageProxy,
+  port,
+  projectDir,
+  siteInfo,
+  config,
+}) {
   const proxy = httpProxy.createProxyServer({
     selfHandleResponse: true,
     target: {

--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -5,12 +5,12 @@ import { NETLIFYDEVERR, log } from './command-helpers.js'
 // Parse, normalize and validate all redirects from `_redirects` files
 // and `netlify.toml`
 // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
-export const parseRedirects = async function ({ configPath, redirectsFiles }) {
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ redirectsFiles: any; netlifyCo... Remove this comment to see the full error message
+export const parseRedirects = async function ({ config, configPath, redirectsFiles }) {
   const { errors, redirects } = await parseAllRedirects({
     redirectsFiles,
     netlifyConfigPath: configPath,
     minimal: false,
+    configRedirects: config?.redirects || [],
   })
   handleRedirectParsingErrors(errors)
   // @ts-expect-error TS(2345) FIXME: Argument of type '({ conditions: { country, langua... Remove this comment to see the full error message

--- a/src/utils/rules-proxy.ts
+++ b/src/utils/rules-proxy.ts
@@ -40,6 +40,8 @@ export const getLanguage = function (headers) {
 }
 
 export const createRewriter = async function ({
+  // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'an... Remove this comment to see the full error message
+  config,
   // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
   configPath,
   // @ts-expect-error TS(7031) FIXME: Binding element 'distDir' implicitly has an 'any' ... Remove this comment to see the full error message
@@ -56,7 +58,7 @@ export const createRewriter = async function ({
   // @ts-expect-error TS(7034) FIXME: Variable 'matcher' implicitly has type 'any' in so... Remove this comment to see the full error message
   let matcher = null
   const redirectsFiles = [...new Set([path.resolve(distDir, '_redirects'), path.resolve(projectDir, '_redirects')])]
-  let redirects = await parseRedirects({ redirectsFiles, configPath })
+  let redirects = await parseRedirects({ config, redirectsFiles, configPath })
 
   const watchedRedirectFiles = configPath === undefined ? redirectsFiles : [...redirectsFiles, configPath]
   onChanges(watchedRedirectFiles, async () => {
@@ -65,7 +67,7 @@ export const createRewriter = async function ({
       `${NETLIFYDEVLOG} Reloading redirect rules from`,
       existingRedirectsFiles.map((redirectFile) => path.relative(projectDir, redirectFile)),
     )
-    redirects = await parseRedirects({ redirectsFiles, configPath })
+    redirects = await parseRedirects({ config, redirectsFiles, configPath })
     matcher = null
   })
 

--- a/src/utils/run-build.ts
+++ b/src/utils/run-build.ts
@@ -148,13 +148,13 @@ export const runNetlifyBuild = async ({ command, env = {}, options, settings, ti
   }
 
   // Run Netlify Build using the `startDev` entry point.
-  const { error: startDevError, success } = await startDev(devCommand, startDevOptions)
+  const { configMutations, error: startDevError, success } = await startDev(devCommand, startDevOptions)
 
   if (!success && startDevError) {
     error(`Could not start local development server\n\n${startDevError.message}\n\n${startDevError.stack}`)
   }
 
-  return {}
+  return { configMutations }
 }
 
 /**

--- a/tests/integration/rules-proxy.test.ts
+++ b/tests/integration/rules-proxy.test.ts
@@ -21,6 +21,7 @@ describe('rules-proxy', () => {
     await builder.build()
 
     const rewriter = await createRewriter({
+      config: {},
       distDir: builder.directory,
       projectDir: builder.directory,
       jwtSecret: '',


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Reimplements @lukasholzer 's code from https://github.com/netlify/cli/pull/5546 which went stale and out of date. That part covered headers. 

My changes ported that, added support for redirects, and added additional checks for this behavior in a *Dev test.

Fixes https://github.com/netlify/cli/issues/5544

> This PR only parses the headers but we might want to do the same for redirects in a follow up or other config mutations not sure what frameworks needs here?

Currently, if you use the *Dev events, config changes within the callbacks are not applied. 

This PR does not include the ability to watch for these file changes and reapply the new config on file changes while dev is running. Meaning the config will get included on the first pass but it will not apply new config file changes unless the dev command is invoked again. For now, this is fine, we want to be able to unblock this issue for a [customer](https://github.com/netlify/cli/pull/5546#issuecomment-1919620467) and we can follow up with another PR to add file watching.


I verified locally that headers and redirects set in onPreDev work as expected.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
