### PR TITLE
fix: hide dynamic ssg endpoint resolution under environment variable

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -354,7 +354,10 @@ const serveRedirect = async function ({
   const reqUrl = reqToURL(req, req.url)
 
   const staticFile = await getStatic(decodeURIComponent(reqUrl.pathname), options.publicFolder)
-  const endpointExists = !staticFile && (await isEndpointExists(decodeURIComponent(reqUrl.pathname), options.target))
+  const endpointExists =
+    !staticFile &&
+    process.env.NETLIFY_DEV_SERVER_CHECK_SSG_ENDPOINTS &&
+    (await isEndpointExists(decodeURIComponent(reqUrl.pathname), options.target))
   if (staticFile || endpointExists) {
     const pathname = staticFile || reqUrl.pathname
     req.url = encodeURI(pathname) + reqUrl.search

--- a/tests/integration/commands/dev/redirects.test.ts
+++ b/tests/integration/commands/dev/redirects.test.ts
@@ -29,7 +29,7 @@ describe('redirects', () => {
     })
   })
 
-  setupFixtureTests('next-app', { devServer: true }, () => {
+  setupFixtureTests('next-app', { devServer: { env: { NETLIFY_DEV_SERVER_CHECK_SSG_ENDPOINTS: 1 } } }, () => {
     test<FixtureTestContext>('should prefer local files instead of redirect when not forced', async ({ devServer }) => {
       const response = await fetch(`http://localhost:${devServer.port}/test.txt`, {})
 

--- a/tests/integration/utils/fixture.ts
+++ b/tests/integration/utils/fixture.ts
@@ -27,7 +27,7 @@ export interface FixtureTestContext {
 type LifecycleHook = (context: FixtureTestContext) => Promise<void> | void
 
 export interface FixtureOptions {
-  devServer?: boolean | { serve?: boolean; args?: string[] }
+  devServer?: boolean | { serve?: boolean; args?: string[]; env?: Record<string, any> }
   mockApi?: MockApiOptions
   /**
    * Executed after fixture setup, but before tests run
@@ -156,6 +156,7 @@ export async function setupFixtureTests(
           args.push(...options.devServer.args)
         }
 
+        const env = typeof options.devServer === 'object' && options.devServer.env
         devServer = await startDevServer({
           serve: typeof options.devServer === 'object' && options.devServer.serve,
           cwd: fixture.directory,
@@ -165,6 +166,7 @@ export async function setupFixtureTests(
             NETLIFY_API_URL: mockApi?.apiUrl,
             NETLIFY_SITE_ID: 'foo',
             NETLIFY_AUTH_TOKEN: 'fake-token',
+            ...env,
           },
         })
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Hides this functionality under env var for better control/transition period while discussing it

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
