### PR TITLE
fix: skip checking for endpoint existence for hidden redirects

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -349,10 +349,14 @@ const serveRedirect = async function ({
   }
 
   const reqUrl = reqToURL(req, req.url)
+  const isHiddenProxy =
+    match.proxyHeaders &&
+    Object.entries(match.proxyHeaders).some(([key, val]) => key.toLowerCase() === 'x-nf-hidden-proxy' && val === 'true')
 
   const staticFile = await getStatic(decodeURIComponent(reqUrl.pathname), options.publicFolder)
   const endpointExists =
     !staticFile &&
+    !isHiddenProxy &&
     process.env.NETLIFY_DEV_SERVER_CHECK_SSG_ENDPOINTS &&
     (await isEndpointExists(decodeURIComponent(reqUrl.pathname), options.target))
   if (staticFile || endpointExists) {
@@ -388,11 +392,6 @@ const serveRedirect = async function ({
         // This is a redirect, so we set the complete external URL as destination
         destURL = `${dest}`
       } else {
-        const isHiddenProxy =
-          match.proxyHeaders &&
-          Object.entries(match.proxyHeaders).some(
-            ([key, val]) => key.toLowerCase() === 'x-nf-hidden-proxy' && val === 'true',
-          )
         if (!isHiddenProxy) {
           console.log(`${NETLIFYDEVLOG} Proxying to ${dest}`)
         }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

For dev servers context, whenever the env var `NETLIFY_DEV_SERVER_CHECK_SSG_ENDPOINTS` is used (currently by dev server), skip the checks for the endpoint existence in case `hidden-proxy` header present.

Redirect works, but because of the endpoint check - it makes unnecessary request for the current server, which produces in case of remix unnecessary console output. For instance, when used with plugin-dev-server, which has redirect:

```
{
        from: `/.ntlfy-dev/*`,
        to: `http://localhost:${port}/:splat`,
        status: 200,
        headers: {
          'x-nf-hidden-proxy': 'true',
        },
}
```

Has next output when something tries to fire a request to `/.ntlfy-dev/health`

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/2cc54492-f6a2-484b-bc85-f9dbbc49ed38" />


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
