### PR TITLE
fix: broken deploy with --skip-functions-cache

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,6 +43,8 @@ module.exports = {
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase' }],
     'max-params': 'off',
+    'no-empty-function': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
   },
   overrides: [
     ...overrides,
@@ -137,6 +139,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
       },
     },
   ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,6 +42,7 @@ module.exports = {
     'unicorn/consistent-destructuring': 0,
     // TODO: harmonize with filename snake_case in other Netlify Dev projects
     'unicorn/filename-case': [2, { case: 'kebabCase' }],
+    'max-params': 'off',
   },
   overrides: [
     ...overrides,

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -696,6 +696,13 @@ export default class BaseCommand extends Command {
   }
 
   /**
+   * get a path inside the `.netlify` project folder
+   */
+  getPathInProject(...paths: string[]): string {
+    return join(this.workspacePackage || '', '.netlify', ...paths)
+  }
+
+  /**
    * Returns the context that should be used in case one hasn't been explicitly
    * set. The default context is `dev` most of the time, but some commands may
    * wish to override that.

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -1,3 +1,4 @@
+import { Stats } from 'fs'
 import { stat } from 'fs/promises'
 import { basename, resolve } from 'path'
 
@@ -37,6 +38,7 @@ import openBrowser from '../../utils/open-browser.js'
 import BaseCommand from '../base-command.js'
 import { link } from '../link/link.js'
 import { sitesCreate } from '../sites/sites-create.js'
+import { $TSFixMe } from '../types.js'
 
 // @ts-expect-error TS(7031) FIXME: Binding element 'api' implicitly has an 'any' type... Remove this comment to see the full error message
 const triggerDeploy = async ({ api, options, siteData, siteId }) => {
@@ -65,19 +67,21 @@ const triggerDeploy = async ({ api, options, siteData, siteId }) => {
   }
 }
 
-/**
- * Retrieves the folder containing the static files that need to be deployed
- * @param {object} config
- * @param {import('../base-command.js').default} config.command The process working directory
- * @param {object} config.config
- * @param {import('commander').OptionValues} config.options
- * @param {object} config.site
- * @param {object} config.siteData
- * @returns {Promise<string>}
- */
-// @ts-expect-error TS(7031) FIXME: Binding element 'command' implicitly has an 'any' ... Remove this comment to see the full error message
-const getDeployFolder = async ({ command, config, options, site, siteData }) => {
-  let deployFolder
+/** Retrieves the folder containing the static files that need to be deployed */
+const getDeployFolder = async ({
+  command,
+  config,
+  options,
+  site,
+  siteData,
+}: {
+  command: BaseCommand
+  config: $TSFixMe
+  options: OptionValues
+  site: $TSFixMe
+  siteData: $TSFixMe
+}): Promise<string> => {
+  let deployFolder: string | undefined
   // if the `--dir .` flag is provided we should resolve it to the working directory.
   // - in regular sites this is the `process.cwd`
   // - in mono repositories this will be the root of the jsWorkspace
@@ -102,31 +106,26 @@ const getDeployFolder = async ({ command, config, options, site, siteData }) => 
         filter: (input) => resolve(command.workingDir, input),
       },
     ])
-    deployFolder = promptPath
+    deployFolder = promptPath as string
   }
 
   return deployFolder
 }
 
-/**
- * @param {string} deployFolder
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'deployFolder' implicitly has an 'any' t... Remove this comment to see the full error message
-const validateDeployFolder = async (deployFolder) => {
-  /** @type {import('fs').Stats} */
-  let stats
+const validateDeployFolder = async (deployFolder: string) => {
+  let stats: Stats
   try {
     stats = await stat(deployFolder)
   } catch (error_) {
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (error_.code === 'ENOENT') {
-      return error(`No such directory ${deployFolder}! Did you forget to run a build?`)
-    }
+    if (error_ && typeof error_ === 'object' && 'code' in error_) {
+      if (error_.code === 'ENOENT') {
+        return error(`No such directory ${deployFolder}! Did you forget to run a build?`)
+      }
 
-    // Improve the message of permission errors
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    if (error_.code === 'EACCES') {
-      return error('Permission error when trying to access deploy folder')
+      // Improve the message of permission errors
+      if (error_.code === 'EACCES') {
+        return error('Permission error when trying to access deploy folder')
+      }
     }
     throw error_
   }
@@ -137,19 +136,22 @@ const validateDeployFolder = async (deployFolder) => {
   return stats
 }
 
-/**
- * get the functions directory
- * @param {object} config
- * @param {object} config.config
- * @param {import('commander').OptionValues} config.options
- * @param {object} config.site
- * @param {object} config.siteData
- * @param {string} config.workingDir // The process working directory
- * @returns {string|undefined}
- */
-// @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any' t... Remove this comment to see the full error message
-const getFunctionsFolder = ({ config, options, site, siteData, workingDir }) => {
-  let functionsFolder
+/** get the functions directory */
+const getFunctionsFolder = ({
+  config,
+  options,
+  site,
+  siteData,
+  workingDir,
+}: {
+  config: $TSFixMe
+  options: OptionValues
+  site: $TSFixMe
+  siteData: $TSFixMe
+  /** The process working directory where the build command is executed  */
+  workingDir: string
+}): string | undefined => {
+  let functionsFolder: string | undefined
   // Support "functions" and "Functions"
   const funcConfig = config.functionsDirectory
   if (options.functions) {
@@ -162,30 +164,24 @@ const getFunctionsFolder = ({ config, options, site, siteData, workingDir }) => 
   return functionsFolder
 }
 
-/**
- *
- * @param {string|undefined} functionsFolder
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'functionsFolder' implicitly has an 'any... Remove this comment to see the full error message
-const validateFunctionsFolder = async (functionsFolder) => {
-  /** @type {import('fs').Stats|undefined} */
-  let stats
+const validateFunctionsFolder = async (functionsFolder: string | undefined) => {
+  let stats: Stats | undefined
   if (functionsFolder) {
     // we used to hard error if functions folder is specified but doesn't exist
     // but this was too strict for onboarding. we can just log a warning.
     try {
       stats = await stat(functionsFolder)
     } catch (error_) {
-      // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-      if (error_.code === 'ENOENT') {
-        log(
-          `Functions folder "${functionsFolder}" specified but it doesn't exist! Will proceed without deploying functions`,
-        )
-      }
-      // Improve the message of permission errors
-      // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-      if (error_.code === 'EACCES') {
-        error('Permission error when trying to access functions folder')
+      if (error_ && typeof error_ === 'object' && 'code' in error_) {
+        if (error_.code === 'ENOENT') {
+          log(
+            `Functions folder "${functionsFolder}" specified but it doesn't exist! Will proceed without deploying functions`,
+          )
+        }
+        // Improve the message of permission errors
+        if (error_.code === 'EACCES') {
+          error('Permission error when trying to access functions folder')
+        }
       }
     }
   }
@@ -197,8 +193,13 @@ const validateFunctionsFolder = async (functionsFolder) => {
   return stats
 }
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'deployFolder' implicitly has an '... Remove this comment to see the full error message
-const validateFolders = async ({ deployFolder, functionsFolder }) => {
+const validateFolders = async ({
+  deployFolder,
+  functionsFolder,
+}: {
+  deployFolder: string
+  functionsFolder?: string
+}) => {
   const deployFolderStat = await validateDeployFolder(deployFolder)
   const functionsFolderStat = await validateFunctionsFolder(functionsFolder)
   return { deployFolderStat, functionsFolderStat }
@@ -353,13 +354,14 @@ const uploadDeployBlobs = async ({
   silent,
   siteId,
 }: {
-  cachedConfig: any
+  cachedConfig: $TSFixMe
   deployId: string
   options: OptionValues
   packagePath?: string
   silent: boolean
   siteId: string
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const statusCb = silent ? () => {} : deployProgressCb()
 
   statusCb({
@@ -402,7 +404,6 @@ const runDeploy = async ({
   alias,
   // @ts-expect-error TS(7031) FIXME: Binding element 'api' implicitly has an 'any' type... Remove this comment to see the full error message
   api,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'command' implicitly has an 'any' ... Remove this comment to see the full error message
   command,
   // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any' t... Remove this comment to see the full error message
   config,
@@ -433,6 +434,7 @@ const runDeploy = async ({
   title,
 }: {
   functionsFolder?: string
+  command: BaseCommand
 }) => {
   let results
   let deployId
@@ -486,11 +488,12 @@ const runDeploy = async ({
       packagePath: command.workspacePackage,
     })
 
-    results = await deploySite(api, siteId, deployFolder, {
+    results = await deploySite(command, api, siteId, deployFolder, {
       // @ts-expect-error FIXME
       config,
       fnDir: functionDirectories,
       functionsConfig,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
       statusCb: silent ? () => {} : deployProgressCb(),
       deployTimeout,
       syncFileLimit: SYNC_FILE_LIMIT,
@@ -572,6 +575,7 @@ const bundleEdgeFunctions = async (options, command: BaseCommand) => {
   // eslint-disable-next-line n/prefer-global/process, unicorn/prefer-set-has
   const argv = process.argv.slice(2)
   const statusCb =
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     options.silent || argv.includes('--json') || argv.includes('--silent') ? () => {} : deployProgressCb()
 
   statusCb({

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -119,7 +119,9 @@ const validateDeployFolder = async (deployFolder: string) => {
   } catch (error_) {
     if (error_ && typeof error_ === 'object' && 'code' in error_) {
       if (error_.code === 'ENOENT') {
-        return error(`The deploy directory "${deployFolder}" has not been found. Did you forget to run 'netlify build'?`)
+        return error(
+          `The deploy directory "${deployFolder}" has not been found. Did you forget to run 'netlify build'?`,
+        )
       }
 
       // Improve the message of permission errors
@@ -361,7 +363,6 @@ const uploadDeployBlobs = async ({
   silent: boolean
   siteId: string
 }) => {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const statusCb = silent ? () => {} : deployProgressCb()
 
   statusCb({
@@ -493,7 +494,7 @@ const runDeploy = async ({
       config,
       fnDir: functionDirectories,
       functionsConfig,
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
+
       statusCb: silent ? () => {} : deployProgressCb(),
       deployTimeout,
       syncFileLimit: SYNC_FILE_LIMIT,
@@ -575,7 +576,6 @@ const bundleEdgeFunctions = async (options, command: BaseCommand) => {
   // eslint-disable-next-line n/prefer-global/process, unicorn/prefer-set-has
   const argv = process.argv.slice(2)
   const statusCb =
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     options.silent || argv.includes('--json') || argv.includes('--silent') ? () => {} : deployProgressCb()
 
   statusCb({

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -119,7 +119,7 @@ const validateDeployFolder = async (deployFolder: string) => {
   } catch (error_) {
     if (error_ && typeof error_ === 'object' && 'code' in error_) {
       if (error_.code === 'ENOENT') {
-        return error(`No such directory ${deployFolder}! Did you forget to run a build?`)
+        return error(`The deploy directory "${deployFolder}" has not been found. Did you forget to run 'netlify build'?`)
       }
 
       // Improve the message of permission errors

--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -1,8 +1,8 @@
 import process from 'process'
 
-import { OptionValues, Option } from 'commander'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module '@net... Remove this comment to see the full error message
 import { applyMutations } from '@netlify/config'
+import { OptionValues, Option } from 'commander'
 
 import { BLOBS_CONTEXT_VARIABLE, encodeBlobsContext, getBlobsContext } from '../../lib/blobs/blobs.js'
 import { promptEditorHelper } from '../../lib/edge-functions/editor-helper.js'
@@ -216,6 +216,7 @@ export const dev = async (options: OptionValues, command: BaseCommand) => {
   await startProxyServer({
     addonsUrls,
     blobsContext,
+    command,
     config: mutatedConfig,
     configPath: configPathOverride,
     debug: options.debug,

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -141,6 +141,7 @@ export const serve = async (options: OptionValues, command: BaseCommand) => {
   // @ts-expect-error TS(2345) FIXME: Argument of type '{ addonsUrls: { [k: string]: any... Remove this comment to see the full error message
   const url = await startProxyServer({
     addonsUrls,
+    command,
     config,
     configPath: configPathOverride,
     debug: options.debug,

--- a/src/lib/edge-functions/deploy.ts
+++ b/src/lib/edge-functions/deploy.ts
@@ -12,7 +12,7 @@ const distPath = getPathInProject([EDGE_FUNCTIONS_FOLDER])
  * @param {*} file
  */
 // @ts-expect-error TS(7006) FIXME: Parameter 'workingDir' implicitly has an 'any' typ... Remove this comment to see the full error message
-export const deployFileNormalizer = (workingDir, file) => {
+export const deployFileNormalizer = (workingDir: string, file) => {
   const absoluteDistPath = join(workingDir, distPath)
   const isEdgeFunction = file.root === absoluteDistPath
   const normalizedPath = isEdgeFunction ? `${PUBLIC_URL_PATH}/${file.normalizedPath}` : file.normalizedPath
@@ -23,11 +23,7 @@ export const deployFileNormalizer = (workingDir, file) => {
   }
 }
 
-/**
- * @param {string} workingDir
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'workingDir' implicitly has an 'any' typ... Remove this comment to see the full error message
-export const getDistPathIfExists = async (workingDir) => {
+export const getDistPathIfExists = async (workingDir: string) => {
   try {
     const absoluteDistPath = join(workingDir, distPath)
     const stats = await stat(absoluteDistPath)
@@ -42,5 +38,4 @@ export const getDistPathIfExists = async (workingDir) => {
   }
 }
 
-// @ts-expect-error TS(7006) FIXME: Parameter 'filePath' implicitly has an 'any' type.
-export const isEdgeFunctionFile = (filePath) => filePath.startsWith(`${PUBLIC_URL_PATH}/`)
+export const isEdgeFunctionFile = (filePath: string) => filePath.startsWith(`${PUBLIC_URL_PATH}/`)

--- a/src/lib/edge-functions/registry.ts
+++ b/src/lib/edge-functions/registry.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 
 import type { Declaration, EdgeFunction, FunctionConfig, Manifest, ModuleGraph } from '@netlify/edge-bundler'
 
+import BaseCommand from '../../commands/base-command.js'
 import {
   NETLIFYDEVERR,
   NETLIFYDEVLOG,
@@ -17,12 +18,11 @@ import {
 } from '../../utils/command-helpers.js'
 import type { FeatureFlags } from '../../utils/feature-flags.js'
 import { MultiMap } from '../../utils/multimap.js'
-import { getPathInProject } from '../settings.js'
 
 import { INTERNAL_EDGE_FUNCTIONS_FOLDER } from './consts.js'
 
 //  TODO: Replace with a proper type for the entire config object.
-interface Config {
+export interface Config {
   edge_functions?: Declaration[]
   [key: string]: unknown
 }
@@ -33,6 +33,7 @@ type RunIsolate = Awaited<ReturnType<typeof import('@netlify/edge-bundler').serv
 type ModuleJson = ModuleGraph['modules'][number]
 
 interface EdgeFunctionsRegistryOptions {
+  command: BaseCommand
   bundler: typeof import('@netlify/edge-bundler')
   config: Config
   configPath: string
@@ -112,9 +113,11 @@ export class EdgeFunctionsRegistry {
   private runIsolate: RunIsolate
   private servePath: string
   private projectDir: string
+  private command: BaseCommand
 
   constructor({
     bundler,
+    command,
     config,
     configPath,
     directories,
@@ -126,6 +129,7 @@ export class EdgeFunctionsRegistry {
     runIsolate,
     servePath,
   }: EdgeFunctionsRegistryOptions) {
+    this.command = command
     this.bundler = bundler
     this.configPath = configPath
     this.directories = directories
@@ -516,7 +520,7 @@ export class EdgeFunctionsRegistry {
   }
 
   private get internalDirectory() {
-    return join(this.projectDir, getPathInProject([INTERNAL_EDGE_FUNCTIONS_FOLDER]))
+    return join(this.projectDir, this.command.getPathInProject(INTERNAL_EDGE_FUNCTIONS_FOLDER))
   }
 
   private async readDeployConfig() {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -32,6 +32,7 @@ export const getPathInHome = (paths) => {
 /**
  * get a path inside the project folder
  * @param {string[]} paths
+ * @deprecated This does not work in monorepos use Basecommand.getPathInProject instead
  * @returns {string}
  */
 // @ts-expect-error TS(7006) FIXME: Parameter 'paths' implicitly has an 'any' type.

--- a/src/utils/deploy/hash-fns.ts
+++ b/src/utils/deploy/hash-fns.ts
@@ -91,17 +91,7 @@ const getFunctionZips = async ({
 const hashFns = async (
   command: BaseCommand,
   directories: string[],
-  {
-    assetType = 'function',
-    concurrentHash,
-    functionsConfig,
-    hashAlgorithm = 'sha256',
-    manifestPath,
-    rootDir,
-    skipFunctionsCache,
-    statusCb,
-    tmpDir,
-  }: {
+  config: {
     /** @default 'function' */
     assetType?: string
     concurrentHash?: number
@@ -115,6 +105,17 @@ const hashFns = async (
     tmpDir: $TSFixMe
   },
 ) => {
+  const {
+    assetType = 'function',
+    concurrentHash,
+    functionsConfig,
+    hashAlgorithm = 'sha256',
+    manifestPath,
+    rootDir,
+    skipFunctionsCache,
+    statusCb,
+    tmpDir,
+  } = config || {}
   // Early out if no functions directories are configured.
   if (directories.length === 0) {
     return { functions: {}, functionsWithNativeModules: [], shaMap: {} }

--- a/src/utils/deploy/hash-fns.ts
+++ b/src/utils/deploy/hash-fns.ts
@@ -8,7 +8,8 @@ import fromArray from 'from2-array'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'pump... Remove this comment to see the full error message
 import pumpModule from 'pump'
 
-import { getPathInProject } from '../../lib/settings.js'
+import BaseCommand from '../../commands/base-command.js'
+import { $TSFixMe } from '../../commands/types.js'
 import { INTERNAL_FUNCTIONS_FOLDER } from '../functions/functions.js'
 
 import { hasherCtor, manifestCollectorCtor } from './hasher-segments.js'
@@ -19,20 +20,23 @@ const pump = promisify(pumpModule)
 const MANIFEST_FILE_TTL = 12e4
 
 const getFunctionZips = async ({
-  // @ts-expect-error TS(7031) FIXME: Binding element 'directories' implicitly has an 'a... Remove this comment to see the full error message
+  command,
   directories,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'functionsConfig' implicitly has a... Remove this comment to see the full error message
   functionsConfig,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'manifestPath' implicitly has an '... Remove this comment to see the full error message
   manifestPath,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'rootDir' implicitly has an 'any' ... Remove this comment to see the full error message
   rootDir,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'skipFunctionsCache' implicitly ha... Remove this comment to see the full error message
   skipFunctionsCache,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'statusCb' implicitly has an 'any'... Remove this comment to see the full error message
   statusCb,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'tmpDir' implicitly has an 'any' t... Remove this comment to see the full error message
   tmpDir,
+}: {
+  command: BaseCommand
+  directories: string[]
+  functionsConfig: $TSFixMe
+  manifestPath: $TSFixMe
+  rootDir: $TSFixMe
+  skipFunctionsCache: $TSFixMe
+  statusCb: $TSFixMe
+  tmpDir: $TSFixMe
 }) => {
   statusCb({
     type: 'functions-manifest',
@@ -79,31 +83,36 @@ const getFunctionZips = async ({
 
   return await zipFunctions(directories, tmpDir, {
     basePath: rootDir,
-    configFileDirectories: [getPathInProject([INTERNAL_FUNCTIONS_FOLDER])],
+    configFileDirectories: [command.getPathInProject(INTERNAL_FUNCTIONS_FOLDER)],
     config: functionsConfig,
   })
 }
 
 const hashFns = async (
-  // @ts-expect-error TS(7006) FIXME: Parameter 'directories' implicitly has an 'any' ty... Remove this comment to see the full error message
-  directories,
+  command: BaseCommand,
+  directories: string[],
   {
     assetType = 'function',
-    // @ts-expect-error TS(7031) FIXME: Binding element 'concurrentHash' implicitly has an... Remove this comment to see the full error message
     concurrentHash,
-    // @ts-expect-error TS(7031) FIXME: Binding element 'functionsConfig' implicitly has a... Remove this comment to see the full error message
     functionsConfig,
     hashAlgorithm = 'sha256',
-    // @ts-expect-error TS(7031) FIXME: Binding element 'manifestPath' implicitly has an '... Remove this comment to see the full error message
     manifestPath,
-    // @ts-expect-error TS(7031) FIXME: Binding element 'rootDir' implicitly has an 'any' ... Remove this comment to see the full error message
     rootDir,
-    // @ts-expect-error TS(7031) FIXME: Binding element 'skipFunctionsCache' implicitly ha... Remove this comment to see the full error message
     skipFunctionsCache,
-    // @ts-expect-error TS(7031) FIXME: Binding element 'statusCb' implicitly has an 'any'... Remove this comment to see the full error message
     statusCb,
-    // @ts-expect-error TS(7031) FIXME: Binding element 'tmpDir' implicitly has an 'any' t... Remove this comment to see the full error message
     tmpDir,
+  }: {
+    /** @default 'function' */
+    assetType?: string
+    concurrentHash?: number
+    functionsConfig: $TSFixMe
+    /** @default 'sha256' */
+    hashAlgorithm?: string
+    manifestPath: $TSFixMe
+    rootDir: $TSFixMe
+    skipFunctionsCache: $TSFixMe
+    statusCb: $TSFixMe
+    tmpDir: $TSFixMe
   },
 ) => {
   // Early out if no functions directories are configured.
@@ -116,6 +125,7 @@ const hashFns = async (
   }
 
   const functionZips = await getFunctionZips({
+    command,
     directories,
     functionsConfig,
     manifestPath,

--- a/src/utils/proxy-server.ts
+++ b/src/utils/proxy-server.ts
@@ -64,6 +64,8 @@ export const startProxyServer = async ({
   addonsUrls,
   // @ts-expect-error TS(7031) FIXME: Binding element 'blobsContext' implicitly has an '... Remove this comment to see the full error message
   blobsContext,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'accountId' implicitly has an 'any... Remove this comment to see the full error message
+  command,
   // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any' t... Remove this comment to see the full error message
   config,
   // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
@@ -100,6 +102,7 @@ export const startProxyServer = async ({
   const url = await startProxy({
     addonsUrls,
     blobsContext,
+    command,
     config,
     configPath: configPath || site.configPath,
     debug,

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -426,23 +426,23 @@ const MILLISEC_TO_SEC = 1e3
 
 const initializeProxy = async function ({
   // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'any... Remove this comment to see the full error message
-  configPath,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'distDir' implicitly has an 'any... Remove this comment to see the full error message
-  distDir,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'env' implicitly has an 'any... Remove this comment to see the full error message
-  env,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'host' implicitly has an 'any... Remove this comment to see the full error message
-  host,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'imageProxy' implicitly has an 'any... Remove this comment to see the full error message
-  imageProxy,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'port' implicitly has an 'any... Remove this comment to see the full error message
-  port,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'projectDir' implicitly has an 'any... Remove this comment to see the full error message
-  projectDir,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'siteInfo' implicitly has an 'any... Remove this comment to see the full error message
-  siteInfo,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any... Remove this comment to see the full error message
   config,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'distDir' implicitly has an 'any... Remove this comment to see the full error message
+  configPath,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'env' implicitly has an 'any... Remove this comment to see the full error message
+  distDir,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'host' implicitly has an 'any... Remove this comment to see the full error message
+  env,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'imageProxy' implicitly has an 'any... Remove this comment to see the full error message
+  host,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'port' implicitly has an 'any... Remove this comment to see the full error message
+  imageProxy,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'projectDir' implicitly has an 'any... Remove this comment to see the full error message
+  port,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'siteInfo' implicitly has an 'any... Remove this comment to see the full error message
+  projectDir,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any... Remove this comment to see the full error message
+  siteInfo,
 }) {
   const proxy = httpProxy.createProxyServer({
     selfHandleResponse: true,
@@ -809,6 +809,8 @@ export const startProxy = async function ({
   addonsUrls,
   // @ts-expect-error TS(7031) FIXME: Binding element 'blobsContext' implicitly has an '... Remove this comment to see the full error message
   blobsContext,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'accountId' implicitly has an 'any... Remove this comment to see the full error message
+  command,
   // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any' t... Remove this comment to see the full error message
   config,
   // @ts-expect-error TS(7031) FIXME: Binding element 'configPath' implicitly has an 'an... Remove this comment to see the full error message
@@ -843,6 +845,7 @@ export const startProxy = async function ({
   const secondaryServerPort = settings.https ? await getAvailablePort() : null
   const functionsServer = settings.functionsPort ? `http://127.0.0.1:${settings.functionsPort}` : null
   const edgeFunctionsProxy = await initializeEdgeFunctionsProxy({
+    command,
     blobsContext,
     config,
     configPath,

--- a/tests/integration/commands/sites/sites.test.ts
+++ b/tests/integration/commands/sites/sites.test.ts
@@ -13,7 +13,6 @@ import { getEnvironmentVariables, withMockApi } from '../../utils/mock-api.js'
 
 vi.mock('../../../../src/utils/command-helpers.js', async () => ({
   ...(await vi.importActual('../../../../src/utils/command-helpers.js')),
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   log: () => {},
 }))
 

--- a/tests/unit/utils/deploy/hash-fns.test.js
+++ b/tests/unit/utils/deploy/hash-fns.test.js
@@ -1,6 +1,7 @@
 import { temporaryDirectory } from 'tempy'
 import { expect, test } from 'vitest'
 
+import BaseCommand from '../../../../dist/commands/base-command.js'
 import { DEFAULT_CONCURRENT_HASH } from '../../../../dist/utils/deploy/constants.js'
 import hashFns from '../../../../dist/utils/deploy/hash-fns.js'
 import { withSiteBuilder } from '../../../integration/utils/site-builder.ts'
@@ -20,7 +21,7 @@ test('Hashes files in a folder', async () => {
       .buildAsync()
 
     const expectedFunctions = ['hello', 'goodbye']
-    const { fnShaMap, functions } = await hashFns(`${builder.directory}/functions`, {
+    const { fnShaMap, functions } = await hashFns(new BaseCommand(), `${builder.directory}/functions`, {
       tmpDir: temporaryDirectory(),
       concurrentHash: DEFAULT_CONCURRENT_HASH,
       statusCb() {},


### PR DESCRIPTION

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes broken deploys when run with `ntl deploy --build --skip-functions-cache` inside monorepos.

As the `getPathInProject` function is not monorepo aware, this breaks on monorepos.

There are more areas that depend on this function, but I'll do this in follow-up PRs to keep the PR size small.


Fixes https://linear.app/netlify/issue/FRA-385/could-not-resolve-vartaskappsdocsnetlifydistrunhandlerstracingjs

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
