### PR TITLE
fix: fix funky apostrophe on "now logged in" page

### DIFF
--- a/src/utils/gh-auth.ts
+++ b/src/utils/gh-auth.ts
@@ -56,7 +56,7 @@ export const authWithNetlify = async () => {
       res.end(
         `${
           "<html><head><title>Logged in</title><script>if(history.replaceState){history.replaceState({},'','/')}</script><style>html{font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';line-height:1.5;background:rgb(18 24 31)}body{overflow:hidden;position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;width:100vw;}h3{margin:0}p{margin: 1rem 0 0.5rem}.card{position:relative;display:flex;flex-direction:column;width:75%;max-width:364px;padding:24px;background:white;color:rgb(18 24 31);border-radius:8px;box-shadow:rgb(6 11 16 / 20%) 0px 16px 24px, rgb(6 11 16 / 30%) 0px 6px 30px, rgb(6 11 16 / 40%) 0px 8px 10px;}</style></head>" +
-          '<body><div class=card><h3>Logged in</h3><p>You’re now logged into Netlify CLI with your '
+          "<body><div class=card><h3>Logged in</h3><p>You're now logged into Netlify CLI with your "
         }${parameters.get('provider')} credentials. Please close this window.</p></div>`,
       )
       server.close()


### PR DESCRIPTION
#### Summary

After authenticating in the browser, the CLI renders this page: ![Screenshot 2024-05-14 at 17 10 28](https://github.com/netlify/cli/assets/1377702/b0bc9b2e-8396-4f71-9df4-421dc56d43ca)

This gives a bit of a bad first impression!

The better fix might be to set the right encoding on the response or something, but this seemed easy enough for now.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://github.com/netlify/cli/assets/1377702/f5ea0eeb-45b6-4503-bc68-8d97a257d354)
