### PR TITLE
fix: add `uncachedEdgeURL` to Blobs context

### DIFF
--- a/src/lib/blobs/blobs.ts
+++ b/src/lib/blobs/blobs.ts
@@ -16,6 +16,7 @@ export interface BlobsContext {
   edgeURL: string
   siteID: string
   token: string
+  uncachedEdgeURL: string
 }
 
 const printLocalBlobsNotice = () => {
@@ -58,11 +59,13 @@ interface GetBlobsContextOptions {
 export const getBlobsContext = async ({ debug, projectRoot, siteID }: GetBlobsContextOptions) => {
   const token = uuidv4()
   const { port } = await startBlobsServer(debug, projectRoot, token)
+  const url = `http://localhost:${port}`
   const context: BlobsContext = {
     deployID: '0',
-    edgeURL: `http://localhost:${port}`,
+    edgeURL: url,
     siteID,
     token,
+    uncachedEdgeURL: url,
   }
 
   return context

--- a/tests/integration/commands/dev/dev.config.test.js
+++ b/tests/integration/commands/dev/dev.config.test.js
@@ -179,10 +179,13 @@ describe.concurrent('commands/dev/config', () => {
 
         t.expect(NETLIFY_BLOBS_CONTEXT).toBeTypeOf('string')
 
-        const { deployID, edgeURL, siteID, token } = JSON.parse(Buffer.from(NETLIFY_BLOBS_CONTEXT, 'base64').toString())
+        const { deployID, edgeURL, siteID, token, uncachedEdgeURL } = JSON.parse(
+          Buffer.from(NETLIFY_BLOBS_CONTEXT, 'base64').toString(),
+        )
 
         t.expect(deployID).toBe('0')
         t.expect(edgeURL.startsWith('http://localhost:')).toBeTruthy()
+        t.expect(uncachedEdgeURL.startsWith('http://localhost:')).toBeTruthy()
         t.expect(siteID).toBeTypeOf('string')
         t.expect(token).toBeTypeOf('string')
 


### PR DESCRIPTION
#### Summary

Adds `uncachedEdgeURL` to local Blobs context for `ntl dev` and `ntl serve`.

Fixes COM-551.