### PR TITLE
chore: fix the CI benchmarks posting and also exit gracefully if not even relevant

### DIFF
--- a/.github/workflows/benchmark-post.yml
+++ b/.github/workflows/benchmark-post.yml
@@ -18,12 +18,19 @@ jobs:
           workflow: ${{ github.event.workflow.id }}
           workflow_conclusion: success
           name: delta-action-deltas
+          if_no_artifact_found: ignore
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check File Existence
+        id: check-file-existence
+        uses: thebinaryfelix/check-file-existence-action@1.0.0
+        with:
+          files: '.delta.*'
       - name: Get PR number
-        if: github.event.workflow_run.event == 'pull_request'
+        if: github.event.workflow_run.event == 'pull_request' && steps.check-file-existence.outputs.exists == 'true'
         id: pr_number
         run: echo "pr_number=$(cat pr_number)" >> $GITHUB_OUTPUT
       - name: Post deltas to GitHub
+        if: steps.check-file-existence.outputs.exists == 'true'
         uses: netlify/delta-action@v4
         with:
           title: '📊 Benchmark results'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           name: delta-action-deltas
           retention-days: 7
+          include-hidden-files: true
           path: |
             .delta.*
             pr_number


### PR DESCRIPTION

#### Summary

The `post-package-size` action isn't a required step, but it is annoying that it fails when it doesn't need to fail, and can make engineers spend too much time in slack threads trying to figure out what is going on. This will hopefully prevent that although long slack threads are fun and maybe we shouldn't avoid them?

Oh also this action hasn't even been working for 7 months because we upgraded to `actions/upload-artifact@v4` which ignores hidden files by default whereas v3 didn't, and all our `.delta.*` files are hidden. lol

**A picture of a cute animal (not mandatory, but encouraged)**
![image](https://github.com/user-attachments/assets/22540ccb-b0a5-43b9-adb1-58dedcf1ea0c)

