### PR TITLE
feat: load edge functions bootstrap from module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@netlify/build-info": "7.13.2",
         "@netlify/config": "20.12.1",
         "@netlify/edge-bundler": "11.3.0",
-        "@netlify/edge-functions": "2.4.3",
+        "@netlify/edge-functions": "^2.5.1",
         "@netlify/local-functions-proxy": "1.1.1",
         "@netlify/zip-it-and-ship-it": "9.31.1",
         "@octokit/rest": "19.0.13",
@@ -3767,9 +3767,9 @@
       }
     },
     "node_modules/@netlify/edge-functions": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.4.3.tgz",
-      "integrity": "sha512-Ts2kUR0KM/7qlIDpJ+ZIZBrRpx6OL3BwrYUR2/sQDAe/8VajoO+Voit/H7xd6Qj6EPBHC56jlWdyFuTHY1HB8Q=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.5.1.tgz",
+      "integrity": "sha512-6YGlbzxPaSqc/D2LhP4T4PXrim/vRmqpO1RwQKqVod6WCWlkdtJcAd3mGoI7efrjfND8twh7TqXtL7RRCI23qA=="
     },
     "node_modules/@netlify/eslint-config-node": {
       "version": "7.0.0",
@@ -26483,9 +26483,9 @@
       }
     },
     "@netlify/edge-functions": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.4.3.tgz",
-      "integrity": "sha512-Ts2kUR0KM/7qlIDpJ+ZIZBrRpx6OL3BwrYUR2/sQDAe/8VajoO+Voit/H7xd6Qj6EPBHC56jlWdyFuTHY1HB8Q=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.5.1.tgz",
+      "integrity": "sha512-6YGlbzxPaSqc/D2LhP4T4PXrim/vRmqpO1RwQKqVod6WCWlkdtJcAd3mGoI7efrjfND8twh7TqXtL7RRCI23qA=="
     },
     "@netlify/eslint-config-node": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@netlify/build-info": "7.13.2",
         "@netlify/config": "20.12.1",
         "@netlify/edge-bundler": "11.3.0",
+        "@netlify/edge-functions": "2.4.3",
         "@netlify/local-functions-proxy": "1.1.1",
         "@netlify/zip-it-and-ship-it": "9.31.1",
         "@octokit/rest": "19.0.13",
@@ -3644,6 +3645,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@netlify/edge-functions": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.4.3.tgz",
+      "integrity": "sha512-Ts2kUR0KM/7qlIDpJ+ZIZBrRpx6OL3BwrYUR2/sQDAe/8VajoO+Voit/H7xd6Qj6EPBHC56jlWdyFuTHY1HB8Q=="
     },
     "node_modules/@netlify/eslint-config-node": {
       "version": "7.0.0",
@@ -26457,6 +26463,11 @@
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
         }
       }
+    },
+    "@netlify/edge-functions": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.4.3.tgz",
+      "integrity": "sha512-Ts2kUR0KM/7qlIDpJ+ZIZBrRpx6OL3BwrYUR2/sQDAe/8VajoO+Voit/H7xd6Qj6EPBHC56jlWdyFuTHY1HB8Q=="
     },
     "@netlify/eslint-config-node": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@netlify/build-info": "7.13.2",
         "@netlify/config": "20.12.1",
         "@netlify/edge-bundler": "11.3.0",
-        "@netlify/edge-functions": "^2.5.1",
+        "@netlify/edge-functions": "2.5.1",
         "@netlify/local-functions-proxy": "1.1.1",
         "@netlify/zip-it-and-ship-it": "9.31.1",
         "@octokit/rest": "19.0.13",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@netlify/build-info": "7.13.2",
     "@netlify/config": "20.12.1",
     "@netlify/edge-bundler": "11.3.0",
+    "@netlify/edge-functions": "2.4.3",
     "@netlify/local-functions-proxy": "1.1.1",
     "@netlify/zip-it-and-ship-it": "9.31.1",
     "@octokit/rest": "19.0.13",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@netlify/build-info": "7.13.2",
     "@netlify/config": "20.12.1",
     "@netlify/edge-bundler": "11.3.0",
-    "@netlify/edge-functions": "2.4.3",
+    "@netlify/edge-functions": "^2.5.1",
     "@netlify/local-functions-proxy": "1.1.1",
     "@netlify/zip-it-and-ship-it": "9.31.1",
     "@octokit/rest": "19.0.13",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@netlify/build-info": "7.13.2",
     "@netlify/config": "20.12.1",
     "@netlify/edge-bundler": "11.3.0",
-    "@netlify/edge-functions": "^2.5.1",
+    "@netlify/edge-functions": "2.5.1",
     "@netlify/local-functions-proxy": "1.1.1",
     "@netlify/zip-it-and-ship-it": "9.31.1",
     "@octokit/rest": "19.0.13",

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -589,7 +589,7 @@ const bundleEdgeFunctions = async (options, command: BaseCommand) => {
     packagePath: command.workspacePackage,
     buffer: true,
     featureFlags: edgeFunctionsFeatureFlags,
-    edgeFunctionsBootstrapURL: getBootstrapURL(),
+    edgeFunctionsBootstrapURL: await getBootstrapURL(),
   })
 
   if (!success) {

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -30,7 +30,7 @@ import { featureFlags as edgeFunctionsFeatureFlags } from './edge-functions/cons
  * @param {*} config.deployHandler
  * @returns {BuildConfig}
  */
-export const getBuildOptions = ({
+export const getBuildOptions = async ({
   // @ts-expect-error TS(7031) FIXME: Binding element 'cachedConfig' implicitly has an '... Remove this comment to see the full error message
   cachedConfig,
   // @ts-expect-error TS(7031) FIXME: Binding element 'currentDir' implicitly has an 'an... Remove this comment to see the full error message
@@ -89,7 +89,7 @@ export const getBuildOptions = ({
       functionsBundlingManifest: true,
     },
     eventHandlers,
-    edgeFunctionsBootstrapURL: getBootstrapURL(),
+    edgeFunctionsBootstrapURL: await getBootstrapURL(),
   }
 }
 

--- a/src/lib/edge-functions/bootstrap.ts
+++ b/src/lib/edge-functions/bootstrap.ts
@@ -4,6 +4,8 @@ import { getURL } from '@netlify/edge-functions/version'
 
 import { isNodeError, warn } from '../../utils/command-helpers.js'
 
+export const FALLBACK_BOOTSTRAP_URL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
+
 export const getBootstrapURL = async () => {
   if (env.NETLIFY_EDGE_BOOTSTRAP) {
     return env.NETLIFY_EDGE_BOOTSTRAP
@@ -19,6 +21,6 @@ export const getBootstrapURL = async () => {
     // If there was an error getting the bootstrap URL from the module, let's
     // use the latest version of the bootstrap. This is not ideal, but better
     // than failing to serve requests with edge functions.
-    return 'https://edge.netlify.com/bootstrap/index-combined.ts'
+    return FALLBACK_BOOTSTRAP_URL
   }
 }

--- a/src/lib/edge-functions/bootstrap.ts
+++ b/src/lib/edge-functions/bootstrap.ts
@@ -2,7 +2,7 @@ import { env } from 'process'
 
 import { getURL } from '@netlify/edge-functions/version'
 
-import { isNodeError, warn } from '../../utils/command-helpers.js'
+import { warn } from '../../utils/command-helpers.js'
 
 export const FALLBACK_BOOTSTRAP_URL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
 
@@ -14,9 +14,7 @@ export const getBootstrapURL = async () => {
   try {
     return await getURL()
   } catch (error) {
-    if (isNodeError(error)) {
-      warn(error.message)
-    }
+    warn(`Could not load latest version of Edge Functions environment: ${(error as NodeJS.ErrnoException)?.message}`)
 
     // If there was an error getting the bootstrap URL from the module, let's
     // use the latest version of the bootstrap. This is not ideal, but better

--- a/src/lib/edge-functions/bootstrap.ts
+++ b/src/lib/edge-functions/bootstrap.ts
@@ -1,5 +1,24 @@
 import { env } from 'process'
 
-const latestBootstrapURL = 'https://65f9b38dc160de0008d35515--edge.netlify.com/bootstrap/index-combined.ts'
+import { getURL } from '@netlify/edge-functions/version'
 
-export const getBootstrapURL = () => env.NETLIFY_EDGE_BOOTSTRAP || latestBootstrapURL
+import { isNodeError, warn } from '../../utils/command-helpers.js'
+
+export const getBootstrapURL = async () => {
+  if (env.NETLIFY_EDGE_BOOTSTRAP) {
+    return env.NETLIFY_EDGE_BOOTSTRAP
+  }
+
+  try {
+    return await getURL()
+  } catch (error) {
+    if (isNodeError(error)) {
+      warn(error.message)
+    }
+
+    // If there was an error getting the bootstrap URL from the module, let's
+    // use the latest version of the bootstrap. This is not ideal, but better
+    // than failing to serve requests with edge functions.
+    return 'https://edge.netlify.com/bootstrap/index-combined.ts'
+  }
+}

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -233,7 +233,7 @@ const prepareServer = async ({
     const runIsolate = await bundler.serve({
       ...getDownloadUpdateFunctions(),
       basePath: projectDir,
-      bootstrapURL: getBootstrapURL(),
+      bootstrapURL: await getBootstrapURL(),
       debug,
       distImportMapPath: join(projectDir, distImportMapPath),
       featureFlags,

--- a/src/utils/run-build.ts
+++ b/src/utils/run-build.ts
@@ -84,7 +84,7 @@ export const runNetlifyBuild = async ({
     cwd: cachedConfig.buildDir,
     quiet: options.quiet,
     saveConfig: options.saveConfig,
-    edgeFunctionsBootstrapURL: getBootstrapURL(),
+    edgeFunctionsBootstrapURL: await getBootstrapURL(),
   }
 
   const devCommand = async (settingsOverrides = {}) => {

--- a/tests/unit/lib/edge-functions/bootstrap.test.js
+++ b/tests/unit/lib/edge-functions/bootstrap.test.js
@@ -1,0 +1,32 @@
+import { env } from 'process'
+
+import { describe, expect, test } from 'vitest'
+
+import { getBootstrapURL, FALLBACK_BOOTSTRAP_URL } from '../../../../dist/lib/edge-functions/bootstrap.js'
+
+describe('`getBootstrapURL()`', () => {
+  test('Returns the URL in the `NETLIFY_EDGE_BOOTSTRAP` URL, if set', async () => {
+    const mockBootstrapURL = 'https://edge.netlify/bootstrap.ts'
+
+    env.NETLIFY_EDGE_BOOTSTRAP = mockBootstrapURL
+
+    const bootstrapURL = await getBootstrapURL()
+
+    delete env.NETLIFY_EDGE_BOOTSTRAP
+
+    expect(bootstrapURL).toEqual(mockBootstrapURL)
+  })
+
+  test('Returns a publicly accessible URL', async () => {
+    const bootstrapURL = await getBootstrapURL()
+
+    // We shouldn't get the fallback URL, because that means we couldn't get
+    // the URL from the `@netlify/edge-functions` module.
+    expect(bootstrapURL).not.toBe(FALLBACK_BOOTSTRAP_URL)
+
+    const res = await fetch(bootstrapURL)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type').startsWith('application/typescript')).toBe(true)
+  })
+})


### PR DESCRIPTION
#### Summary

Rather than having to manually update the version of the edge functions bootstrap every time there's a new release, this PR loads the bootstrap URL from the `@netlify/edge-functions` module. When there's a new version of the bootstrap, we'll release a new version of the module and Renovate will kick the usual update routine, meaning we'll have a semi-automated way of keeping the bootstrap up-to-date.