### PR TITLE
fix: increased the default functions timeout to 30s

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -91,7 +91,7 @@ const getSiteAccount = ({ accounts, siteInfo }) => {
 }
 
 // default 10 seconds for synchronous functions
-const SYNCHRONOUS_FUNCTION_TIMEOUT = 10
+const SYNCHRONOUS_FUNCTION_TIMEOUT = 30
 
 // default 15 minutes for background functions
 const BACKGROUND_FUNCTION_TIMEOUT = 900


### PR DESCRIPTION
#### Summary

Fixes FRP-1293, changing the default local timeout to 30s

**A picture of a cute animal (not mandatory, but encouraged)**

🦫 