### PR TITLE
fix: bug around v1 functions with `nodeModuleFormat: "esm"`

### DIFF
--- a/src/lib/functions/registry.ts
+++ b/src/lib/functions/registry.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, stat } from 'fs/promises'
+import { mkdir, stat } from 'fs/promises'
 import { createRequire } from 'module'
 import { basename, extname, isAbsolute, join, resolve } from 'path'
 import { env } from 'process'
@@ -434,13 +434,7 @@ export class FunctionsRegistry {
 
         func.mainFile = v2EntryPointPath
       } catch {
-        const files = await readdir(unzippedDirectory)
-        func.mainFile = join(
-          unzippedDirectory,
-          files.find(
-            (file) => file === `${func.name}.mjs` || file === `${func.name}.js` || file === `${func.name}.cjs`,
-          ) ?? `${func.name}.js`,
-        )
+        func.mainFile = join(unzippedDirectory, `${func.name}${extname(manifestEntry.mainFile)}`)
       }
     } else {
       this.buildFunctionAndWatchFiles(func, !isReload)

--- a/src/lib/functions/registry.ts
+++ b/src/lib/functions/registry.ts
@@ -434,7 +434,7 @@ export class FunctionsRegistry {
 
         func.mainFile = v2EntryPointPath
       } catch {
-        func.mainFile = join(unzippedDirectory, `${func.name}${extname(manifestEntry.mainFile)}`)
+        func.mainFile = join(unzippedDirectory, basename(manifestEntry.mainFile))
       }
     } else {
       this.buildFunctionAndWatchFiles(func, !isReload)

--- a/src/lib/functions/registry.ts
+++ b/src/lib/functions/registry.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat } from 'fs/promises'
+import { mkdir, readdir, stat } from 'fs/promises'
 import { createRequire } from 'module'
 import { basename, extname, isAbsolute, join, resolve } from 'path'
 import { env } from 'process'
@@ -434,7 +434,13 @@ export class FunctionsRegistry {
 
         func.mainFile = v2EntryPointPath
       } catch {
-        func.mainFile = join(unzippedDirectory, `${func.name}.js`)
+        const files = await readdir(unzippedDirectory)
+        func.mainFile = join(
+          unzippedDirectory,
+          files.find(
+            (file) => file === `${func.name}.mjs` || file === `${func.name}.js` || file === `${func.name}.cjs`,
+          ) ?? `${func.name}.js`,
+        )
       }
     } else {
       this.buildFunctionAndWatchFiles(func, !isReload)

--- a/src/lib/functions/runtimes/js/index.ts
+++ b/src/lib/functions/runtimes/js/index.ts
@@ -6,10 +6,12 @@ import { Worker } from 'worker_threads'
 import lambdaLocal from 'lambda-local'
 
 import { BLOBS_CONTEXT_VARIABLE } from '../../../blobs/blobs.js'
+import type NetlifyFunction from '../../netlify-function.js'
 
 import detectNetlifyLambdaBuilder from './builders/netlify-lambda.js'
 import detectZisiBuilder, { parseFunctionForMetadata } from './builders/zisi.js'
 import { SECONDS_TO_MILLISECONDS } from './constants.js'
+import { $TSFixMe } from '../../../../commands/types.js'
 
 export const name = 'js'
 
@@ -99,11 +101,21 @@ export const invokeFunction = async ({ context, environment, event, func, timeou
   })
 }
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'context' implicitly has an 'any' ... Remove this comment to see the full error message
-export const invokeFunctionDirectly = async ({ context, event, func, timeout }) => {
+export const invokeFunctionDirectly = async ({
+  context,
+  event,
+  func,
+  timeout,
+}: {
+  context: $TSFixMe
+  event: $TSFixMe
+  func: NetlifyFunction
+  timeout: number
+}) => {
   // If a function builder has defined a `buildPath` property, we use it.
   // Otherwise, we'll invoke the function's main file.
-  const lambdaPath = func.buildData?.buildPath ?? func.mainFile
+  const { buildPath } = await func.getBuildData()
+  const lambdaPath = buildPath ?? func.mainFile
   const result = await lambdaLocal.execute({
     clientContext: JSON.stringify(context),
     environment: {

--- a/src/lib/functions/runtimes/js/index.ts
+++ b/src/lib/functions/runtimes/js/index.ts
@@ -118,6 +118,7 @@ export const invokeFunctionDirectly = async ({ context, event, func, timeout }) 
     lambdaPath,
     timeoutMs: timeout * SECONDS_TO_MILLISECONDS,
     verboseLevel: 3,
+    esm: lambdaPath.endsWith('.mjs'),
   })
 
   return result

--- a/tests/integration/commands/dev/functions.test.ts
+++ b/tests/integration/commands/dev/functions.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'vitest'
+
+import { withDevServer } from '../../utils/dev-server'
+import { withSiteBuilder } from '../../utils/site-builder'
+
+test('nodeModuleFormat: esm v1 functions should work', async (t) => {
+  await withSiteBuilder(t, async (builder) => {
+    await builder
+      .withNetlifyToml({
+        config: {
+          plugins: [{ package: './plugins/setup-functions' }],
+        },
+      })
+      .withBuildPlugin({
+        name: 'setup-functions',
+        plugin: {
+          onBuild: async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, n/global-require
+            const { mkdir, writeFile } = require('node:fs/promises')
+            await mkdir('.netlify/functions-internal', { recursive: true })
+            await writeFile(
+              '.netlify/functions-internal/server.json',
+              JSON.stringify({
+                config: {
+                  nodeModuleFormat: 'esm',
+                },
+                version: 1,
+              }),
+            )
+
+            await writeFile(
+              '.netlify/functions-internal/server.mjs',
+              `
+              export async function handler(event, context) {
+                return {
+                  statusCode: 200,
+                  body: "This is an internal function.",
+                };
+              }              
+              `,
+            )
+          },
+        },
+      })
+      .build()
+
+    await withDevServer({ cwd: builder.directory, serve: true }, async (server) => {
+      const response = await fetch(new URL('/.netlify/functions/server', server.url))
+      t.expect(await response.text()).toBe("This is an internal function.")
+      t.expect(response.status).toBe(200)
+    })
+  })
+})

--- a/tests/integration/commands/dev/functions.test.ts
+++ b/tests/integration/commands/dev/functions.test.ts
@@ -46,7 +46,7 @@ test('nodeModuleFormat: esm v1 functions should work', async (t) => {
 
     await withDevServer({ cwd: builder.directory, serve: true }, async (server) => {
       const response = await fetch(new URL('/.netlify/functions/server', server.url))
-      t.expect(await response.text()).toBe("This is an internal function.")
+      t.expect(await response.text()).toBe('This is an internal function.')
       t.expect(response.status).toBe(200)
     })
   })


### PR DESCRIPTION
Resolves https://linear.app/netlify/issue/COM-434/internal-v1-functions-with-esm-nodemoduleformat-are-broken-in-local