### PR TITLE
chore: added TS to open-browser file

### DIFF
--- a/src/utils/open-browser.ts
+++ b/src/utils/open-browser.ts
@@ -6,8 +6,12 @@ import isDockerContainer from 'is-docker'
 
 import { chalk, log } from './command-helpers.js'
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'message' implicitly has an 'any' ... Remove this comment to see the full error message
-const unableToOpenBrowserMessage = function ({ message, url }) {
+type BrowserUnableMessage = {
+  message: string
+  url: string
+}
+
+const unableToOpenBrowserMessage = function ({ message, url }: BrowserUnableMessage) {
   log('---------------------------')
   log(chalk.redBright(`Error: Unable to open browser automatically: ${message}`))
   log(chalk.cyan('Please open your browser and open the URL below:'))
@@ -15,15 +19,12 @@ const unableToOpenBrowserMessage = function ({ message, url }) {
   log('---------------------------')
 }
 
-/**
- * Opens a browser and logs a message if it is not possible
- * @param {object} config
- * @param {string} config.url The url to open
- * @param {boolean} [config.silentBrowserNoneError]
- * @returns {Promise<void>}
- */
-// @ts-expect-error TS(7031) FIXME: Binding element 'silentBrowserNoneError' implicitl... Remove this comment to see the full error message
-const openBrowser = async function ({ silentBrowserNoneError, url }) {
+type OpenBrowsrProps = {
+  silentBrowserNoneError: boolean
+  url: string
+}
+
+const openBrowser = async function ({ silentBrowserNoneError, url }: OpenBrowsrProps) {
   if (isDockerContainer()) {
     unableToOpenBrowserMessage({ url, message: 'Running inside a docker container' })
     return
@@ -38,8 +39,9 @@ const openBrowser = async function ({ silentBrowserNoneError, url }) {
   try {
     await open(url)
   } catch (error) {
-    // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
-    unableToOpenBrowserMessage({ url, message: error.message })
+    if (error instanceof Error) {
+      unableToOpenBrowserMessage({ url, message: error.message })
+    }
   }
 }
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Added TS to open-browser file. I couldn't find any `@types/open-browser` package in the DefinitelyTyped repo, so left the @ts-expect-error. 


---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
