### PR TITLE
fix: revert get-port dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "folder-walker": "3.2.0",
         "from2-array": "0.0.4",
         "fuzzy": "0.1.3",
-        "get-port": "7.1.0",
+        "get-port": "5.1.1",
         "gh-release-fetch": "4.0.3",
         "git-repo-info": "2.1.1",
         "gitconfiglocal": "2.1.0",
@@ -13679,11 +13679,11 @@
       }
     },
     "node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -34194,9 +34194,9 @@
       "integrity": "sha512-LmCKVxioe63Fy6KDAQ/mmCSOSSRUE/x4zdrMD+7dU8quF3bGpzvP8mOmq4Dgce3nzU9AgkVDotucNOOg7c27BQ=="
     },
     "get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-port-please": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "folder-walker": "3.2.0",
     "from2-array": "0.0.4",
     "fuzzy": "0.1.3",
-    "get-port": "7.1.0",
+    "get-port": "5.1.1",
     "gh-release-fetch": "4.0.3",
     "git-repo-info": "2.1.1",
     "gitconfiglocal": "2.1.0",


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary
The `get-port` dependency update has been reverted back to `5.1.1` as users were reporting that they were not able to acquire ports that they required as part of their development workflow. One such port that was affected was `443`, but others around that range were also affected.

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
