### PR TITLE
fix: an issue where the user had to select a build command that is already defined

### DIFF
--- a/src/utils/build-info.ts
+++ b/src/utils/build-info.ts
@@ -69,6 +69,13 @@ export const detectFrameworkSettings = async (
     return settings[0]
   }
 
+  if (type === 'build' && command.netlify.config?.build?.command?.length) {
+    return {
+      ...settings[0],
+      buildCommand: command.netlify.config.build.command,
+    }
+  }
+
   if (settings.length > 1) {
     // multiple matching detectors, make the user choose
     const scriptInquirerOptions = formatSettingsArrForInquirer(settings, type)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://github.com/netlify/build/issues/4542

Previously, when it detected multiple frameworks like (Astro and Solidjs) even though a `netlify.toml` exists with a build command it still asked to select one.

This broke CI workflows as there was no way to hide the interactive select.

![CleanShot 2024-02-22 at 14 31 24](https://github.com/netlify/cli/assets/11156362/008c69aa-c4ab-4bff-bdb8-5c02e1a2bf3e)

The fix just takes the first setting now as they are ordered after likelihood and things like the publish directory are getting overridden later on as well.


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
