### PR TITLE
ci: fix new job config

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,7 @@ jobs:
   format:
     name: Format
     if: "${{ !startsWith(github.head_ref, 'release-') }}"
+    runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,5 +21,8 @@ jobs:
           cache: npm
       - name: Install core dependencies
         run: npm ci --no-audit
+      # Almost not needed, but a single file in `scripts/` imports built code
+      - name: Build package
+        run: npm run build
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: Lint
     if: "${{ !startsWith(github.head_ref, 'release-') }}"
+    runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
#### Summary

Whoops. I split up a job in https://github.com/netlify/cli/pull/7069, but it turns out if your workflow is invalid, it doesn't even report as failed. And I hadn't marked the new jobs as required yet. 🤦🏼

**Note:** Now that these jobs have run successfully once on this PR, I was able to mark the checks as required.