### PR TITLE
fix: only intercept form submissions if form handler is configured

### DIFF
--- a/src/lib/functions/form-submissions-handler.ts
+++ b/src/lib/functions/form-submissions-handler.ts
@@ -11,22 +11,31 @@ import { warn } from '../../utils/command-helpers.js'
 import { BACKGROUND } from '../../utils/functions/index.js'
 import { capitalize } from '../string.js'
 
+import type NetlifyFunction from './netlify-function.js'
 import type { FunctionsRegistry } from './registry.js'
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'functionsRegistry' implicitly has... Remove this comment to see the full error message
-const getFormHandler = function ({ functionsRegistry }) {
+export const getFormHandler = function ({
+  functionsRegistry,
+  logWarning = true,
+}: {
+  functionsRegistry: FunctionsRegistry
+  logWarning?: boolean
+}) {
   const handlers = ['submission-created', `submission-created${BACKGROUND}`]
     .map((name) => functionsRegistry.get(name))
-    .filter(Boolean)
+    .filter((func): func is NetlifyFunction => Boolean(func))
     .map(({ name }) => name)
 
   if (handlers.length === 0) {
-    warn(`Missing form submission function handler`)
+    logWarning && warn(`Missing form submission function handler`)
     return
   }
 
   if (handlers.length === 2) {
-    warn(`Detected both '${handlers[0]}' and '${handlers[1]}' form submission functions handlers, using ${handlers[0]}`)
+    logWarning &&
+      warn(
+        `Detected both '${handlers[0]}' and '${handlers[1]}' form submission functions handlers, using ${handlers[0]}`,
+      )
   }
 
   return handlers[0]

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -29,6 +29,7 @@ import {
   isEdgeFunctionsRequest,
 } from '../lib/edge-functions/proxy.js'
 import { fileExistsAsync, isFileAsync } from '../lib/fs.js'
+import { getFormHandler } from '../lib/functions/form-submissions-handler.js'
 import { DEFAULT_FUNCTION_URL_EXPRESSION } from '../lib/functions/registry.js'
 import { initializeProxy as initializeImageProxy, isImageRequest } from '../lib/images/proxy.js'
 import renderErrorTemplate from '../lib/render-error-template.js'
@@ -774,8 +775,12 @@ const onRequest = async (
   // @ts-expect-error TS(7031) FIXME: Binding element 'statusCode' implicitly has an 'an... Remove this comment to see the full error message
   req[shouldGenerateETag] = ({ statusCode }) => statusCode >= 200 && statusCode < 300
 
+  const hasFormSubmissionHandler: boolean =
+    functionsRegistry && getFormHandler({ functionsRegistry, logWarning: false })
+
   const ct = req.headers['content-type'] ? contentType.parse(req).type : ''
   if (
+    hasFormSubmissionHandler &&
     functionsServer &&
     req.method === 'POST' &&
     !isInternal(req.url) &&

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -77,7 +77,7 @@ const validateRoleBasedRedirectsSite = async ({ builder, jwtRolePath, jwtSecret,
 
 describe.concurrent('commands/dev-miscellaneous', () => {
   test('should follow redirect for fully qualified rule', async (t) => {
-    await withSiteBuilder('site-with-fully-qualified-redirect-rule', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -99,7 +99,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           redirects: [{ from: `http://localhost/hello-world`, to: `/local-hello`, status: 200 }],
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/hello-world`)
@@ -111,7 +111,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should return 202 ok and empty response for background function', async (t) => {
-    await withSiteBuilder('site-with-background-function', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { functions: { directory: 'functions' } } }).withFunction({
         path: 'hello-background.js',
         handler: () => {
@@ -119,7 +119,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
         },
       })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/.netlify/functions/hello-background`)
@@ -130,7 +130,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('background function clientContext,identity should be null', async (t) => {
-    await withSiteBuilder('site-with-background-function', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({ config: { functions: { directory: 'functions' } } })
         .withFunction({
@@ -139,7 +139,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             console.log(`__CLIENT_CONTEXT__START__${JSON.stringify(context)}__CLIENT_CONTEXT__END__`)
           },
         })
-        .buildAsync()
+        .build()
 
       await withDevServer({ cwd: builder.directory }, async ({ outputBuffer, url }) => {
         await fetch(`${url}/.netlify/functions/hello-background`)
@@ -153,7 +153,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('function clientContext.custom.netlify should be set', async (t) => {
-    await withSiteBuilder('site-with-function', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({ config: { functions: { directory: 'functions' } } })
         .withFunction({
@@ -163,7 +163,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             body: JSON.stringify(context),
           }),
         })
-        .buildAsync()
+        .build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/.netlify/functions/hello`, {
@@ -186,15 +186,15 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should enforce role based redirects with default secret and role path', async (t) => {
-    await withSiteBuilder('site-with-default-role-based-redirects', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       setupRoleBasedRedirectsSite(builder)
-      await builder.buildAsync()
+      await builder.build()
       await validateRoleBasedRedirectsSite({ builder, t })
     })
   })
 
   test('should enforce role based redirects with custom secret and role path', async (t) => {
-    await withSiteBuilder('site-with-custom-role-based-redirects', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const jwtSecret = 'custom'
       const jwtRolePath = 'roles'
       setupRoleBasedRedirectsSite(builder).withNetlifyToml({
@@ -205,13 +205,13 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           },
         },
       })
-      await builder.buildAsync()
+      await builder.build()
       await validateRoleBasedRedirectsSite({ builder, t, jwtSecret, jwtRolePath })
     })
   })
 
   test('Serves an Edge Function that terminates a response', async (t) => {
-    await withSiteBuilder('site-with-edge-function-that-terminates-response', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -239,7 +239,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/edge-function`)
@@ -253,7 +253,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves an Edge Function with a rewrite', async (t) => {
-    await withSiteBuilder('site-with-edge-function-that-rewrites', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -302,7 +302,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const [response1, response2] = await Promise.all([
@@ -320,7 +320,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves an Edge Function with caching', async (t) => {
-    await withSiteBuilder('site-with-edge-function-with-caching', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -349,7 +349,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/edge-function`)
@@ -361,7 +361,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves an Edge Function that includes context with site and deploy information', async (t) => {
-    await withSiteBuilder('site-with-edge-function-printing-site-deploy-info', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -386,7 +386,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'siteContext',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       const siteInfo = {
         account_slug: 'test-account',
@@ -430,7 +430,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves an Edge Function that transforms the response', async (t) => {
-    await withSiteBuilder('site-with-edge-function-that-transforms-response', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -463,7 +463,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'yell',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/hello`)
@@ -475,7 +475,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves an Edge Function that streams the response', async (t) => {
-    await withSiteBuilder('site-with-edge-function-that-streams-response', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -517,7 +517,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'stream',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         let numberOfChunks = 0
@@ -539,7 +539,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('When an edge function fails, serves a fallback defined by its `on_error` mode', async (t) => {
-    await withSiteBuilder('site-with-edge-function-that-fails', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -583,7 +583,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello-2',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const [response1, response2] = await Promise.all([
@@ -600,7 +600,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('When an edge function throws uncaught exception, the dev server continues working', async (t) => {
-    await withSiteBuilder('site-with-edge-function-uncaught-exception', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({
           config: {
@@ -618,7 +618,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello-1',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/hello`, {
@@ -633,7 +633,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('redirect with country cookie', async (t) => {
-    await withSiteBuilder('site-with-country-cookie', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withContentFiles([
           {
@@ -649,7 +649,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           redirects: [{ from: `/`, to: `/index-es.html`, status: '200!', condition: 'Country=ES' }],
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async (server) => {
         const response = await fetch(`${server.url}/`, {
@@ -664,7 +664,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('redirect with country flag', async (t) => {
-    await withSiteBuilder('site-with-country-flag', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withContentFiles([
           {
@@ -680,7 +680,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           redirects: [{ from: `/`, to: `/index-es.html`, status: '200!', condition: 'Country=ES' }],
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       // NOTE: default fallback for country is 'US' if no flag is provided
       await withDevServer({ cwd: builder.directory }, async (server) => {
@@ -698,11 +698,11 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test(`doesn't hang when sending a application/json POST request to function server`, async (t) => {
-    await withSiteBuilder('site-with-functions', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const functionsPort = 6666
       await builder
         .withNetlifyToml({ config: { functions: { directory: 'functions' }, dev: { functionsPort } } })
-        .buildAsync()
+        .build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port, url }) => {
         const response = await fetch(`${url.replace(port, functionsPort)}/test`, {
@@ -730,7 +730,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             body: JSON.stringify(event),
           }),
         })
-        .buildAsync()
+        .build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port, url }) => {
         const response = await fetch(`${url.replace(port, functionsPort)}/.netlify/functions/exclamat!on`, {
@@ -749,9 +749,9 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should detect content changes in edge functions', async (t) => {
-    await withSiteBuilder('site-with-edge-functions', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
-      await builder
+      builder
         .withNetlifyToml({
           config: {
             build: {
@@ -771,7 +771,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port }) => {
         const helloWorldMessage = await got(`http://localhost:${port}/hello`).then((res) => res.body)
@@ -781,7 +781,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             handler: () => new Response('Hello builder'),
             name: 'hello',
           })
-          .buildAsync()
+          .build()
 
         const DETECT_FILE_CHANGE_DELAY = 500
         await pause(DETECT_FILE_CHANGE_DELAY)
@@ -795,7 +795,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should detect deleted edge functions', async (t) => {
-    await withSiteBuilder('site-with-edge-functions', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -817,7 +817,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'auth',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port }) => {
         const authResponseMessage = await fetch(`http://localhost:${port}/auth`).then((response) => response.text())
@@ -826,7 +826,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           .withoutFile({
             path: 'netlify/edge-functions/auth.js',
           })
-          .buildAsync()
+          .build()
 
         const DETECT_FILE_CHANGE_DELAY = 500
         await pause(DETECT_FILE_CHANGE_DELAY)
@@ -840,9 +840,9 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should respect in-source configuration from edge functions', async (t) => {
-    await withSiteBuilder('site-with-edge-functions', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
-      await builder
+      builder
         .withNetlifyToml({
           config: {
             build: {
@@ -857,7 +857,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port, waitForLogMatching }) => {
         const res1 = await fetch(`http://localhost:${port}/hello-1`)
@@ -875,7 +875,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             handler: () => new Response('Hello world'),
             name: 'hello',
           })
-          .buildAsync()
+          .build()
 
         await waitForLogMatching('Reloaded edge function')
 
@@ -897,9 +897,9 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should respect excluded paths', async (t) => {
-    await withSiteBuilder('site-with-excluded-path', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
-      await builder
+      builder
         .withNetlifyToml({
           config: {
             build: {
@@ -914,7 +914,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           name: 'hello',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withDevServer({ cwd: builder.directory }, async ({ port }) => {
         const [res1, res2] = await Promise.all([
@@ -931,7 +931,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('should respect in-source configuration from internal edge functions', async (t) => {
-    await withSiteBuilder('site-with-internal-edge-functions', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       await builder
         .withNetlifyToml({
@@ -971,7 +971,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             internal: true,
             name: 'internal',
           })
-          .buildAsync()
+          .build()
 
         await waitForLogMatching('Reloaded edge function')
 
@@ -988,7 +988,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
   })
 
   test('Serves edge functions with import maps coming from the `functions.deno_import_map` config property and from the internal manifest', async (t) => {
-    await withSiteBuilder('site-with-edge-functions-and-import-maps', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const internalEdgeFunctionsDir = path.join('.netlify', 'edge-functions')
 
       await builder
@@ -1082,7 +1082,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
         response: [{ slug: siteInfo.account_slug }],
       },
     ]
-    await withSiteBuilder('site-with-edge-functions-and-env', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder
         .withNetlifyToml({
@@ -1115,7 +1115,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
           path: '.env',
         })
 
-      await builder.buildAsync()
+      await builder.build()
 
       await withMockApi(routes, async ({ apiUrl }) => {
         await withDevServer(
@@ -1167,7 +1167,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
     const externalServerPath = path.join(__dirname, '../../utils', 'external-server-cli.js')
     const command = `node ${externalServerPath} ${externalServerPort}`
 
-    await withSiteBuilder('site-with-legacy-env-vars', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
 
       await builder
@@ -1240,7 +1240,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
     const externalServerPath = path.join(__dirname, '../../utils', 'external-server-cli.js')
     const command = `node ${externalServerPath} ${externalServerPort}`
 
-    await withSiteBuilder('site-with-env-vars', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
 
       await builder
@@ -1257,7 +1257,7 @@ describe.concurrent('commands/dev-miscellaneous', () => {
             },
           },
         })
-        .buildAsync()
+        .build()
 
       await withMockApi(routes, async ({ apiUrl }) => {
         await withDevServer(

--- a/tests/integration/commands/dev/dev.zisi.test.js
+++ b/tests/integration/commands/dev/dev.zisi.test.js
@@ -21,7 +21,7 @@ const testMatrix = [{ args: [] }]
 
 describe.concurrent.each(testMatrix)('withSiteBuilder with args: $args', ({ args }) => {
   test('should handle query params in redirects', async (t) => {
-    await withSiteBuilder('site-with-query-redirects', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withContentFile({
           path: 'public/index.html',
@@ -80,7 +80,7 @@ describe.concurrent.each(testMatrix)('withSiteBuilder with args: $args', ({ args
   })
 
   test('Should not use the ZISI function bundler if not using esbuild', async (t) => {
-    await withSiteBuilder('site-with-esm-function-and-no-esbuild', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { functions: { directory: 'functions' } } }).withContentFile({
         path: path.join('functions', 'esm-function', 'esm-function.js'),
         content: `
@@ -103,7 +103,7 @@ export async function handler(event, context) {
   })
 
   test('Should use the ZISI function bundler and serve ESM functions if using esbuild', async (t) => {
-    await withSiteBuilder('site-with-esm-function-and-esbuild', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { functions: { directory: 'functions', node_bundler: 'esbuild' } } })
         .withContentFile({
@@ -128,7 +128,7 @@ export async function handler(event, context) {
   })
 
   test('Should use the ZISI function bundler and serve TypeScript functions if using esbuild', async (t) => {
-    await withSiteBuilder('site-with-ts-function-and-esbuild', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder
         .withNetlifyToml({ config: { functions: { directory: 'functions', node_bundler: 'esbuild' } } })
         .withContentFile({
@@ -158,7 +158,7 @@ export const handler = async function () {
   })
 
   test('Should use the ZISI function bundler and serve TypeScript functions if not using esbuild', async (t) => {
-    await withSiteBuilder('site-with-ts-function-and-no-esbuild', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       builder.withNetlifyToml({ config: { functions: { directory: 'functions' } } }).withContentFile({
         path: path.join('functions', 'ts-function', 'ts-function.ts'),
         content: `
@@ -186,7 +186,7 @@ export const handler = async function () {
   })
 
   test(`should start https server when https dev block is configured`, async (t) => {
-    await withSiteBuilder('sites-with-https-certificate', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({
           config: {
@@ -279,7 +279,7 @@ export const handler = async function () {
   })
 
   test(`should use custom functions timeouts`, async (t) => {
-    await withSiteBuilder('site-with-custom-functions-timeout', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({
           config: {
@@ -340,8 +340,8 @@ export const handler = async function () {
   })
 
   // we need curl to reproduce this issue
-  test.skipIf(os.platform() === 'win32')(`don't hang on 'Expect: 100-continue' header`, async () => {
-    await withSiteBuilder('site-with-expect-header', async (builder) => {
+  test.skipIf(os.platform() === 'win32')(`don't hang on 'Expect: 100-continue' header`, async (t) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withNetlifyToml({
           config: {
@@ -370,7 +370,7 @@ export const handler = async function () {
   })
 
   test(`serves non ascii static files correctly`, async (t) => {
-    await withSiteBuilder('site-with-non-ascii-files', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withContentFile({
           path: 'public/范.txt',
@@ -392,7 +392,7 @@ export const handler = async function () {
   })
 
   test(`returns headers set by function`, async (t) => {
-    await withSiteBuilder('site-with-function-with-custom-headers', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withFunction({
           pathPrefix: 'netlify/functions',
@@ -422,7 +422,7 @@ export const handler = async function () {
   })
 
   test('should match redirect when path is URL encoded', async (t) => {
-    await withSiteBuilder('site-with-encoded-redirect', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder
         .withContentFile({ path: 'static/special[test].txt', content: `special` })
         .withRedirectsFile({ redirects: [{ from: '/_next/static/*', to: '/static/:splat', status: 200 }] })
@@ -440,7 +440,7 @@ export const handler = async function () {
   })
 
   test(`always redirects POST requests to functions server`, async (t) => {
-    await withSiteBuilder('site-with-post-request', async (builder) => {
+    await withSiteBuilder(t, async (builder) => {
       await builder.build()
 
       await withDevServer({ cwd: builder.directory, args }, async (server) => {

--- a/tests/integration/commands/dev/dev.zisi.test.js
+++ b/tests/integration/commands/dev/dev.zisi.test.js
@@ -439,7 +439,7 @@ export const handler = async function () {
     })
   })
 
-  test(`always redirects POST requests to functions server`, async (t) => {
+  test(`should not redirect POST request to functions server when it doesn't exists`, async (t) => {
     await withSiteBuilder(t, async (builder) => {
       await builder.build()
 
@@ -454,8 +454,8 @@ export const handler = async function () {
           body: 'some=thing',
         })
 
-        t.expect(error.status).toBe(404)
-        t.expect(await error.text()).toEqual('Function not found...')
+        t.expect(error.status).toBe(405)
+        t.expect(await error.text()).toEqual('Method Not Allowed')
       })
     })
   })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Resolves https://linear.app/netlify/issue/COM-366/ntl-dev-intercepts-all-form-submissions.

We're currently sending all form submissions (POST requests with the right content-type) towards the functions server, which will call the `submission-created` handler if it exists. That breaks frameworks like Remix that make heavy use of form submissions, because those requests aren't passed through to the framework server!

This PR fixes this, by only sending form submissions to the functions server if there's a submission handler registered.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
