### PR TITLE
fix!: upgrade to commander@12 and fix some conflicting short option names

### DIFF
--- a/docs/commands/api.md
+++ b/docs/commands/api.md
@@ -27,6 +27,7 @@ netlify api
 - `data` (*string*) - Data to use
 - `list` (*boolean*) - List out available API methods
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/blobs.md
+++ b/docs/commands/blobs.md
@@ -20,6 +20,7 @@ netlify blobs
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -61,6 +62,7 @@ netlify blobs:delete
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `force` (*boolean*) - Bypasses prompts & Force the command to run.
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `blobs:get`
@@ -83,6 +85,7 @@ netlify blobs:get
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `output` (*string*) - Defines the filesystem path where the blob data should be persisted
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `blobs:list`
@@ -106,6 +109,7 @@ netlify blobs:list
 - `json` (*boolean*) - Output list contents as JSON
 - `prefix` (*string*) - A string for filtering down the entries; when specified, only the entries whose key starts with that prefix are returned
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `blobs:set`
@@ -130,6 +134,7 @@ netlify blobs:set
 - `force` (*boolean*) - Bypasses prompts & Force the command to run.
 - `input` (*string*) - Defines the filesystem path where the blob data should be read from
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 

--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -20,8 +20,9 @@ netlify build
 - `context` (*string*) - Specify a build context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev")
 - `dry` (*boolean*) - Dry run: show instructions without running them
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
-- `offline` (*boolean*) - disables any features that require network access
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `offline` (*boolean*) - Disables any features that require network access
 
 **Examples**
 

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -20,6 +20,7 @@ netlify completion
 **Flags**
 
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -47,6 +48,7 @@ netlify completion:install
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -85,7 +85,6 @@ netlify deploy
 **Flags**
 
 - `alias` (*string*) - Specifies the alias for deployment, the string at the beginning of the deploy subdomain. Useful for creating predictable deployment URLs. Avoid setting an alias string to the same value as a deployed branch. `alias` doesn’t create a branch deploy and can’t be used in conjunction with the branch subdomain feature. Maximum 37 characters.
-- `auth` (*string*) - Netlify auth token to deploy with
 - `branch` (*string*) - Serves the same functionality as --alias. Deprecated and will be removed in future versions
 - `build` (*boolean*) - Run build command before deploying
 - `context` (*string*) - Context to use when resolving build configuration
@@ -94,14 +93,15 @@ netlify deploy
 - `functions` (*string*) - Specify a functions folder to deploy
 - `json` (*boolean*) - Output deployment data as JSON
 - `message` (*string*) - A short message to include in the deploy log
+- `prod-if-unlocked` (*boolean*) - Deploy to production if unlocked, create a draft otherwise
+- `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 - `open` (*boolean*) - Open site after deploy
 - `prod` (*boolean*) - Deploy to production
-- `prod-if-unlocked` (*boolean*) - Deploy to production if unlocked, create a draft otherwise
 - `site` (*string*) - A site name or ID to deploy to
 - `skip-functions-cache` (*boolean*) - Ignore any functions created as part of a previous `build` or `deploy` commands, forcing them to be bundled again as part of the deployment
 - `timeout` (*string*) - Timeout to wait for deployment to finish
 - `trigger` (*boolean*) - Trigger a new build of your site on Netlify without uploading local files
-- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -32,10 +32,11 @@ netlify dev
 - `geo` (*cache | mock | update*) - force geolocation data to be updated, use cached data from the last 24h if found, or use a mock location
 - `live` (*string*) - start a public live session; optionally, supply a subdomain to generate a custom URL
 - `no-open` (*boolean*) - disables the automatic opening of a browser window
-- `offline` (*boolean*) - disables any features that require network access
+- `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `offline` (*boolean*) - Disables any features that require network access
 - `port` (*string*) - port of netlify dev
 - `target-port` (*string*) - port of target app server
-- `debug` (*boolean*) - Print debugging information
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -76,6 +77,7 @@ netlify dev:exec
 - `context` (*string*) - Specify a deploy context or branch for environment variables (contexts: "production", "deploy-preview", "branch-deploy", "dev")
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/env.md
+++ b/docs/commands/env.md
@@ -20,6 +20,7 @@ netlify env
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -60,6 +61,7 @@ netlify env:clone
 - `from` (*string*) - Site ID (From)
 - `to` (*string*) - Site ID (To)
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 
@@ -87,8 +89,10 @@ netlify env:get
 
 - `context` (*string*) - Specify a deploy context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev")
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
-- `scope` (*builds | functions | post-processing | runtime | any*) - Specify a scope
+- `json` (*boolean*) - Output environment variables as JSON
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `scope` (*builds | functions | post-processing | runtime | any*) - Specify a scope
 
 **Examples**
 
@@ -117,8 +121,10 @@ netlify env:import
 **Flags**
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
+- `json` (*boolean*) - Output environment variables as JSON
 - `replace-existing` (*boolean*) - Replace all existing variables instead of merging them with the current ones
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `env:list`
@@ -136,9 +142,10 @@ netlify env:list
 - `context` (*string*) - Specify a deploy context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev")
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `json` (*boolean*) - Output environment variables as JSON
-- `plain` (*boolean*) - Output environment variables as plaintext
 - `scope` (*builds | functions | post-processing | runtime | any*) - Specify a scope
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `plain` (*boolean*) - Output environment variables as plaintext
 
 **Examples**
 
@@ -171,9 +178,11 @@ netlify env:set
 - `context` (*string*) - Specify a deploy context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev") (default: all contexts)
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `force` (*boolean*) - Bypasses prompts & Force the command to run.
-- `scope` (*builds | functions | post-processing | runtime*) - Specify a scope (default: all scopes)
+- `json` (*boolean*) - Output environment variables as JSON
 - `secret` (*boolean*) - Indicate whether the environment variable value can be read again.
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `scope` (*builds | functions | post-processing | runtime*) - Specify a scope (default: all scopes)
 
 **Examples**
 
@@ -207,7 +216,9 @@ netlify env:unset
 - `context` (*string*) - Specify a deploy context or branch (contexts: "production", "deploy-preview", "branch-deploy", "dev") (default: all contexts)
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `force` (*boolean*) - Bypasses prompts & Force the command to run.
+- `json` (*boolean*) - Output environment variables as JSON
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -21,6 +21,7 @@ netlify functions
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -55,6 +56,7 @@ netlify functions:build
 - `functions` (*string*) - Specify a functions directory to build to
 - `src` (*string*) - Specify the source directory for the functions
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `functions:create`
@@ -76,8 +78,10 @@ netlify functions:create
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `language` (*string*) - function language
 - `name` (*string*) - function name
+- `offline` (*boolean*) - Disables any features that require network access
 - `url` (*string*) - pull template from URL
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 
@@ -109,10 +113,12 @@ netlify functions:invoke
 - `identity` (*boolean*) - simulate Netlify Identity authentication JWT. pass --identity to affirm unauthenticated request
 - `name` (*string*) - function name to invoke
 - `no-identity` (*boolean*) - simulate Netlify Identity authentication JWT. pass --no-identity to affirm unauthenticated request
+- `offline` (*boolean*) - Disables any features that require network access
 - `payload` (*string*) - Supply POST payload in stringified json, or a path to a json file
+- `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 - `port` (*string*) - Port where netlify dev is accessible. e.g. 8888
 - `querystring` (*string*) - Querystring to add to your function invocation
-- `debug` (*boolean*) - Print debugging information
 
 **Examples**
 
@@ -147,6 +153,7 @@ netlify functions:list
 - `functions` (*string*) - Specify a functions directory to list
 - `json` (*boolean*) - Output function data as JSON
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `functions:serve`
@@ -163,9 +170,10 @@ netlify functions:serve
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `functions` (*string*) - Specify a functions directory to serve
-- `offline` (*boolean*) - disables any features that require network access
+- `offline` (*boolean*) - Disables any features that require network access
 - `port` (*string*) - Specify a port for the functions server
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -23,6 +23,7 @@ netlify init
 - `git-remote-name` (*string*) - Name of Git remote to use. e.g. "origin"
 - `manual` (*boolean*) - Manually configure a git remote for CI
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/link.md
+++ b/docs/commands/link.md
@@ -23,6 +23,7 @@ netlify link
 - `id` (*string*) - ID of site to link to
 - `name` (*string*) - Name of site to link to
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -21,6 +21,7 @@ netlify login
 
 - `new` (*boolean*) - Login to new Netlify account
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -19,6 +19,7 @@ netlify logs
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -49,6 +50,7 @@ netlify logs:deploy
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 ## `logs:function`
@@ -70,6 +72,7 @@ netlify logs:function
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `level` (*string*) - Log levels to stream. Choices are: trace, debug, info, warn, error, fatal
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -21,6 +21,7 @@ netlify open
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `site` (*boolean*) - Open site
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -52,6 +53,7 @@ netlify open:admin
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 
@@ -74,6 +76,7 @@ netlify open:site
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/recipes.md
+++ b/docs/commands/recipes.md
@@ -23,6 +23,7 @@ netlify recipes
 
 - `name` (*string*) - recipe name to use
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -51,6 +52,7 @@ netlify recipes:list
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/serve.md
+++ b/docs/commands/serve.md
@@ -25,9 +25,10 @@ netlify serve
 - `functions` (*string*) - specify a functions folder to serve
 - `functions-port` (*string*) - port of functions server
 - `geo` (*cache | mock | update*) - force geolocation data to be updated, use cached data from the last 24h if found, or use a mock location
-- `offline` (*boolean*) - disables any features that require network access
+- `offline` (*boolean*) - Disables any features that require network access
 - `port` (*string*) - port of netlify dev
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/docs/commands/sites.md
+++ b/docs/commands/sites.md
@@ -21,6 +21,7 @@ netlify sites
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -56,8 +57,9 @@ netlify sites:create
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `manual` (*boolean*) - force manual CI setup.  Used --with-ci flag
 - `name` (*string*) - name of site
-- `with-ci` (*boolean*) - initialize CI hooks during site creation
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `with-ci` (*boolean*) - initialize CI hooks during site creation
 
 ---
 ## `sites:create-template`
@@ -81,8 +83,9 @@ netlify sites:create-template
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `name` (*string*) - name of site
 - `url` (*string*) - template url
-- `with-ci` (*boolean*) - initialize CI hooks during site creation
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `with-ci` (*boolean*) - initialize CI hooks during site creation
 
 **Examples**
 
@@ -113,6 +116,7 @@ netlify sites:delete
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `force` (*boolean*) - Delete without prompting (useful for CI).
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 
@@ -136,6 +140,7 @@ netlify sites:list
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `json` (*boolean*) - Output site data as JSON
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -18,8 +18,10 @@ netlify status
 
 **Flags**
 
+- `json` (*boolean*) - Output status information as JSON
 - `verbose` (*boolean*) - Output system info
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
@@ -41,6 +43,7 @@ netlify status:hooks
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 ---
 

--- a/docs/commands/switch.md
+++ b/docs/commands/switch.md
@@ -19,6 +19,7 @@ netlify switch
 **Flags**
 
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/unlink.md
+++ b/docs/commands/unlink.md
@@ -20,6 +20,7 @@ netlify unlink
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -20,6 +20,7 @@ netlify watch
 
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
 **Examples**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "chokidar": "3.6.0",
         "ci-info": "4.1.0",
         "clean-deep": "3.4.0",
-        "commander": "10.0.1",
+        "commander": "12.1.0",
         "comment-json": "4.2.5",
         "configstore": "7.0.0",
         "content-type": "1.0.5",
@@ -9768,11 +9768,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/comment-json": {
@@ -16298,6 +16298,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/lambda-local/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/latest-version": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
@@ -19372,6 +19380,14 @@
       },
       "engines": {
         "node": "^14.14.0 || >=16.0.0"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/precond": {
@@ -31046,9 +31062,9 @@
       }
     },
     "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
     },
     "comment-json": {
       "version": "4.2.5",
@@ -35680,6 +35696,13 @@
         "commander": "^10.0.1",
         "dotenv": "^16.3.1",
         "winston": "^3.10.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+        }
       }
     },
     "latest-version": {
@@ -37904,6 +37927,13 @@
         "detective-typescript": "^11.1.0",
         "module-definition": "^5.0.1",
         "node-source-walk": "^6.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+        }
       }
     },
     "precond": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chokidar": "3.6.0",
     "ci-info": "4.1.0",
     "clean-deep": "3.4.0",
-    "commander": "10.0.1",
+    "commander": "12.1.0",
     "comment-json": "4.2.5",
     "configstore": "7.0.0",
     "content-type": "1.0.5",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/starlight": "0.31.1",
-        "astro": "5.1.8",
+        "@astrojs/starlight": "^0.31.1",
+        "astro": "^5.1.9",
         "markdown-magic": "2.6.1",
         "sharp": "0.32.6",
         "strip-ansi": "7.1.0"
@@ -22,9 +22,9 @@
       "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw=="
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.2.tgz",
-      "integrity": "sha512-EdDWkC3JJVcpGpqJAU/5hSk2LKXyG3mNGkzGoAuyK+xoPHbaVdSuIWoN1QTnmK3N/gGfaaAfM8gO2KDCAW7S3w=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.5.1.tgz",
+      "integrity": "sha512-M7rAge1n2+aOSxNvKUFa0u/KFn0W+sZy7EW91KOSERotm2Ti8qs+1K0xx3zbOxtAVrmJb5/J98eohVvvEqtNkw=="
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "6.0.2",
@@ -1376,57 +1376,57 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.1.tgz",
-      "integrity": "sha512-Mo1gGGkuOYjDu5H8YwzmOuly9vNr8KDVkqj9xiKhhhFS8jisAtDSEWB9hzqRHLVQgFdA310e8XRJcW4tYhRB2A==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.29.1",
-        "@shikijs/engine-oniguruma": "1.29.1",
-        "@shikijs/types": "1.29.1",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.4"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.1.tgz",
-      "integrity": "sha512-Hpi8k9x77rCQ7F/7zxIOUruNkNidMyBnP5qAGbLFqg4kRrg1HZhkB8btib5EXbQWTtLb5gBHOdBwshk20njD7Q==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
+      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
       "dependencies": {
-        "@shikijs/types": "1.29.1",
+        "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1",
         "oniguruma-to-es": "^2.2.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.1.tgz",
-      "integrity": "sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
       "dependencies": {
-        "@shikijs/types": "1.29.1",
+        "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.1.tgz",
-      "integrity": "sha512-iERn4HlyuT044/FgrvLOaZgKVKf3PozjKjyV/RZ5GnlyYEAZFcgwHGkYboeBv2IybQG1KVS/e7VGgiAU4JY2Gw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
+      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
       "dependencies": {
-        "@shikijs/types": "1.29.1"
+        "@shikijs/types": "1.29.2"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.1.tgz",
-      "integrity": "sha512-lb11zf72Vc9uxkl+aec2oW1HVTHJ2LtgZgumb4Rr6By3y/96VmlU44bkxEb8WBWH3RUtbqAJEN0jljD9cF7H7g==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
+      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
       "dependencies": {
-        "@shikijs/types": "1.29.1"
+        "@shikijs/types": "1.29.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.1.tgz",
-      "integrity": "sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
@@ -2100,9 +2100,9 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -2297,14 +2297,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.1.8.tgz",
-      "integrity": "sha512-7fNNceI/dXqGIkkZQjxhH31alAfgf33cDv34cPLCGFVSHHOpYG0NSrofnxdYf0BvWRlddqkq393UqDM5cJlv1w==",
-      "license": "MIT",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.2.5.tgz",
+      "integrity": "sha512-AYXyYkc+c5xbKTm48FyQA91y81nXyNPAaoyafR0LUugE4lAwuvIUcXDBfMzmbuP1lGRvsE33G2oypv6gbGaPFg==",
       "dependencies": {
         "@astrojs/compiler": "^2.10.3",
-        "@astrojs/internal-helpers": "0.4.2",
-        "@astrojs/markdown-remark": "6.0.2",
+        "@astrojs/internal-helpers": "0.5.1",
+        "@astrojs/markdown-remark": "6.1.0",
         "@astrojs/telemetry": "3.2.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.1.4",
@@ -2330,7 +2329,7 @@
         "fast-glob": "^3.3.3",
         "flattie": "^1.1.1",
         "github-slugger": "^2.0.0",
-        "html-escaper": "^3.0.3",
+        "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.1.1",
         "js-yaml": "^4.1.0",
         "kleur": "^4.1.5",
@@ -2340,24 +2339,24 @@
         "mrmime": "^2.0.0",
         "neotraverse": "^0.6.18",
         "p-limit": "^6.2.0",
-        "p-queue": "^8.0.1",
-        "preferred-pm": "^4.0.0",
+        "p-queue": "^8.1.0",
+        "preferred-pm": "^4.1.1",
         "prompts": "^2.4.2",
         "rehype": "^13.0.2",
-        "semver": "^7.6.3",
-        "shiki": "^1.29.1",
+        "semver": "^7.7.1",
+        "shiki": "^1.29.2",
         "tinyexec": "^0.3.2",
         "tsconfck": "^3.1.4",
         "ultrahtml": "^1.5.3",
         "unist-util-visit": "^5.0.0",
         "unstorage": "^1.14.4",
         "vfile": "^6.0.3",
-        "vite": "^6.0.9",
+        "vite": "^6.0.11",
         "vitefu": "^1.0.5",
-        "which-pm": "^3.0.0",
+        "which-pm": "^3.0.1",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^21.1.1",
-        "yocto-spinner": "^0.1.2",
+        "yocto-spinner": "^0.2.0",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.1",
         "zod-to-ts": "^1.2.0"
@@ -2387,6 +2386,33 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.1.0.tgz",
+      "integrity": "sha512-emZNNSTPGgPc3V399Cazpp5+snogjaF04ocOSQn9vy3Kw/eIC4vTQjXOrWDEoSEy+AwPDZX9bQ4wd3bxhpmGgQ==",
+      "dependencies": {
+        "@astrojs/prism": "3.2.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "import-meta-resolve": "^4.1.0",
+        "js-yaml": "^4.1.0",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.1",
+        "remark-smartypants": "^3.0.2",
+        "shiki": "^1.29.1",
+        "smol-toml": "^1.3.1",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/astro/node_modules/sharp": {
@@ -3010,9 +3036,9 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/crossws": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.1.tgz",
-      "integrity": "sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.2.tgz",
+      "integrity": "sha512-S2PpQHRcgYABOS2465b34wqTOn5dbLL+iSvyweJYGGFLDsKq88xrjDXUiEhfYkhWZq1HuS6of3okRHILbkrqxw==",
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -4059,12 +4085,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/h3": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.1.tgz",
-      "integrity": "sha512-u/z6Z4YY+ANZ05cRRfsFJadTBrNA6e3jxdU+AN5UCbZSZEUwgHiwjvUEe0k1NoQmAvQmETwr+xB5jd7mhCJuIQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.14.0.tgz",
+      "integrity": "sha512-ao22eiONdgelqcnknw0iD645qW0s9NnrJHr5OBz4WOMdBdycfSas1EQf1wXRsm+PcB2Yoj43pjBPwqIpJQTeWg==",
       "dependencies": {
         "cookie-es": "^1.2.2",
-        "crossws": "^0.3.1",
+        "crossws": "^0.3.2",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
         "iron-webcrypto": "^1.2.1",
@@ -5376,12 +5402,13 @@
       }
     },
     "node_modules/mdast-util-directive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.0.0.tgz",
-      "integrity": "sha512-JUpYOqKI4mM3sZcNxmF/ox04XYFFkNwr0CFlrQIkCwbvH0xzMCqkMqAde9wRd80VAhaUrwFwKm2nxretdT1h7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0",
@@ -6629,9 +6656,9 @@
       }
     },
     "node_modules/micromark-util-subtokenize": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.3.tgz",
-      "integrity": "sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
+      "integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7000,9 +7027,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -7291,13 +7318,13 @@
       }
     },
     "node_modules/preferred-pm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.0.0.tgz",
-      "integrity": "sha512-gYBeFTZLu055D8Vv3cSPox/0iTPtkzxpLroSYYA7WXgRi31WCJ51Uyl8ZiPeUUjyvs2MBzK+S8v9JVUgHU/Sqw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.1.1.tgz",
+      "integrity": "sha512-rU+ZAv1Ur9jAUZtGPebQVQPzdGhNzaEiQ7VL9+cjsAWPHFYOccNXPNiev1CCDSOg/2j7UujM7ojNhpkuILEVNQ==",
       "dependencies": {
         "find-up-simple": "^1.0.0",
         "find-yarn-workspace-root2": "1.2.16",
-        "which-pm": "^3.0.0"
+        "which-pm": "^3.0.1"
       },
       "engines": {
         "node": ">=18.12"
@@ -7674,9 +7701,9 @@
       }
     },
     "node_modules/remark-directive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.0.tgz",
-      "integrity": "sha512-l1UyWJ6Eg1VPU7Hm/9tt0zKtReJQNOA4+iDMAxTyZNWnJnFlbS/7zhiel/rogTLQ2vMYwDzSJa4BiVNqGlqIMA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
@@ -8010,9 +8037,9 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8087,16 +8114,16 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.1.tgz",
-      "integrity": "sha512-TghWKV9pJTd/N+IgAIVJtr0qZkB7FfFCUrrEJc0aRmZupo3D1OCVRknQWVRVA7AX/M0Ld7QfoAruPzr3CnUJuw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
+      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
       "dependencies": {
-        "@shikijs/core": "1.29.1",
-        "@shikijs/engine-javascript": "1.29.1",
-        "@shikijs/engine-oniguruma": "1.29.1",
-        "@shikijs/langs": "1.29.1",
-        "@shikijs/themes": "1.29.1",
-        "@shikijs/types": "1.29.1",
+        "@shikijs/core": "1.29.2",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/langs": "1.29.2",
+        "@shikijs/themes": "1.29.2",
+        "@shikijs/types": "1.29.2",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
       }
@@ -8254,6 +8281,17 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
+      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {
@@ -9203,9 +9241,9 @@
       }
     },
     "node_modules/which-pm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-3.0.0.tgz",
-      "integrity": "sha512-ysVYmw6+ZBhx3+ZkcPwRuJi38ZOTLJJ33PSHaitLxSKUMsh0LkKd0nC69zZCwt5D+AYUcMK2hhw4yWny20vSGg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-3.0.1.tgz",
+      "integrity": "sha512-v2JrMq0waAI4ju1xU5x3blsxBBMgdgZve580iYMN5frDaLGjbA24fok7wKCsya8KLVO19Ju4XDc5+zTZCJkQfg==",
       "dependencies": {
         "load-yaml-file": "^0.2.0"
       },
@@ -9300,9 +9338,9 @@
       }
     },
     "node_modules/yocto-spinner": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.1.2.tgz",
-      "integrity": "sha512-VfmLIh/ZSZOJnVRQZc/dvpPP90lWL4G0bmxQMP0+U/2vKBA8GSpcBuWv17y7F+CZItRuO97HN1wdbb4p10uhOg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.0.tgz",
+      "integrity": "sha512-Qu6WAqNLGleB687CCGcmgHIo8l+J19MX/32UrSMfbf/4L8gLoxjpOYoiHT1asiWyqvjRZbgvOhLlvne6E5Tbdw==",
       "dependencies": {
         "yoctocolors": "^2.1.1"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -16,8 +16,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@astrojs/starlight": "0.31.1",
-    "astro": "5.1.8",
+    "@astrojs/starlight": "^0.31.1",
+    "astro": "^5.1.9",
     "markdown-magic": "2.6.1",
     "sharp": "0.32.6",
     "strip-ansi": "7.1.0"

--- a/site/scripts/util/generate-command-data.js
+++ b/site/scripts/util/generate-command-data.js
@@ -3,13 +3,13 @@ import { sortOptions } from '../../../dist/utils/command-helpers.js'
 
 const program = createMainCommand()
 
-/** @type {Array<import('../../src/commands/base-command.js').default>} */
+/** @type {Array<import('../../../src/commands/base-command.js').default>} */
 // @ts-ignore typecast needed
 const commands = program.commands.sort((cmdA, cmdB) => cmdA.name().localeCompare(cmdB.name()))
 
 /**
  *
- * @param {import('../../src/commands/base-command.js').default} command
+ * @param {import('../../../src/commands/base-command.js').default} command
  */
 const parseCommand = function (command) {
   const args = command._args.map(({ _name: name, description }) => ({

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -188,7 +188,7 @@ export default class BaseCommand extends Command {
       .addOption(new Option('--json', 'Output return values as JSON').hideHelp(true))
       .addOption(new Option('--silent', 'Silence CLI output').hideHelp(true))
       .addOption(new Option('--cwd <cwd>').hideHelp(true))
-      .addOption(new Option('-o, --offline').hideHelp(true))
+      .addOption(new Option('-o, --offline').default(false).hideHelp(true))
       .addOption(new Option('--auth <token>', 'Netlify auth token').hideHelp(true))
       .addOption(
         new Option('--http-proxy [address]', 'Proxy server address to route requests through.')

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -183,13 +183,12 @@ export default class BaseCommand extends Command {
    */
   createCommand(name: string): BaseCommand {
     const base = new BaseCommand(name)
-      // If  --silent or --json flag passed disable logger
       // .addOption(new Option('--force', 'Force command to run. Bypasses prompts for certain destructive commands.'))
-      .addOption(new Option('--json', 'Output return values as JSON').hideHelp(true))
       .addOption(new Option('--silent', 'Silence CLI output').hideHelp(true))
       .addOption(new Option('--cwd <cwd>').hideHelp(true))
-      .addOption(new Option('-o, --offline').default(false).hideHelp(true))
-      .addOption(new Option('--auth <token>', 'Netlify auth token').hideHelp(true))
+      .addOption(
+        new Option('--auth <token>', 'Netlify auth token - can be used to run this command without logging in'),
+      )
       .addOption(
         new Option('--http-proxy [address]', 'Proxy server address to route requests through.')
           .default(process.env.HTTP_PROXY || process.env.HTTPS_PROXY)

--- a/src/commands/blobs/blobs.ts
+++ b/src/commands/blobs/blobs.ts
@@ -1,4 +1,4 @@
-import { OptionValues } from 'commander'
+import { Option, OptionValues } from 'commander'
 
 import requiresSiteInfo from '../../utils/hooks/requires-site-info.js'
 import BaseCommand from '../base-command.js'
@@ -53,7 +53,8 @@ export const createBlobsCommand = (program: BaseCommand) => {
       '-p, --prefix <prefix>',
       `A string for filtering down the entries; when specified, only the entries whose key starts with that prefix are returned`,
     )
-    .option('--json', `Output list contents as JSON`)
+    // The BaseCommand defines a `--json` option which is hidden from the help by default
+    .addHelpOption(new Option('--json', 'Output list contents as JSON'))
     .alias('blob:list')
     .hook('preAction', requiresSiteInfo)
     .action(async (storeName: string, options: OptionValues, command: BaseCommand) => {

--- a/src/commands/blobs/blobs.ts
+++ b/src/commands/blobs/blobs.ts
@@ -1,4 +1,4 @@
-import { Option, OptionValues } from 'commander'
+import { OptionValues } from 'commander'
 
 import requiresSiteInfo from '../../utils/hooks/requires-site-info.js'
 import BaseCommand from '../base-command.js'
@@ -53,8 +53,7 @@ export const createBlobsCommand = (program: BaseCommand) => {
       '-p, --prefix <prefix>',
       `A string for filtering down the entries; when specified, only the entries whose key starts with that prefix are returned`,
     )
-    // The BaseCommand defines a `--json` option which is hidden from the help by default
-    .addHelpOption(new Option('--json', 'Output list contents as JSON'))
+    .option('--json', 'Output list contents as JSON')
     .alias('blob:list')
     .hook('preAction', requiresSiteInfo)
     .action(async (storeName: string, options: OptionValues, command: BaseCommand) => {

--- a/src/commands/blobs/blobs.ts
+++ b/src/commands/blobs/blobs.ts
@@ -33,7 +33,7 @@ export const createBlobsCommand = (program: BaseCommand) => {
     )
     .argument('<store>', 'Name of the store')
     .argument('<key>', 'Object key')
-    .option('-o, --output <path>', 'Defines the filesystem path where the blob data should be persisted')
+    .option('-O, --output <path>', 'Defines the filesystem path where the blob data should be persisted')
     .alias('blob:get')
     .hook('preAction', requiresSiteInfo)
     .action(async (storeName: string, key: string, options: OptionValues, command: BaseCommand) => {

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -2,6 +2,7 @@ import process from 'process'
 
 import { normalizeContext } from '../../utils/env/index.js'
 import BaseCommand from '../base-command.js'
+import { Option } from 'commander'
 
 export const createBuildCommand = (program: BaseCommand) =>
   program
@@ -14,7 +15,7 @@ export const createBuildCommand = (program: BaseCommand) =>
       process.env.CONTEXT || 'production',
     )
     .option('--dry', 'Dry run: show instructions without running them', false)
-    .option('-o, --offline', 'disables any features that require network access', false)
+    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
     .addExamples(['netlify build'])
     .action(async (options, command) => {
       const { build } = await import('./build.js')

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -2,7 +2,6 @@ import process from 'process'
 
 import { normalizeContext } from '../../utils/env/index.js'
 import BaseCommand from '../base-command.js'
-import { Option } from 'commander'
 
 export const createBuildCommand = (program: BaseCommand) =>
   program
@@ -15,7 +14,7 @@ export const createBuildCommand = (program: BaseCommand) =>
       process.env.CONTEXT || 'production',
     )
     .option('--dry', 'Dry run: show instructions without running them', false)
-    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
+    .option('-o, --offline', 'Disables any features that require network access')
     .addExamples(['netlify build'])
     .action(async (options, command) => {
       const { build } = await import('./build.js')

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -97,7 +97,7 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
       '-b, --branch <name>',
       'Serves the same functionality as --alias. Deprecated and will be removed in future versions',
     )
-    .option('-o, --open', 'Open site after deploy', false)
+    .option('-O, --open', 'Open site after deploy', false)
     .option('-m, --message <message>', 'A short message to include in the deploy log')
     .option('-a, --auth <token>', 'Netlify auth token to deploy with', env.NETLIFY_AUTH_TOKEN)
     .option('-s, --site <name-or-id>', 'A site name or ID to deploy to', env.NETLIFY_SITE_ID)

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -99,11 +99,8 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
     )
     .option('-O, --open', 'Open site after deploy', false)
     .option('-m, --message <message>', 'A short message to include in the deploy log')
-    // The BaseCommand defines an `--auth` option which is hidden from the help by default
-    .addHelpOption(new Option('-a, --auth <token>', 'Netlify auth token to deploy with'))
     .option('-s, --site <name-or-id>', 'A site name or ID to deploy to', env.NETLIFY_SITE_ID)
-    // The BaseCommand defines a `--json` option which is hidden from the help by default
-    .addHelpOption(new Option('--json', 'Output deployment data as JSON'))
+    .option('--json', 'Output deployment data as JSON')
     .option('--timeout <number>', 'Timeout to wait for deployment to finish', (value) => Number.parseInt(value))
     .addOption(
       new Option('--trigger', 'Trigger a new build of your site on Netlify without uploading local files').conflicts(

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -99,7 +99,7 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
     )
     .option('-O, --open', 'Open site after deploy', false)
     .option('-m, --message <message>', 'A short message to include in the deploy log')
-    .option('-a, --auth <token>', 'Netlify auth token to deploy with', env.NETLIFY_AUTH_TOKEN)
+    .addHelpOption(new Option('-a, --auth <token>', 'Netlify auth token to deploy with'))
     .option('-s, --site <name-or-id>', 'A site name or ID to deploy to', env.NETLIFY_SITE_ID)
     .option('--json', 'Output deployment data as JSON')
     .option('--timeout <number>', 'Timeout to wait for deployment to finish', (value) => Number.parseInt(value))

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -99,9 +99,11 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
     )
     .option('-O, --open', 'Open site after deploy', false)
     .option('-m, --message <message>', 'A short message to include in the deploy log')
+    // The BaseCommand defines an `--auth` option which is hidden from the help by default
     .addHelpOption(new Option('-a, --auth <token>', 'Netlify auth token to deploy with'))
     .option('-s, --site <name-or-id>', 'A site name or ID to deploy to', env.NETLIFY_SITE_ID)
-    .option('--json', 'Output deployment data as JSON')
+    // The BaseCommand defines a `--json` option which is hidden from the help by default
+    .addHelpOption(new Option('--json', 'Output deployment data as JSON'))
     .option('--timeout <number>', 'Timeout to wait for deployment to finish', (value) => Number.parseInt(value))
     .addOption(
       new Option('--trigger', 'Trigger a new build of your site on Netlify without uploading local files').conflicts(

--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -272,7 +272,7 @@ export const createDevCommand = (program: BaseCommand) => {
     .option('--framework <name>', 'framework to use. Defaults to #auto which automatically detects a framework')
     .option('-d ,--dir <path>', 'dir with static files')
     .option('-f ,--functions <folder>', 'specify a functions folder to serve')
-    .option('-o ,--offline', 'disables any features that require network access')
+    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
     .addOption(
       new Option('--offline-env', 'disables fetching environment variables from the Netlify API').hideHelp(true),
     )

--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -272,7 +272,7 @@ export const createDevCommand = (program: BaseCommand) => {
     .option('--framework <name>', 'framework to use. Defaults to #auto which automatically detects a framework')
     .option('-d ,--dir <path>', 'dir with static files')
     .option('-f ,--functions <folder>', 'specify a functions folder to serve')
-    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
+    .option('-o, --offline', 'Disables any features that require network access')
     .addOption(
       new Option('--offline-env', 'disables fetching environment variables from the Netlify API').hideHelp(true),
     )

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -56,7 +56,8 @@ export const createEnvCommand = (program: BaseCommand) => {
       normalizeContext,
       'dev',
     )
-    .option('--json', 'Output environment variables as JSON')
+    // The BaseCommand defines a `--json` option which is hidden from the help by default
+    .addHelpOption(new Option('--json', 'Output environment variables as JSON'))
     .addOption(new Option('--plain', 'Output environment variables as plaintext').conflicts('json'))
     .addOption(
       new Option('-s, --scope <scope>', 'Specify a scope')

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -39,7 +39,7 @@ export const createEnvCommand = (program: BaseCommand) => {
     .command('env:import')
     .argument('<fileName>', '.env file to import')
     .option(
-      '-R, --replace-existing',
+      '-r, --replace-existing',
       'Replace all existing variables instead of merging them with the current ones',
       false,
     )

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -38,7 +38,7 @@ export const createEnvCommand = (program: BaseCommand) => {
     .command('env:import')
     .argument('<fileName>', '.env file to import')
     .option(
-      '-r, --replace-existing',
+      '-R, --replace-existing',
       'Replace all existing variables instead of merging them with the current ones',
       false,
     )

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -3,7 +3,7 @@ import { OptionValues, Option } from 'commander'
 import { normalizeContext } from '../../utils/env/index.js'
 import BaseCommand from '../base-command.js'
 
-const env = (options: OptionValues, command: BaseCommand) => {
+const env = (_options: OptionValues, command: BaseCommand) => {
   command.help()
 }
 
@@ -17,6 +17,7 @@ export const createEnvCommand = (program: BaseCommand) => {
       normalizeContext,
       'dev',
     )
+    .option('--json', 'Output environment variables as JSON')
     .addOption(
       new Option('-s, --scope <scope>', 'Specify a scope')
         .choices(['builds', 'functions', 'post-processing', 'runtime', 'any'])
@@ -42,6 +43,7 @@ export const createEnvCommand = (program: BaseCommand) => {
       'Replace all existing variables instead of merging them with the current ones',
       false,
     )
+    .option('--json', 'Output environment variables as JSON')
     .description('Import and set environment variables from .env file')
     .action(async (fileName: string, options: OptionValues, command: BaseCommand) => {
       const { envImport } = await import('./env-import.js')
@@ -56,8 +58,7 @@ export const createEnvCommand = (program: BaseCommand) => {
       normalizeContext,
       'dev',
     )
-    // The BaseCommand defines a `--json` option which is hidden from the help by default
-    .addHelpOption(new Option('--json', 'Output environment variables as JSON'))
+    .option('--json', 'Output environment variables as JSON')
     .addOption(new Option('--plain', 'Output environment variables as plaintext').conflicts('json'))
     .addOption(
       new Option('-s, --scope <scope>', 'Specify a scope')
@@ -88,6 +89,7 @@ export const createEnvCommand = (program: BaseCommand) => {
       // @ts-expect-error TS(7006) FIXME: Parameter 'context' implicitly has an 'any' type.
       (context, previous = []) => [...previous, normalizeContext(context)],
     )
+    .option('--json', 'Output environment variables as JSON')
     .addOption(
       new Option('-s, --scope <scope...>', 'Specify a scope (default: all scopes)').choices([
         'builds',
@@ -123,6 +125,7 @@ export const createEnvCommand = (program: BaseCommand) => {
       // @ts-expect-error TS(7006) FIXME: Parameter 'context' implicitly has an 'any' type.
       (context, previous = []) => [...previous, normalizeContext(context)],
     )
+    .option('--json', 'Output environment variables as JSON')
     .addExamples([
       'netlify env:unset VAR_NAME # unset in all contexts',
       'netlify env:unset VAR_NAME --context production',

--- a/src/commands/functions/functions.ts
+++ b/src/commands/functions/functions.ts
@@ -1,4 +1,4 @@
-import { OptionValues } from 'commander'
+import { Option, OptionValues } from 'commander'
 
 import { chalk } from '../../utils/command-helpers.js'
 import requiresSiteInfo from '../../utils/hooks/requires-site-info.js'
@@ -97,7 +97,7 @@ NOT the same as listing the functions that have been deployed. For that info you
     .description('Serve functions locally')
     .option('-f, --functions <dir>', 'Specify a functions directory to serve')
     .option('-p, --port <port>', 'Specify a port for the functions server', (value) => Number.parseInt(value))
-    .option('-o, --offline', 'disables any features that require network access')
+    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
     .addHelpText('after', 'Helpful for debugging functions.')
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { functionsServe } = await import('./functions-serve.js')

--- a/src/commands/functions/functions.ts
+++ b/src/commands/functions/functions.ts
@@ -1,10 +1,10 @@
-import { Option, OptionValues } from 'commander'
+import type { OptionValues } from 'commander'
 
 import { chalk } from '../../utils/command-helpers.js'
 import requiresSiteInfo from '../../utils/hooks/requires-site-info.js'
-import BaseCommand from '../base-command.js'
+import type BaseCommand from '../base-command.js'
 
-const functions = (options: OptionValues, command: BaseCommand) => {
+const functions = (_options: OptionValues, command: BaseCommand) => {
   command.help()
 }
 
@@ -28,6 +28,7 @@ export const createFunctionsCommand = (program: BaseCommand) => {
     .option('-n, --name <name>', 'function name')
     .option('-u, --url <url>', 'pull template from URL')
     .option('-l, --language <lang>', 'function language')
+    .option('-o, --offline', 'Disables any features that require network access')
     .addExamples([
       'netlify functions:create',
       'netlify functions:create hello-world',
@@ -59,6 +60,7 @@ export const createFunctionsCommand = (program: BaseCommand) => {
       'simulate Netlify Identity authentication JWT. pass --no-identity to affirm unauthenticated request',
     )
     .option('--port <port>', 'Port where netlify dev is accessible. e.g. 8888', (value) => Number.parseInt(value))
+    .option('-o, --offline', 'Disables any features that require network access')
     .addExamples([
       'netlify functions:invoke',
       'netlify functions:invoke myfunction',
@@ -84,8 +86,7 @@ Helpful for making sure that you have formatted your functions correctly
 NOT the same as listing the functions that have been deployed. For that info you need to go to your Netlify deploy log.`,
     )
     .option('-f, --functions <dir>', 'Specify a functions directory to list')
-    // The BaseCommand defines a `--json` option which is hidden from the help by default
-    .addHelpOption(new Option('--json', 'Output function data as JSON'))
+    .option('--json', 'Output function data as JSON')
     .hook('preAction', requiresSiteInfo)
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { functionsList } = await import('./functions-list.js')
@@ -98,7 +99,7 @@ NOT the same as listing the functions that have been deployed. For that info you
     .description('Serve functions locally')
     .option('-f, --functions <dir>', 'Specify a functions directory to serve')
     .option('-p, --port <port>', 'Specify a port for the functions server', (value) => Number.parseInt(value))
-    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
+    .option('-o, --offline', 'Disables any features that require network access')
     .addHelpText('after', 'Helpful for debugging functions.')
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { functionsServe } = await import('./functions-serve.js')

--- a/src/commands/functions/functions.ts
+++ b/src/commands/functions/functions.ts
@@ -84,7 +84,8 @@ Helpful for making sure that you have formatted your functions correctly
 NOT the same as listing the functions that have been deployed. For that info you need to go to your Netlify deploy log.`,
     )
     .option('-f, --functions <dir>', 'Specify a functions directory to list')
-    .option('--json', 'Output function data as JSON')
+    // The BaseCommand defines a `--json` option which is hidden from the help by default
+    .addHelpOption(new Option('--json', 'Output function data as JSON'))
     .hook('preAction', requiresSiteInfo)
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { functionsList } = await import('./functions-list.js')

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -18,7 +18,7 @@ export const createServeCommand = (program: BaseCommand) =>
     .option('-p ,--port <port>', 'port of netlify dev', (value) => Number.parseInt(value))
     .option('-d ,--dir <path>', 'dir with static files')
     .option('-f ,--functions <folder>', 'specify a functions folder to serve')
-    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
+    .option('-o, --offline', 'Disables any features that require network access')
     .addOption(
       new Option(
         '--internal-disable-edge-functions',

--- a/src/commands/serve/index.ts
+++ b/src/commands/serve/index.ts
@@ -18,7 +18,7 @@ export const createServeCommand = (program: BaseCommand) =>
     .option('-p ,--port <port>', 'port of netlify dev', (value) => Number.parseInt(value))
     .option('-d ,--dir <path>', 'dir with static files')
     .option('-f ,--functions <folder>', 'specify a functions folder to serve')
-    .option('-o ,--offline', 'disables any features that require network access')
+    .addHelpOption(new Option('-o, --offline', 'Disables any features that require network access'))
     .addOption(
       new Option(
         '--internal-disable-edge-functions',

--- a/src/commands/sites/sites.ts
+++ b/src/commands/sites/sites.ts
@@ -1,4 +1,4 @@
-import { OptionValues, InvalidArgumentError } from 'commander'
+import { OptionValues, InvalidArgumentError, Option } from 'commander'
 
 import BaseCommand from '../base-command.js'
 
@@ -71,7 +71,8 @@ export const createSitesCommand = (program: BaseCommand) => {
   program
     .command('sites:list')
     .description('List all sites you have access to')
-    .option('--json', 'Output site data as JSON')
+    // The BaseCommand defines a `--json` option which is hidden from the help by default
+    .addHelpOption(new Option('--json', 'Output site data as JSON'))
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { sitesList } = await import('./sites-list.js')
       await sitesList(options, command)

--- a/src/commands/sites/sites.ts
+++ b/src/commands/sites/sites.ts
@@ -1,4 +1,4 @@
-import { OptionValues, InvalidArgumentError, Option } from 'commander'
+import { OptionValues, InvalidArgumentError } from 'commander'
 
 import BaseCommand from '../base-command.js'
 
@@ -71,8 +71,7 @@ export const createSitesCommand = (program: BaseCommand) => {
   program
     .command('sites:list')
     .description('List all sites you have access to')
-    // The BaseCommand defines a `--json` option which is hidden from the help by default
-    .addHelpOption(new Option('--json', 'Output site data as JSON'))
+    .option('--json', 'Output site data as JSON')
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { sitesList } = await import('./sites-list.js')
       await sitesList(options, command)

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -13,10 +13,11 @@ export const createStatusCommand = (program: BaseCommand) => {
       await statusHooks(options, command)
     })
 
-  return program
+  program
     .command('status')
     .description('Print status information')
     .option('--verbose', 'Output system info')
+    .option('--json', 'Output status information as JSON')
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { status } = await import('./status.js')
       await status(options, command)

--- a/src/lib/functions/runtimes/js/builders/netlify-lambda.ts
+++ b/src/lib/functions/runtimes/js/builders/netlify-lambda.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { resolve } from 'path'
 
-import { program } from 'commander'
+import { Command } from 'commander'
 
 import execa from '../../../../../utils/execa.js'
 import { fileExistsAsync } from '../../../../fs.js'
@@ -14,19 +14,21 @@ export const detectNetlifyLambda = async function ({ packageJson } = {}) {
     return false
   }
 
+  const program = new Command()
+    .option('-s, --static')
+    .option('-c, --config [file]')
+    .option('-p, --port [number]')
+    .option('-b, --babelrc [file]')
+    .option('-t, --timeout [delay]')
+
+  program.allowExcessArguments()
+
   // @ts-expect-error TS(2571) FIXME: Object is of type 'unknown'.
   const matchingScripts = Object.entries(scripts).filter(([, script]) => script.match(/netlify-lambda\s+build/))
 
   for (const [key, script] of matchingScripts) {
     // E.g. ["netlify-lambda", "build", "functions/folder"]
     // these are all valid options for netlify-lambda
-    program
-      .option('-s, --static')
-      .option('-c, --config [file]')
-      .option('-p, --port [number]')
-      .option('-b, --babelrc [file]')
-      .option('-t, --timeout [delay]')
-
     program.parse((script as string).split(' ') ?? [])
 
     // We are not interested in 'netlify-lambda' and 'build' commands

--- a/tests/integration/commands/help/__snapshots__/help.test.ts.snap
+++ b/tests/integration/commands/help/__snapshots__/help.test.ts.snap
@@ -44,6 +44,8 @@ USAGE
 OPTIONS
   -h, --help             display help for command
   --debug                Print debugging information
+  --auth <token>         Netlify auth token - can be used to run this command
+                         without logging in
 
 DESCRIPTION
   Run this command to see instructions for your shell.


### PR DESCRIPTION
#### Summary

This upgrades commander from v10 to v12. (The latest is v13, but we'll cross that bridge later.)

This revealed some errors in some command options, which this PR also fixes.

#### Details

The two main updates in this PR are due to https://github.com/tj/commander.js/pull/2055, which no longer allows redefining the same option twice on the same command:
1. We were doing this intentionally by defining a few options in the `BaseCommand` with the option hidden from help and then redefining it in some specific commands. I decided to bite the bullet here and just refactored these three problematic options:
    - I moved `--json` and `--offline` entirely out of `BaseCommand`. This uncovered that we weren't exhaustively redeclaring this on all the commands that use it. I fixed those.
    - I moved `--auth` entirely _into_ `BaseCommand`. It's intended as an alternative authentication mechanism to `ntl login` and `NETLIFY_AUTH_TOKEN`, so I believe this is reasonable.
2. We were doing this unintentionally in a few places, where we were using the same short flag for two options on the same command, resulting in the last registered one being quietly not registered. I chose new flags for these. You could argue this is a breaking change, but these options seemingly never worked. This will be in a major anyway so it's fine.

This did result in some docs/help changes, but IMO they're good changes. It did result in a handful of commands now having a documented `--auth` option that doesn't make much sense, but I'm not sure it's worth the effort to find some way to hide those.