### PR TITLE
Locally emulated Identity service URL should use .app

### DIFF
--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -39,7 +39,7 @@ const buildClientContext = function (headers) {
   if (parts.length !== 2 || parts[0] !== 'Bearer') return
 
   const identity = {
-    url: 'https://netlify-dev-locally-emulated-identity.netlify.com/.netlify/identity',
+    url: 'https://netlify-dev-locally-emulated-identity.netlify.app/.netlify/identity',
     token:
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb3VyY2UiOiJuZXRsaWZ5IGRldiIsInRlc3REYXRhIjoiTkVUTElGWV9ERVZfTE9DQUxMWV9FTVVMQVRFRF9JREVOVElUWSJ9.2eSDqUOZAOBsx39FHFePjYj12k0LrxldvGnlvDu3GMI',
     // you can decode this with https://jwt.io/

--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -177,12 +177,12 @@ describe.concurrent('commands/dev-miscellaneous', () => {
         }).then((res) => res.json())
 
         t.expect(response.clientContext.identity.url).toEqual(
-          'https://netlify-dev-locally-emulated-identity.netlify.com/.netlify/identity',
+          'https://netlify-dev-locally-emulated-identity.netlify.app/.netlify/identity',
         )
 
         const netlifyContext = Buffer.from(response.clientContext.custom.netlify, 'base64').toString()
         t.expect(JSON.parse(netlifyContext).identity.url).toEqual(
-          'https://netlify-dev-locally-emulated-identity.netlify.com/.netlify/identity',
+          'https://netlify-dev-locally-emulated-identity.netlify.app/.netlify/identity',
         )
       })
     })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes CT-1153

Following this change by Netlify: https://answers.netlify.com/t/deprecating-automatic-com-redirects/115442

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] ~Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.~
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] ~Update or add documentation (if features were changed or added) 📝~
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
