### PR TITLE
ci: split lint, format tasks into jobs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,25 @@
+---
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.14.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit
+
+      - name: Lint
+        run: npm run format:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+---
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.14.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Install core dependencies
         run: npm ci --no-audit
         if: '${{!steps.release-check.outputs.IS_RELEASE}}'
-
-      - name: Formatting
-        run: npm run format:check
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
-
       - name: Run unit tests
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,10 +45,6 @@ jobs:
         run: npm run format:check
         if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
-      - name: Linting
-        run: npm run lint
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
-
       - name: Run unit tests
         uses: nick-fields/retry@v3
         with:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start": "node ./bin/run.js",
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "run-s format test:dev",
+    "test": "npm run test:dev",
     "format": "npm run _format -- --write",
     "format:check": "npm run _format -- --check",
     "lint": "eslint --cache \"{src,scripts,tests,.github}/**/*.{mjs,cjs,js,md,html}\" \"*.{mjs,cjs,js,md,html}\"",


### PR DESCRIPTION
This changeset splits the lint and format tasks--formerly run as part of the unit test job--into their own CI jobs.