### PR TITLE
fix: replace bad doc URL in output

### DIFF
--- a/src/utils/detect-server-settings.ts
+++ b/src/utils/detect-server-settings.ts
@@ -94,7 +94,7 @@ const DEFAULT_STATIC_PORT = 3999
 const getDefaultDist = (workingDir: string) => {
   log(`${NETLIFYDEVWARN} Unable to determine public folder to serve files from. Using current working directory`)
   log(`${NETLIFYDEVWARN} Setup a netlify.toml file with a [dev] section to specify your dev server settings.`)
-  log(`${NETLIFYDEVWARN} See docs at: https://cli.netlify.com/netlify-dev#project-detection`)
+  log(`${NETLIFYDEVWARN} See docs at: https://docs.netlify.com/cli/local-development/#project-detection`)
   return workingDir
 }
 

--- a/tests/integration/__snapshots__/framework-detection.test.js.snap
+++ b/tests/integration/__snapshots__/framework-detection.test.js.snap
@@ -5,7 +5,7 @@ exports[`frameworks/framework-detection > should default to process.cwd() and st
 ◈ No app server detected. Using simple static server
 ◈ Unable to determine public folder to serve files from. Using current working directory
 ◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
-◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
+◈ See docs at: https://docs.netlify.com/cli/local-development/#project-detection
 ◈ Running static server from \\"site-with-index-file\\"
 ◈ Setting up local development server
 
@@ -34,7 +34,7 @@ exports[`frameworks/framework-detection > should filter frameworks with no dev c
 ◈ No app server detected. Using simple static server
 ◈ Unable to determine public folder to serve files from. Using current working directory
 ◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
-◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
+◈ See docs at: https://docs.netlify.com/cli/local-development/#project-detection
 ◈ Running static server from \\"site-with-gulp\\"
 ◈ Setting up local development server
 
@@ -73,7 +73,7 @@ exports[`frameworks/framework-detection > should not run framework detection if 
 "◈ Netlify Dev ◈
 ◈ Unable to determine public folder to serve files from. Using current working directory
 ◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
-◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
+◈ See docs at: https://docs.netlify.com/cli/local-development/#project-detection
 ◈ Setting up local development server
 ◈ Starting Netlify Dev with custom config
 hello
@@ -96,7 +96,7 @@ exports[`frameworks/framework-detection > should print specific error when comma
 "◈ Netlify Dev ◈
 ◈ Unable to determine public folder to serve files from. Using current working directory
 ◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
-◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
+◈ See docs at: https://docs.netlify.com/cli/local-development/#project-detection
 ◈ Setting up local development server
 ◈ Starting Netlify Dev with #custom
 ◈ Failed running command: oops-i-did-it-again forgot-to-use-a-valid-command. Please verify 'oops-i-did-it-again' exists"
@@ -179,7 +179,7 @@ exports[`frameworks/framework-detection > should use static server when framewor
 ◈ Using simple static server because '[dev.framework]' was set to '#static'
 ◈ Unable to determine public folder to serve files from. Using current working directory
 ◈ Setup a netlify.toml file with a [dev] section to specify your dev server settings.
-◈ See docs at: https://cli.netlify.com/netlify-dev#project-detection
+◈ See docs at: https://docs.netlify.com/cli/local-development/#project-detection
 ◈ Running static server from \\"site-with-index-file\\"
 ◈ Setting up local development server
 


### PR DESCRIPTION
#### Summary

When the framework isn't detected, a message is printed to stdout. Currently, this includes a link to a page that provides no useful information about framework detection. This replaces the URL with an actionable one.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://github.com/netlify/cli/assets/1377702/cfac5ac2-ef90-4ff1-bd7b-fdf076aa8b49)
