### PR TITLE
fix: a regression in ntl serve with the package path

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -696,7 +696,7 @@ export default class BaseCommand extends Command {
   }
 
   /**
-   * get a path inside the `.netlify` project folder
+   * get a path inside the `.netlify` project folder resolving with the workspace package
    */
   getPathInProject(...paths: string[]): string {
     return join(this.workspacePackage || '', '.netlify', ...paths)

--- a/src/commands/serve/serve.ts
+++ b/src/commands/serve/serve.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer'
 import process from 'process'
 
 import { OptionValues } from 'commander'
@@ -8,16 +7,16 @@ import { promptEditorHelper } from '../../lib/edge-functions/editor-helper.js'
 import { startFunctionsServer } from '../../lib/functions/server.js'
 import { printBanner } from '../../utils/banner.js'
 import {
-  chalk,
-  exit,
-  log,
   NETLIFYDEVERR,
   NETLIFYDEVLOG,
   NETLIFYDEVWARN,
+  chalk,
+  exit,
+  log,
   normalizeConfig,
 } from '../../utils/command-helpers.js'
 import detectServerSettings, { getConfigWithPlugins } from '../../utils/detect-server-settings.js'
-import { getDotEnvVariables, getSiteInformation, injectEnvVariables, UNLINKED_SITE_MOCK_ID } from '../../utils/dev.js'
+import { UNLINKED_SITE_MOCK_ID, getDotEnvVariables, getSiteInformation, injectEnvVariables } from '../../utils/dev.js'
 import { getEnvelopeEnv } from '../../utils/env/index.js'
 import { getInternalFunctionsDir } from '../../utils/functions/functions.js'
 import { ensureNetlifyIgnore } from '../../utils/gitignore.js'
@@ -69,7 +68,11 @@ export const serve = async (options: OptionValues, command: BaseCommand) => {
   // Ensure the internal functions directory exists so that the functions
   // server and registry are initialized, and any functions created by
   // Netlify Build are loaded.
-  await getInternalFunctionsDir({ base: site.root, ensureExists: true })
+  await getInternalFunctionsDir({
+    base: site.root,
+    ensureExists: true,
+    packagePath: command.workspacePackage,
+  })
 
   let settings: ServerSettings
   try {

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -12,6 +12,7 @@ import { NETLIFYDEVERR, chalk, error as printError } from '../../utils/command-h
 import { FeatureFlags, getFeatureFlagsFromSiteInfo } from '../../utils/feature-flags.js'
 import { BlobsContext } from '../blobs/blobs.js'
 import { getGeoLocation } from '../geo-location.js'
+import { getPathInProject } from '../settings.js'
 import { startSpinner, stopSpinner } from '../spinner.js'
 
 import { getBootstrapURL } from './bootstrap.js'
@@ -224,9 +225,15 @@ const prepareServer = async ({
   repositoryRoot?: string
 }) => {
   try {
-    const distImportMapPath = command.getPathInProject(DIST_IMPORT_MAP_PATH)
+    const distImportMapPath = getPathInProject([DIST_IMPORT_MAP_PATH])
     const servePath = resolve(projectDir, command.getPathInProject(EDGE_FUNCTIONS_SERVE_FOLDER))
 
+    console.log({
+      distImportMapPath,
+      servePath,
+      projectDir,
+      repositoryRoot,
+    })
     await rm(servePath, { force: true, recursive: true })
 
     const runIsolate = await bundler.serve({

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -228,12 +228,6 @@ const prepareServer = async ({
     const distImportMapPath = getPathInProject([DIST_IMPORT_MAP_PATH])
     const servePath = resolve(projectDir, command.getPathInProject(EDGE_FUNCTIONS_SERVE_FOLDER))
 
-    console.log({
-      distImportMapPath,
-      servePath,
-      projectDir,
-      repositoryRoot,
-    })
     await rm(servePath, { force: true, recursive: true })
 
     const runIsolate = await bundler.serve({

--- a/src/lib/edge-functions/registry.ts
+++ b/src/lib/edge-functions/registry.ts
@@ -18,6 +18,7 @@ import {
 } from '../../utils/command-helpers.js'
 import type { FeatureFlags } from '../../utils/feature-flags.js'
 import { MultiMap } from '../../utils/multimap.js'
+import { getPathInProject } from '../settings.js'
 
 import { INTERNAL_EDGE_FUNCTIONS_FOLDER } from './consts.js'
 
@@ -535,7 +536,7 @@ export class EdgeFunctionsRegistry {
   }
 
   private get internalDirectory() {
-    return join(this.projectDir, this.command.getPathInProject(INTERNAL_EDGE_FUNCTIONS_FOLDER))
+    return join(this.projectDir, getPathInProject([INTERNAL_EDGE_FUNCTIONS_FOLDER]))
   }
 
   private async readDeployConfig() {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,34 +9,15 @@ const NETLIFY_HOME = '.netlify'
 /**
  * Deprecated method to get netlify's home config - ~/.netlify/...
  * @deprecated
- * @param {string[]} paths
- * @returns {string}
  */
-// @ts-expect-error TS(7006) FIXME: Parameter 'paths' implicitly has an 'any' type.
-export const getLegacyPathInHome = (paths) => {
-  const pathInHome = path.join(os.homedir(), NETLIFY_HOME, ...paths)
-  return pathInHome
-}
+export const getLegacyPathInHome = (paths: string[]) => path.join(os.homedir(), NETLIFY_HOME, ...paths)
 
 /**
  * get a global path on the os base path
- * @param {string[]} paths
- * @returns {string}
  */
-// @ts-expect-error TS(7006) FIXME: Parameter 'paths' implicitly has an 'any' type.
-export const getPathInHome = (paths) => {
-  const pathInHome = path.join(OSBasedPaths.config, ...paths)
-  return pathInHome
-}
+export const getPathInHome = (paths: string[]) => path.join(OSBasedPaths.config, ...paths)
 
 /**
- * get a path inside the project folder
- * @param {string[]} paths
- * @deprecated This does not work in monorepos use Basecommand.getPathInProject instead
- * @returns {string}
+ * get a path inside the project folder "NOT WORKSPACE AWARE"
  */
-// @ts-expect-error TS(7006) FIXME: Parameter 'paths' implicitly has an 'any' type.
-export const getPathInProject = (paths) => {
-  const pathInProject = path.join(NETLIFY_HOME, ...paths)
-  return pathInProject
-}
+export const getPathInProject = (paths: string[]) => path.join(NETLIFY_HOME, ...paths)

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -46,13 +46,7 @@ const brotliDecompress = util.promisify(zlib.brotliDecompress)
 const deflate = util.promisify(zlib.deflate)
 const shouldGenerateETag = Symbol('Internal: response should generate ETag')
 
-/**
- * @param {Buffer} body
- * @param {string | undefined} contentEncoding
- * @returns {Promise<Buffer>}
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'body' implicitly has an 'any' type.
-const decompressResponseBody = async function (body, contentEncoding = '') {
+const decompressResponseBody = async function (body: Buffer, contentEncoding = ''): Promise<Buffer> {
   switch (contentEncoding) {
     case 'gzip':
       return await gunzip(body)
@@ -82,40 +76,21 @@ const formatEdgeFunctionError = (errorBuffer, acceptsHtml) => {
   })
 }
 
-/**
- * @param {string} url
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'url' implicitly has an 'any' type.
-function isInternal(url) {
+function isInternal(url: string) {
   return url.startsWith('/.netlify/')
 }
 
-/**
- * @param {boolean|number|undefined} functionsPort
- * @param {string} url
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'functionsPort' implicitly has an 'any' ... Remove this comment to see the full error message
-function isFunction(functionsPort, url) {
+function isFunction(functionsPort: boolean | number | undefined, url: string) {
   return functionsPort && url.match(DEFAULT_FUNCTION_URL_EXPRESSION)
 }
 
-/**
- * @param {Record<string, string>} addonsUrls
- * @param {http.IncomingMessage} req
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'addonsUrls' implicitly has an 'any' typ... Remove this comment to see the full error message
-function getAddonUrl(addonsUrls, req) {
+function getAddonUrl(addonsUrls: Record<string, string>, req: http.IncomingMessage) {
   const matches = req.url?.match(/^\/.netlify\/([^/]+)(\/.*)/)
   const addonUrl = matches && addonsUrls[matches[1]]
   return addonUrl ? `${addonUrl}${matches[2]}` : null
 }
 
-/**
- * @param {string} pathname
- * @param {string} publicFolder
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'pathname' implicitly has an 'any' type.
-const getStatic = async function (pathname, publicFolder) {
+const getStatic = async function (pathname: string, publicFolder: string) {
   const alternatives = [pathname, ...alternativePathsFor(pathname)].map((filePath) =>
     path.resolve(publicFolder, filePath.slice(1)),
   )


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes https://linear.app/netlify/issue/COM-549/monorepo-with-edge-functions-ssr-returning-404-since-cli-v-17193

Fixes a regression that was introduced with #6433 

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
