### PR TITLE
fix: handle empty store on `blobs:list`

### DIFF
--- a/src/commands/blobs/blobs-list.ts
+++ b/src/commands/blobs/blobs-list.ts
@@ -27,9 +27,11 @@ export const blobsList = async (storeName: string, options: Options, command: Ba
     })
 
     if (options.json) {
-      logJson({ blobs, directories })
+      return logJson({ blobs, directories })
+    }
 
-      return
+    if (blobs.length === 0 && directories.length === 0) {
+      return log(`Netlify Blobs store ${chalk.yellow(storeName)} is empty`)
     }
 
     const table = new AsciiTable(`Netlify Blobs (${storeName})`)


### PR DESCRIPTION
#### Summary

Gracefully handles the case of an empty store in the `blobs:list` command.

_Before_

<img width="518" alt="Screenshot 2024-03-07 at 16 07 46" src="https://github.com/netlify/cli/assets/4162329/92c6b7ad-3703-4d7c-bd2b-d1e948d7f443">

_After_

<img width="524" alt="Screenshot 2024-03-07 at 16 07 51" src="https://github.com/netlify/cli/assets/4162329/bf1d04ed-4706-4826-9229-98ad6752b3b4">


Closes COM-302