### PR TITLE
fix: serve function support in monorepos

### DIFF
--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -10,6 +10,7 @@ import { jwtDecode } from 'jwt-decode'
 import type BaseCommand from '../../commands/base-command.js'
 import type { $TSFixMe } from '../../commands/types.js'
 import { NETLIFYDEVERR, NETLIFYDEVLOG, error as errorExit, log } from '../../utils/command-helpers.js'
+import { UNLINKED_SITE_MOCK_ID } from '../../utils/dev.js'
 import { isFeatureFlagEnabled } from '../../utils/feature-flags.js'
 import {
   CLOCKWORK_USERAGENT,
@@ -22,7 +23,6 @@ import type { BlobsContext } from '../blobs/blobs.js'
 import { headers as efHeaders } from '../edge-functions/headers.js'
 import { getGeoLocation } from '../geo-location.js'
 
-import { UNLINKED_SITE_MOCK_ID } from '../../utils/dev.js'
 import { handleBackgroundFunction, handleBackgroundFunctionResult } from './background.js'
 import { createFormSubmissionHandler } from './form-submissions-handler.js'
 import { FunctionsRegistry } from './registry.js'
@@ -56,13 +56,13 @@ const buildClientContext = function (headers) {
     const user = jwtDecode(parts[1])
 
     const netlifyContext = JSON.stringify({
-      identity: identity,
-      user: user,
+      identity,
+      user,
     })
 
     return {
-      identity: identity,
-      user: user,
+      identity,
+      user,
       custom: {
         netlify: Buffer.from(netlifyContext).toString('base64'),
       },
@@ -320,7 +320,7 @@ export const startFunctionsServer = async (
     siteUrl,
     timeouts,
   } = options
-  const internalFunctionsDir = await getInternalFunctionsDir({ base: site.root })
+  const internalFunctionsDir = await getInternalFunctionsDir({ base: site.root, packagePath: command.workspacePackage })
   const functionsDirectories: string[] = []
   let manifest
 
@@ -328,7 +328,7 @@ export const startFunctionsServer = async (
   // use the built functions created by zip-it-and-ship-it rather than building
   // them from source.
   if (loadDistFunctions) {
-    const distPath = await getFunctionsDistPath({ base: site.root })
+    const distPath = await getFunctionsDistPath({ base: site.root, packagePath: command.workspacePackage })
 
     if (distPath) {
       functionsDirectories.push(distPath)
@@ -354,7 +354,7 @@ export const startFunctionsServer = async (
   }
 
   try {
-    const functionsServePath = getFunctionsServePath({ base: site.root })
+    const functionsServePath = getFunctionsServePath({ base: site.root, packagePath: command.workspacePackage })
 
     await fs.rm(functionsServePath, { force: true, recursive: true })
   } catch {

--- a/src/utils/functions/functions.ts
+++ b/src/utils/functions/functions.ts
@@ -19,24 +19,21 @@ export const SERVE_FUNCTIONS_FOLDER = 'functions-serve'
 export const getFunctionsDir = ({ config, options }, defaultValue) =>
   options.functions || config.dev?.functions || config.functionsDirectory || config.dev?.Functions || defaultValue
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'base' implicitly has an 'any' typ... Remove this comment to see the full error message
-export const getFunctionsManifestPath = async ({ base, packagePath = '' }) => {
+export const getFunctionsManifestPath = async ({ base, packagePath = '' }: { base: string; packagePath?: string }) => {
   const path = resolve(base, packagePath, getPathInProject(['functions', 'manifest.json']))
   const isFile = await isFileAsync(path)
 
   return isFile ? path : null
 }
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'base' implicitly has an 'any' typ... Remove this comment to see the full error message
-export const getFunctionsDistPath = async ({ base, packagePath = '' }) => {
+export const getFunctionsDistPath = async ({ base, packagePath = '' }: { base: string; packagePath?: string }) => {
   const path = resolve(base, packagePath, getPathInProject(['functions']))
   const isDirectory = await isDirectoryAsync(path)
 
   return isDirectory ? path : null
 }
 
-// @ts-expect-error TS(7031) FIXME: Binding element 'base' implicitly has an 'any' typ... Remove this comment to see the full error message
-export const getFunctionsServePath = ({ base, packagePath = '' }) => {
+export const getFunctionsServePath = ({ base, packagePath = '' }: { base: string; packagePath?: string }) => {
   const path = resolve(base, packagePath, getPathInProject([SERVE_FUNCTIONS_FOLDER]))
 
   return path


### PR DESCRIPTION
#### Summary

Fixes [#CT-1145](https://linear.app/netlify/issue/CT-1145/internal-functions-not-running-locally-in-monorepos)

`ntl serve` was skipping including `functions-internal`, `functions-dist`, and `functions-serve` because it wasn't able to locate them. Adding the package path into the function call resolves the issue.

Tested with a next monorepo

Before:
![image](https://github.com/netlify/cli/assets/3572990/4368990a-0861-46ad-9bee-bb652e544d8e)

After:
![image](https://github.com/netlify/cli/assets/3572990/b3ef4ef2-dd3e-4c0a-996e-f73eb6080251)
(Even though it's an error, we know it's being registered now)
