### PR TITLE
chore(deps): add missing @types/lodash dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
         "@types/fs-extra": "11.0.4",
         "@types/inquirer": "9.0.7",
         "@types/jsonwebtoken": "9.0.7",
+        "@types/lodash": "^4.17.10",
         "@types/node": "20.14.8",
         "@types/node-fetch": "2.6.11",
         "@types/parse-gitignore": "1.0.2",
@@ -5830,9 +5831,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.195",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
-      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -28157,9 +28158,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.195",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
-      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==",
       "dev": true
     },
     "@types/mdast": {

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/inquirer": "9.0.7",
     "@types/jsonwebtoken": "9.0.7",
+    "@types/lodash": "^4.17.10",
     "@types/node": "20.14.8",
     "@types/node-fetch": "2.6.11",
     "@types/parse-gitignore": "1.0.2",


### PR DESCRIPTION
Because almost every package uses lodash, we always happened to have a copy of @types/lodash end up at the root of our `node_modules` due to a transitive dependency, so this worked out.

I confirmed this fixes that branch locally. I didn't wanna push to it unnecessarily since then Dependabot would stop auto-rebasing it and I am lazy. 😄