### PR TITLE
fix(deploy): fix edge function logs url scope key

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -536,7 +536,7 @@ const runDeploy = async ({
 
   if (!deployToProduction) {
     functionLogsUrl += `?scope=deploy:${deployId}`
-    edgeFunctionLogsUrl += `?scope=deploy:${deployId}`
+    edgeFunctionLogsUrl += `?scope=deployid:${deployId}`
   }
 
   return {

--- a/tests/integration/commands/deploy/deploy.test.ts
+++ b/tests/integration/commands/deploy/deploy.test.ts
@@ -296,7 +296,7 @@ describe.skipIf(process.env.NETLIFY_TEST_DISABLE_LIVE === 'true').concurrent('co
       )
       expect(deploy).toHaveProperty(
         'edge_function_logs',
-        `https://app.netlify.com/sites/${SITE_NAME}/logs/edge-functions?scope=deploy:${deploy.deploy_id}`,
+        `https://app.netlify.com/sites/${SITE_NAME}/logs/edge-functions?scope=deployid:${deploy.deploy_id}`,
       )
     })
   })


### PR DESCRIPTION
Follow-up to https://github.com/netlify/cli/pull/6851.

You can see here it says "Show logs for deploy...": https://app.netlify.com/sites/hydrogen-advanced-caching/logs/edge-functions?scope=deployid:6705473738103f2856071dbd.

This doesn't work with `?scope=deploy:`.

This is a bit of a footgun since the Functions log URL takes `deploy:` but the Edge Functions log URL takes `deployid:`. 😓