### PR TITLE
fix: remove extra call to accounts endpoint across cli

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -3,10 +3,10 @@ import { argv } from 'process'
 
 import updateNotifier from 'update-notifier'
 
-import { runProgram } from '../dist/utils/run-program.js'
+import { createMainCommand } from '../dist/commands/main.js'
 import { error } from '../dist/utils/command-helpers.js'
 import getPackageJson from '../dist/utils/get-package-json.js'
-import { createMainCommand } from '../dist/commands/main.js'
+import { runProgram } from '../dist/utils/run-program.js'
 
 // 12 hours
 const UPDATE_CHECK_INTERVAL = 432e5

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -596,7 +596,7 @@ export default class BaseCommand extends Command {
       token,
       ...apiUrlOpts,
     })
-    const { buildDir, config, configPath, repositoryRoot, siteInfo } = cachedConfig
+    const { accounts, buildDir, config, configPath, repositoryRoot, siteInfo } = cachedConfig
     let { env } = cachedConfig
     if (flags.offlineEnv) {
       env = {}
@@ -642,6 +642,7 @@ export default class BaseCommand extends Command {
     const configFilePath = configPath || join(this.workingDir, 'netlify.toml')
 
     actionCommand.netlify = {
+      accounts,
       // api methods
       api,
       apiOpts,

--- a/src/commands/sites/sites-create-template.ts
+++ b/src/commands/sites/sites-create-template.ts
@@ -1,10 +1,11 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { OptionValues } from 'commander'
 import inquirer from 'inquirer'
 import pick from 'lodash/pick.js'
 import { render } from 'prettyjson'
 import { v4 as uuid } from 'uuid'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 import {
   chalk,
@@ -30,7 +31,7 @@ import BaseCommand from '../base-command.js'
 import { getSiteNameInput } from './sites-create.js'
 
 export const sitesCreateTemplate = async (repository: string, options: OptionValues, command: BaseCommand) => {
-  const { api } = command.netlify
+  const { accounts, api } = command.netlify
   await command.authenticate()
 
   const { globalConfig } = command.netlify
@@ -52,7 +53,6 @@ export const sitesCreateTemplate = async (repository: string, options: OptionVal
     error(`${getTerminalLink(chalk.bold(templateName), githubLink)} is not a valid GitHub template`)
     return
   }
-  const accounts = await api.listAccountsForUser()
 
   let { accountSlug } = options
 

--- a/src/commands/sites/sites-create.ts
+++ b/src/commands/sites/sites-create.ts
@@ -29,11 +29,9 @@ export const getSiteNameInput = async (name: string | undefined): Promise<{ name
 }
 
 export const sitesCreate = async (options: OptionValues, command: BaseCommand) => {
-  const { api } = command.netlify
+  const { accounts, api } = command.netlify
 
   await command.authenticate()
-
-  const accounts: Account[] = await api.listAccountsForUser()
 
   let { accountSlug }: { accountSlug?: string } = options
   if (!accountSlug) {

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -26,8 +26,7 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
   let user
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;[user] = await Promise.all([api.getCurrentUser()])
+    user = await api.getCurrentUser()
   } catch (error_) {
     if ((error_ as APIError).status === 401) {
       error('Your session has expired. Please try to re-authenticate by running `netlify logout` and `netlify login`.')

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -43,7 +43,6 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
   }
   const teamsData = {}
 
-  // @ts-expect-error TS(7006) FIXME: Parameter 'team' implicitly has an 'any' type.
   accounts.forEach((team) => {
     // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     teamsData[team.name] = team.roles_allowed.join(' ')

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -6,7 +6,7 @@ import { chalk, error, exit, getToken, log, logJson, warn, APIError } from '../.
 import BaseCommand from '../base-command.js'
 
 export const status = async (options: OptionValues, command: BaseCommand) => {
-  const { api, globalConfig, site, siteInfo } = command.netlify
+  const { accounts, api, globalConfig, site, siteInfo } = command.netlify
   const current = globalConfig.get('userId')
   const [accessToken] = await getToken()
 
@@ -23,12 +23,11 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
  Current Netlify User │
 ──────────────────────┘`)
 
-  let accounts
   let user
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;[accounts, user] = await Promise.all([api.listAccountsForUser(), api.getCurrentUser()])
+    ;[user] = await Promise.all([api.getCurrentUser()])
   } catch (error_) {
     if ((error_ as APIError).status === 401) {
       error('Your session has expired. Please try to re-authenticate by running `netlify logout` and `netlify login`.')

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -57,7 +57,7 @@ export type EnvironmentVariables = Record<string, { sources: EnvironmentVariable
  * The netlify object inside each command with the state
  */
 export type NetlifyOptions = {
-  accounts: $TSFixMe
+  accounts: Account[]
   // poorly duck type the missing api functions
   api: NetlifyAPI & Record<string, (...args: $TSFixMe) => Promise<$TSFixMe>>
   apiOpts: $TSFixMe
@@ -81,4 +81,23 @@ export interface AddressInUseError extends Error {
   syscall: 'listen'
   address: string
   port: number
+}
+
+export interface Account {
+	id: string;
+	name: string;
+	slug: string;
+	type: string;
+	capabilities: Record<string, {included: string, used: string}>;
+	billing_name: string;
+	billing_email: string;
+	billing_details: string;
+	billing_period: string;
+	payment_method_id: string;
+	type_name: string;
+	type_id: string;
+	owner_ids: string[];
+	roles_allowed: string[];
+	created_at: string;
+	updated_at: string;
 }

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -57,6 +57,7 @@ export type EnvironmentVariables = Record<string, { sources: EnvironmentVariable
  * The netlify object inside each command with the state
  */
 export type NetlifyOptions = {
+  accounts: $TSFixMe
   // poorly duck type the missing api functions
   api: NetlifyAPI & Record<string, (...args: $TSFixMe) => Promise<$TSFixMe>>
   apiOpts: $TSFixMe

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -4,6 +4,7 @@ import type { NetlifyAPI } from 'netlify'
 
 import type { FrameworksAPIPaths } from "../utils/frameworks-api.ts";
 import StateConfig from '../utils/state-config.js'
+import { Account } from "../utils/types.ts";
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -81,23 +82,4 @@ export interface AddressInUseError extends Error {
   syscall: 'listen'
   address: string
   port: number
-}
-
-export interface Account {
-	id: string;
-	name: string;
-	slug: string;
-	type: string;
-	capabilities: Record<string, {included: string, used: string}>;
-	billing_name: string;
-	billing_email: string;
-	billing_details: string;
-	billing_period: string;
-	payment_method_id: string;
-	type_name: string;
-	type_id: string;
-	owner_ids: string[];
-	roles_allowed: string[];
-	created_at: string;
-	updated_at: string;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -168,16 +168,7 @@ export interface Account {
   name: string
   slug: string
   type: string
-  capabilities: {
-    sites: {
-      included: number
-      used: number
-    }
-    collaborators: {
-      included: number
-      used: number
-    }
-  }
+  capabilities: Record<string, {included: string, used: string}>
   billing_name: string
   billing_email: string
   billing_details: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -168,7 +168,7 @@ export interface Account {
   name: string
   slug: string
   type: string
-  capabilities: Record<string, {included: string, used: string}>
+  capabilities: Record<string, { included: string; used: string }>
   billing_name: string
   billing_email: string
   billing_details: string


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

We're calling the non-minimal accounts API in `@netlify/config` and including it in the object returned from `resolveConfig`. Then we were doing it a second time in the CLI on a few different commands. The non minimal endpoint is really expensive so this saves a good chunk of time (a couple seconds in my testing).

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
