### PR TITLE
fix: make outputs more user-friendly for `sites:create-template`

### DIFF
--- a/src/commands/sites/sites-create-template.ts
+++ b/src/commands/sites/sites-create-template.ts
@@ -118,7 +118,7 @@ export const sitesCreateTemplate = async (repository: string, options: OptionVal
           error(
             `Could not create repository: ${
               (error_ as GitHubAPIError).message
-            }. Ensure that your PAT grants permission to create repositories`,
+            }. Ensure that your GitHub personal access token grants permission to create repositories`,
           )
         } else {
           error(

--- a/src/utils/gh-auth.ts
+++ b/src/utils/gh-auth.ts
@@ -90,7 +90,7 @@ export const authWithNetlify = async () => {
 const getPersonalAccessToken = async () => {
   const { token } = await inquirer.prompt([
     {
-      type: 'input',
+      type: 'password',
       name: 'token',
       message: 'Your GitHub personal access token:',
       filter: (input) => input.trim(),


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

This PR implements two small changes to the `sites:create-template` command to make it more user-friendly.

1. When user validates with GitHub personal access token, the PAT is hidden from the console, so as to protect these sensitive credentials.
2. If creating a GitHub repo fails because of a possible PAT issue, the error output reads "GitHub personal access token" rather than "GitHub PAT"

These are both suggestions from internal Netlify folks. Thanks for the feedback!

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
![Lion Cub](https://github.com/user-attachments/assets/d1beb81e-283a-4585-a7e1-1ad5cc222707)
