### PR TITLE
fix(deps): mark all dev deps as dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
         "through2-map": "4.0.0",
         "toml": "3.0.0",
         "tomlify-j0.4": "3.0.0",
+        "typescript": "5.1.6",
         "ulid": "2.3.0",
         "unixify": "1.0.0",
         "update-notifier": "7.3.1",
@@ -160,7 +161,6 @@
         "strip-ansi": "7.1.0",
         "temp-dir": "3.0.0",
         "tree-kill": "1.2.2",
-        "typescript": "5.1.6",
         "verdaccio": "6.0.5",
         "vitest": "1.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "through2-map": "4.0.0",
     "toml": "3.0.0",
     "tomlify-j0.4": "3.0.0",
+    "typescript": "5.1.6",
     "ulid": "2.3.0",
     "unixify": "1.0.0",
     "update-notifier": "7.3.1",
@@ -217,7 +218,6 @@
     "strip-ansi": "7.1.0",
     "temp-dir": "3.0.0",
     "tree-kill": "1.2.2",
-    "typescript": "5.1.6",
     "verdaccio": "6.0.5",
     "vitest": "1.6.0"
   },


### PR DESCRIPTION
#### Summary

The size (on disk) of this package including all installed dependencies is bananas (300+ MB). I found a few log-hanging fruit in dependencies that should be marked as `devDependencies` but weren't, meaning they were getting installed when users install `netlify-cli`.

WIP - pushing incrementally to get the nice CI package size thingy