### PR TITLE
fix: un-awaited prompt when creating edge function from template  

### DIFF
--- a/src/commands/functions/functions-create.ts
+++ b/src/commands/functions/functions-create.ts
@@ -551,7 +551,7 @@ const scaffoldFromTemplate = async function (command, options, argumentName, fun
     }
 
     if (funcType === 'edge') {
-      registerEFInToml(name, command.netlify)
+      await registerEFInToml(name, command.netlify)
     }
 
     await installAddons(command, addons, path.resolve(functionPath))


### PR DESCRIPTION
#### Summary

Fixes CT-1060

When creating an edge function from a template, we weren't awaiting the step where we prompted the user for the route to register the edge function on, leading to the prompt being interrupted by the "Function created!" success message as the rest of `scaffoldFromTemplate` executed. This sometimes appeared as the CLI hanging, since the prompt for user input was no longer on the last line, making it easy to overlook that the CLI was waiting for user input.

Unfortunately, difficult to test for this without reworking the `handleQuestions` test helper, which seems daunting right now 😬   

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
here is my cat playing a card game
<img src="https://github.com/netlify/cli/assets/1895116/817831ca-bfb3-4342-aba2-703ab1bfa1cf" width="300" />
