### PR TITLE
fix: dev server - tweak which requests are considered activity

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -800,10 +800,6 @@ const onRequest = async (
     framework: settings.framework,
   }
 
-  if (api && process.env.NETLIFY_DEV_SERVER_ID) {
-    notifyActivity(api, siteInfo.id, process.env.NETLIFY_DEV_SERVER_ID)
-  }
-
   if (match) {
     // We don't want to generate an ETag for 3xx redirects.
     // @ts-expect-error TS(7031) FIXME: Binding element 'statusCode' implicitly has an 'an... Remove this comment to see the full error message
@@ -830,6 +826,10 @@ const onRequest = async (
     (ct.endsWith('/x-www-form-urlencoded') || ct === 'multipart/form-data')
   ) {
     return proxy.web(req, res, { target: functionsServer })
+  }
+
+  if (req.method === 'GET' && api && process.env.NETLIFY_DEV_SERVER_ID) {
+    notifyActivity(api, siteInfo.id, process.env.NETLIFY_DEV_SERVER_ID)
   }
 
   proxy.web(req, res, options)


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Tweak which requests are considered activity. Now we filter out redirects (including to internal plugins) and non-GET requests.

ref CRE-1189

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
