### PR TITLE
fix: set Blobs region in `serve` command

### DIFF
--- a/src/lib/blobs/blobs.ts
+++ b/src/lib/blobs/blobs.ts
@@ -10,6 +10,7 @@ import { getPathInProject } from '../settings.js'
 interface BaseBlobsContext {
   deployID: string
   siteID: string
+  primaryRegion?: string
   token: string
 }
 
@@ -27,6 +28,7 @@ export type BlobsContext = BlobsContextWithAPIAccess | BlobsContextWithEdgeAcces
 let hasPrintedLocalBlobsNotice = false
 
 export const BLOBS_CONTEXT_VARIABLE = 'NETLIFY_BLOBS_CONTEXT'
+const DEV_REGION = 'dev'
 
 const printLocalBlobsNotice = () => {
   if (hasPrintedLocalBlobsNotice) {
@@ -76,6 +78,7 @@ export const getBlobsContextWithAPIAccess = async ({ debug, projectRoot, siteID 
   const context: BlobsContextWithAPIAccess = {
     apiURL: url,
     deployID: '0',
+    primaryRegion: DEV_REGION,
     siteID,
     token,
   }
@@ -95,10 +98,22 @@ export const getBlobsContextWithEdgeAccess = async ({ debug, projectRoot, siteID
     siteID,
     token,
     uncachedEdgeURL: url,
+    primaryRegion: DEV_REGION,
   }
 
   return context
 }
+
+/**
+ * Returns the Blobs metadata that should be added to the Lambda event when
+ * invoking a serverless function.
+ */
+export const getBlobsEventProperty = (context: BlobsContextWithEdgeAccess) => ({
+  primary_region: context.primaryRegion,
+  url: context.edgeURL,
+  url_uncached: context.edgeURL,
+  token: context.token,
+})
 
 /**
  * Returns a Base-64, JSON-encoded representation of the Blobs context. This is

--- a/src/lib/functions/netlify-function.ts
+++ b/src/lib/functions/netlify-function.ts
@@ -7,7 +7,7 @@ import semver from 'semver'
 
 import { error as errorExit } from '../../utils/command-helpers.js'
 import { BACKGROUND } from '../../utils/functions/get-functions.js'
-import type { BlobsContextWithEdgeAccess } from '../blobs/blobs.js'
+import { BlobsContextWithEdgeAccess, getBlobsEventProperty } from '../blobs/blobs.js'
 
 const TYPESCRIPT_EXTENSIONS = new Set(['.cts', '.mts', '.ts'])
 const V2_MIN_NODE_VERSION = '18.14.0'
@@ -237,11 +237,7 @@ export default class NetlifyFunction {
     const environment = {}
 
     if (this.blobsContext) {
-      const payload = JSON.stringify({
-        url: this.blobsContext.edgeURL,
-        url_uncached: this.blobsContext.edgeURL,
-        token: this.blobsContext.token,
-      })
+      const payload = JSON.stringify(getBlobsEventProperty(this.blobsContext))
 
       // @ts-expect-error TS(2339) FIXME: Property 'blobs' does not exist on type '{}'.
       event.blobs = Buffer.from(payload).toString('base64')


### PR DESCRIPTION
#### Summary

Sets the right metadata properties in the Blobs context for the `experimentalRegion` property to work correctly in the `serve` command.

Fixes FRA-503.