### PR TITLE
test: skip test on windows due to unexpected fetch behaviour

### DIFF
--- a/tests/integration/commands/dev/dev-miscellaneous.test.js
+++ b/tests/integration/commands/dev/dev-miscellaneous.test.js
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer'
 import path from 'path'
+import { platform } from 'process'
 import { fileURLToPath } from 'url'
 
 import { setProperty } from 'dot-prop'
@@ -751,7 +752,8 @@ describe.concurrent('commands/dev-miscellaneous', () => {
     })
   })
 
-  test('should detect content changes in edge functions', async (t) => {
+  // on windows, fetch throws an error while files are refreshing instead of returning the old value
+  test.skipIf(platform === 'win32')('should detect content changes in edge functions', async (t) => {
     await withSiteBuilder(t, async (builder) => {
       const publicDir = 'public'
       builder


### PR DESCRIPTION
#### Summary

Fixes tests for https://github.com/netlify/cli/pull/6235
See [discussion](https://github.com/netlify/cli/pull/6235#discussion_r1596798506) for more information on the behaviour

We opted to skip the test on windows as edge functions will not be hosted on windows machines in production, and during local development there is no need for a short refresh window (< 1s)

Confirmed test passes / gets skipped on windows with these changes

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅