### PR TITLE
ci: fix vale by pinning the ubuntu image to 22.04 

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes DOC-1029 by pinning the ubuntu image to 22.04 for the Vale lint docs action. Similar to what we've done for the [SDK](https://github.com/netlify/sdk/pull/1819) and [docs](https://github.com/netlify/docs/pull/4194) repos. 

I'll keep the action disabled for now so that it doesn't impact other PRs but will re-enable it after this is merged and confirm that it works. 

Background info:
- https://github.com/errata-ai/vale-action/issues/128
- https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img src="https://github.com/user-attachments/assets/09f32976-86e0-41f9-8f8d-325fe4058148" height="200">
