### PR TITLE
fix: load functions timeout from site properly

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -122,7 +122,7 @@ export const getSiteInformation = async ({ api, offline, site, siteInfo }) => {
         backgroundFunctions: supportsBackgroundFunctions(account),
       },
       timeouts: {
-        syncFunctions: siteInfo.functions_config?.timeout ?? SYNCHRONOUS_FUNCTION_TIMEOUT,
+        syncFunctions: siteInfo.functions_timeout ?? siteInfo.functions_config?.timeout ?? SYNCHRONOUS_FUNCTION_TIMEOUT,
         backgroundFunctions: BACKGROUND_FUNCTION_TIMEOUT,
       },
     }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes #6125

When a site has a custom timelimit for functions, its exposed as `function_timelimit` directly on the site object returned from the API. The current CLI code always tries to read it from the generic function_config hash if one is present.

---

**A picture of a cute animal (not mandatory, but encouraged)**

![99676c72-5a6c-48b1-891a-373ceac143f1 (1)](https://github.com/user-attachments/assets/013c9b99-b8ae-4c10-ba43-280e8681d422)
