### PR TITLE
feat: rename next.js adapter package

### DIFF
--- a/src/utils/init/utils.ts
+++ b/src/utils/init/utils.ts
@@ -30,7 +30,7 @@ const formatTitle = (title: string) => chalk.cyan(title)
  * @returns
  */
 export const getPluginsToAutoInstall = (
-  command: BaseCommand,
+  _command: BaseCommand,
   pluginsInstalled: string[] = [],
   pluginsRecommended: string[] = [],
 ) => {
@@ -100,10 +100,10 @@ export const getBuildSettings = async ({ command, config }: { command: BaseComma
   // eslint-disable-next-line unicorn/explicit-length-check
   const setting: Partial<Settings> = settings.length > 0 ? settings[0] : {}
   const { defaultBaseDir, defaultBuildCmd, defaultBuildDir, defaultFunctionsDir, recommendedPlugins } =
-    await normalizeSettings(setting, config, command)
+    normalizeSettings(setting, config, command)
 
   if (recommendedPlugins.length !== 0 && setting.framework?.name) {
-    log(`Configuring ${formatTitle(setting.framework.name)} runtime...`)
+    log(`Configuring ${formatTitle(setting.framework.name)}...`)
     log()
   }
 

--- a/src/utils/init/utils.ts
+++ b/src/utils/init/utils.ts
@@ -34,7 +34,7 @@ export const getPluginsToAutoInstall = (
   pluginsInstalled: string[] = [],
   pluginsRecommended: string[] = [],
 ) => {
-  const nextRuntime = '@netlify/plugin-nextjs'
+  const nextRuntime = '@opennextjs/netlify'
   const pluginsToAlwaysInstall = new Set([nextRuntime])
   return pluginsRecommended.reduce(
     (acc, plugin) =>

--- a/tests/integration/commands/init/init.test.js
+++ b/tests/integration/commands/init/init.test.js
@@ -274,7 +274,7 @@ describe.concurrent('commands/init', () => {
         method: 'patch',
         response: { deploy_hook: 'deploy_hook' },
         requestBody: {
-          plugins: [{ package: '@netlify/plugin-nextjs' }],
+          plugins: [{ package: '@opennextjs/netlify' }],
           repo: {
             allowed_branches: ['main'],
             cmd: command,
@@ -377,7 +377,7 @@ describe.concurrent('commands/init', () => {
         method: 'patch',
         response: { deploy_hook: 'deploy_hook' },
         requestBody: {
-          plugins: [{ package: '@netlify/plugin-nextjs' }],
+          plugins: [{ package: '@opennextjs/netlify' }],
           repo: {
             allowed_branches: ['main'],
             cmd: command,
@@ -466,7 +466,7 @@ describe.concurrent('commands/init', () => {
         method: 'patch',
         response: { deploy_hook: 'deploy_hook' },
         requestBody: {
-          plugins: [{ package: '@netlify/plugin-lighthouse' }, { package: '@netlify/plugin-nextjs' }],
+          plugins: [{ package: '@netlify/plugin-lighthouse' }, { package: '@opennextjs/netlify' }],
           repo: {
             allowed_branches: ['main'],
             cmd: command,


### PR DESCRIPTION
#### Summary

Update to use new package name for our Next.js Adapter, which is moving to the @opennextjs scope.

#### To do

- [ ] when https://github.com/netlify/build/pull/5897 is released, bump it in this PR (tests won't pass otherwise)