### PR TITLE
chore: increase timeout for streaming test

### DIFF
--- a/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/stream.js
+++ b/tests/integration/__fixtures__/dev-server-with-v2-functions/functions/stream.js
@@ -6,7 +6,7 @@ export default async () =>
         setTimeout(() => {
           controller.enqueue('second chunk')
           controller.close()
-        }, 50)
+        }, 200)
       },
     }),
     {


### PR DESCRIPTION
We have an integration test that's a little flaky on CI. I'm not sure what's causing that, but I have a hunch that we're sending the two chunks fast enough that a busy CI runner will see them batched together. Let's see if this CI runs better!

Resolves https://linear.app/netlify/issue/COM-373/unflake-cli-test-for-streaming