### PR TITLE
fix: an issue where the package path was missing when the cwd was not on the root

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -503,6 +503,12 @@ export default class BaseCommand extends Command {
       this.workingDir = join(this.project.jsWorkspaceRoot, this.workspacePackage)
     }
 
+    if (this.project.workspace?.packages.length && !this.project.workspace.isRoot) {
+      // set the package path even though we are not in the workspace root
+      // as the build command will set the process working directory to the workspace root
+      this.workspacePackage = this.project.relativeBaseDirectory
+    }
+
     this.jsWorkspaceRoot = this.project.jsWorkspaceRoot
     // detect if a toml exists in this package.
     const tomlFile = join(this.workingDir, 'netlify.toml')


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

If you had a monorepo and you did `cd apps/my-app` and then run `ntl build` the `PACKAGE_PATH`  was not set which leads to build failures for build plugins that rely on this monorepo configuration.

Now the PACKAGE_PATH constant will be set on those builds as well

Fixes https://linear.app/netlify/issue/FRA-350/enoent-no-such-file-or-directory-open-vartasknextbuild-id

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
