### PR TITLE
feat: add `ai-context` recipe

### DIFF
--- a/src/commands/recipes/recipes.ts
+++ b/src/commands/recipes/recipes.ts
@@ -11,7 +11,7 @@ import { getRecipe, listRecipes } from './common.js'
 
 const SUGGESTION_TIMEOUT = 1e4
 
-interface RunRecipeOptions {
+export interface RunRecipeOptions {
   args: string[]
   command?: BaseCommand
   config: unknown

--- a/src/recipes/ai-context/context.ts
+++ b/src/recipes/ai-context/context.ts
@@ -2,16 +2,17 @@ import { promises as fs } from 'node:fs'
 import { dirname } from 'node:path'
 
 const ATTRIBUTES_REGEX = /(\S*)="([^\s"]*)"/gim
+const BASE_URL = 'https://docs.netlify.com/ai-context'
+export const FILE_NAME = 'netlify-development.mdc'
 const MINIMUM_CLI_VERSION_HEADER = 'x-cli-min-ver'
 export const NETLIFY_PROVIDER = 'netlify'
 const PROVIDER_CONTEXT_REGEX = /<providercontext ([^>]*)>(.*)<\/providercontext>/ims
 const PROVIDER_CONTEXT_OVERRIDES_REGEX = /<providercontextoverrides([^>]*)>(.*)<\/providercontextoverrides>/ims
 const PROVIDER_CONTEXT_OVERRIDES_TAG = 'ProviderContextOverrides'
-const BASE_URL = 'https://docs.netlify.com/ai-context/netlify-development.mdc'
 
 export const downloadFile = async (cliVersion: string) => {
   try {
-    const res = await fetch(BASE_URL, {
+    const res = await fetch(`${BASE_URL}/${FILE_NAME}`, {
       headers: {
         'user-agent': `NetlifyCLI ${cliVersion}`,
       },

--- a/src/recipes/ai-context/context.ts
+++ b/src/recipes/ai-context/context.ts
@@ -1,0 +1,138 @@
+import { promises as fs } from 'node:fs'
+import { dirname } from 'node:path'
+
+const ATTRIBUTES_REGEX = /(\S*)="([^\s"]*)"/gim
+const MINIMUM_CLI_VERSION_HEADER = 'x-cli-min-ver'
+export const NETLIFY_PROVIDER = 'netlify'
+const PROVIDER_CONTEXT_REGEX = /<providercontext ([^>]*)>(.*)<\/providercontext>/ims
+const PROVIDER_CONTEXT_OVERRIDES_REGEX = /<providercontextoverrides([^>]*)>(.*)<\/providercontextoverrides>/ims
+const PROVIDER_CONTEXT_OVERRIDES_TAG = 'ProviderContextOverrides'
+const BASE_URL = 'https://docs.netlify.com/ai-context/netlify-development.mdc'
+
+export const downloadFile = async (cliVersion: string) => {
+  try {
+    const res = await fetch(BASE_URL, {
+      headers: {
+        'user-agent': `NetlifyCLI ${cliVersion}`,
+      },
+    })
+    const contents = await res.text()
+    const minimumCLIVersion = res.headers.get(MINIMUM_CLI_VERSION_HEADER) ?? undefined
+
+    return {
+      contents,
+      minimumCLIVersion,
+    }
+  } catch {
+    // no-op
+  }
+
+  return null
+}
+
+interface ParsedContextFile {
+  contents: string
+  innerContents?: string
+  overrides?: {
+    contents?: string
+    innerContents?: string
+  }
+  provider?: string
+  version?: string
+}
+
+/**
+ * Parses the `<ProviderContext>` and `<ProviderContextOverrides>` blocks in
+ * a context file.
+ */
+export const parseContextFile = (contents: string) => {
+  const result: ParsedContextFile = {
+    contents,
+  }
+
+  const providerContext = contents.match(PROVIDER_CONTEXT_REGEX)
+
+  if (providerContext) {
+    const [, attributes, innerContents] = providerContext
+
+    result.innerContents = innerContents
+
+    for (const [, name, value] of attributes.matchAll(ATTRIBUTES_REGEX)) {
+      switch (name.toLowerCase()) {
+        case 'provider':
+          result.provider = value
+
+          break
+
+        case 'version':
+          result.version = value
+
+          break
+
+        default:
+          continue
+      }
+    }
+  }
+
+  const contextOverrides = contents.match(PROVIDER_CONTEXT_OVERRIDES_REGEX)
+
+  if (contextOverrides) {
+    const [overrideContents, , innerContents] = contextOverrides
+
+    result.overrides = {
+      contents: overrideContents,
+      innerContents,
+    }
+  }
+
+  return result
+}
+
+/**
+ * Takes a context file (a template) and injects a string in an overrides block
+ * if one is found. Returns the resulting context file.
+ */
+export const applyOverrides = (template: string, overrides?: string) => {
+  if (!overrides) {
+    return template
+  }
+
+  return template.replace(
+    PROVIDER_CONTEXT_OVERRIDES_REGEX,
+    `<${PROVIDER_CONTEXT_OVERRIDES_TAG}>${overrides}</${PROVIDER_CONTEXT_OVERRIDES_TAG}>`,
+  )
+}
+
+/**
+ * Reads a file on disk and tries to parse it as a context file.
+ */
+export const getExistingContext = async (path: string) => {
+  try {
+    const stats = await fs.stat(path)
+
+    if (!stats.isFile()) {
+      throw new Error(`${path} already exists but is not a file. Please remove it or rename it and try again.`)
+    }
+
+    const file = await fs.readFile(path, 'utf8')
+    const parsedFile = parseContextFile(file)
+
+    return parsedFile
+  } catch (error) {
+    const exception = error as NodeJS.ErrnoException
+
+    if (exception.code !== 'ENOENT') {
+      throw new Error(`Could not open context file at ${path}: ${exception.message}`)
+    }
+
+    return null
+  }
+}
+
+export const writeFile = async (path: string, contents: string) => {
+  const directory = dirname(path)
+
+  await fs.mkdir(directory, { recursive: true })
+  await fs.writeFile(path, contents)
+}

--- a/src/recipes/ai-context/index.ts
+++ b/src/recipes/ai-context/index.ts
@@ -1,0 +1,129 @@
+import { resolve } from 'node:path'
+
+import inquirer from 'inquirer'
+import semver from 'semver'
+
+import type { RunRecipeOptions } from '../../commands/recipes/recipes.js'
+import { chalk, error, log, version } from '../../utils/command-helpers.js'
+
+import {
+  applyOverrides,
+  downloadFile,
+  getExistingContext,
+  parseContextFile,
+  writeFile,
+  NETLIFY_PROVIDER,
+} from './context.js'
+
+export const description = 'Create and update context files for AI tools'
+
+const toolOptions = [
+  { name: 'Cursor', value: 'cursor' },
+  { name: 'Other', value: '' },
+]
+
+const TOOLS = {
+  cursor: '.cursor/rules/netlify_development_rules.mdc',
+}
+
+export const run = async ({ args, command }: RunRecipeOptions) => {
+  // Start the download in the background while we wait for the prompts.
+  // eslint-disable-next-line promise/prefer-await-to-then
+  const download = downloadFile(version).catch(() => null)
+
+  let [tool] = args
+
+  if (!tool) {
+    const { selectedTool } = await inquirer.prompt([
+      {
+        name: 'selectedTool',
+        message: "Select the AI tool you're working with",
+        type: 'list',
+        choices: toolOptions,
+      },
+    ])
+
+    tool = selectedTool
+  }
+
+  let filePath = TOOLS[tool as keyof typeof TOOLS]
+
+  if (!filePath) {
+    const { selectedPath } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'selectedPath',
+        message: 'Enter the path, relative to the project root, where the context files should be placed',
+        default: './ai-context/netlify_development_rules.mdc',
+      },
+    ])
+
+    filePath = selectedPath
+  }
+
+  const { contents: downloadedFile, minimumCLIVersion } = (await download) ?? {}
+
+  if (!downloadedFile) {
+    error('An error occurred when pulling the latest context files. Please try again.')
+
+    return
+  }
+
+  if (minimumCLIVersion && semver.lt(version, minimumCLIVersion)) {
+    error(
+      `This command requires version ${minimumCLIVersion} or above of the Netlify CLI. Refer to ${chalk.underline(
+        'https://ntl.fyi/update-cli',
+      )} for information on how to update.`,
+    )
+
+    return
+  }
+
+  const absoluteFilePath = resolve(command?.workingDir ?? '', filePath)
+  const existing = await getExistingContext(absoluteFilePath)
+  const remote = parseContextFile(downloadedFile)
+
+  let { contents } = remote
+
+  // Does a file already exist at this path?
+  if (existing) {
+    // If it's a file we've created, let's check the version and bail if we're
+    // already on the latest, otherwise rewrite it with the latest version.
+    if (existing.provider?.toLowerCase() === NETLIFY_PROVIDER) {
+      if (remote?.version === existing.version) {
+        log(
+          `You're all up to date! ${chalk.underline(
+            absoluteFilePath,
+          )} contains the latest version of the context files.`,
+        )
+
+        return
+      }
+
+      // We must preserve any overrides found in the existing file.
+      contents = applyOverrides(remote.contents, existing.overrides?.innerContents)
+    } else {
+      // If this is not a file we've created, we can offer to overwrite it and
+      // preserve the existing contents by moving it to the overrides slot.
+      const { confirm } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'confirm',
+        message: `A context file already exists at ${chalk.underline(
+          absoluteFilePath,
+        )}. It has not been created by the Netlify CLI, but we can update it while preserving its existing content. Can we proceed?`,
+        default: true,
+      })
+
+      if (!confirm) {
+        return
+      }
+
+      // Whatever exists in the file goes in the overrides block.
+      contents = applyOverrides(remote.contents, existing.contents)
+    }
+  }
+
+  await writeFile(absoluteFilePath, contents)
+
+  log(`${existing ? 'Updated' : 'Created'} context files at ${chalk.underline(absoluteFilePath)}`)
+}

--- a/tests/integration/commands/recipes/__snapshots__/recipes.test.js.snap
+++ b/tests/integration/commands/recipes/__snapshots__/recipes.test.js.snap
@@ -6,6 +6,7 @@ exports[`commands/recipes > Shows a list of all the available recipes 1`] = `
 |-----------------------------------------------------------------------------------------|
 |     Name      |                               Description                               |
 |---------------|-------------------------------------------------------------------------|
+| ai-context    | Manage context files for AI tools                                       |
 | blobs-migrate | Migrate legacy Netlify Blobs stores                                     |
 | vscode        | Create VS Code settings for an optimal experience with Netlify projects |
 '-----------------------------------------------------------------------------------------'"

--- a/tests/unit/recipes/ai-context/context.test.ts
+++ b/tests/unit/recipes/ai-context/context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest'
+
+import { applyOverrides, parseContextFile } from '../../../../dist/recipes/ai-context/context.js'
+
+describe('applyOverrides', () => {
+  test('applies overrides to a context file', () => {
+    const file = `
+    <ProviderContextOverrides>sdf</ProviderContextOverrides>
+    <ProviderContext version="1.0" provider="Netlify">This is the contents
+      Something here
+      Something there
+    </ProviderContext>`
+    const expected = `
+    <ProviderContextOverrides>Here come the overrides</ProviderContextOverrides>
+    <ProviderContext version="1.0" provider="Netlify">This is the contents
+      Something here
+      Something there
+    </ProviderContext>`
+
+    expect(applyOverrides(file, 'Here come the overrides')).toBe(expected)
+  })
+
+  test('supports a multiline overrides slot', () => {
+    const file = `
+    <ProviderContextOverrides>
+      This is where overrides go
+    </ProviderContextOverrides>
+    <ProviderContext version="1.0" provider="Netlify">This is the contents
+      Something here
+      Something there
+    </ProviderContext>`
+    const expected = `
+    <ProviderContextOverrides>Here come the overrides</ProviderContextOverrides>
+    <ProviderContext version="1.0" provider="Netlify">This is the contents
+      Something here
+      Something there
+    </ProviderContext>`
+
+    expect(applyOverrides(file, 'Here come the overrides')).toBe(expected)
+  })
+})
+
+describe('parseContextFile', () => {
+  test('extracts the provider, version and contents', () => {
+    const file = `<ProviderContext provider="Netlify" version="1.0">This is the contents</ProviderContext>`
+
+    expect(parseContextFile(file)).toStrictEqual({
+      provider: 'Netlify',
+      version: '1.0',
+      contents: file,
+      innerContents: 'This is the contents',
+    })
+  })
+
+  test('ignores unknown attributes', () => {
+    const file = `<ProviderContext foo="bar" provider="Netlify" version="1.0">This is the contents</ProviderContext>`
+
+    expect(parseContextFile(file)).toStrictEqual({
+      provider: 'Netlify',
+      version: '1.0',
+      contents: file,
+      innerContents: 'This is the contents',
+    })
+  })
+
+  test('ignores the order of attributes', () => {
+    const file = `<ProviderContext version="1.0" provider="Netlify">This is the contents</ProviderContext>`
+
+    expect(parseContextFile(file)).toStrictEqual({
+      provider: 'Netlify',
+      version: '1.0',
+      contents: file,
+      innerContents: 'This is the contents',
+    })
+  })
+
+  test('extracts overrides', () => {
+    const overrides = `<ProviderContextOverrides>This will be kept</ProviderContextOverrides>`
+    const file = `
+      ${overrides}
+      <ProviderContext version="1.0" provider="Netlify">This is the contents
+        Something here
+        Something there
+      </ProviderContext>`
+
+    expect(parseContextFile(file)).toStrictEqual({
+      provider: 'Netlify',
+      version: '1.0',
+      contents: file,
+      innerContents: `This is the contents
+        Something here
+        Something there
+      `,
+      overrides: {
+        contents: overrides,
+        innerContents: 'This will be kept',
+      },
+    })
+  })
+})


### PR DESCRIPTION
#### Summary

Adds a `ai-context` recipe that creates context files for AI tools.

Usage:

- `ntl recipes ai-context <directory>`: Saves context files on the given directory
- `ntl recipes ai-context`: Prompts the user for the location of where the context files should be placed