### PR TITLE
build: relocate site netlify.toml to site/ directory

### DIFF
--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -11,19 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v4
-      - name: Use Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: npm
-      - name: Install core dependencies
+
+      - name: Install dependencies
         run: npm ci --no-audit
-      - name: Install site dependencies
-        run: npm run site:build:install
+
+      - name: Install ./site dependencies
+        run: npm ci  --prefix=site --no-audit
+
       - name: Generate docs
-        run: npm run docs
+        run: npm run --prefix=site build
+
       - name: Check for changes
         run: |
           if [ -z "$(git status --porcelain)" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,6 @@ promote a positive and inclusive environment.
 - [Releasing](#releasing)
 - [License](#license)
 
-
 ## Developing locally
 
 First, fork and clone the repository. If you’re not sure how to do this, please watch
@@ -33,7 +32,7 @@ First, fork and clone the repository. If you’re not sure how to do this, pleas
 Run:
 
 ```bash
-npm install && npm run site:build:install
+npm install
 ```
 
 Tests are run with:
@@ -91,11 +90,14 @@ DEBUG=true ./bin/run.js [command]
 
 ### Attaching a Debugger
 
-When debugging a project, it's super helpful to attach a debugger to the CLI. If you use VS Code, here's how you can do it:
+When debugging a project, it's super helpful to attach a debugger to the CLI. If you use VS Code, here's how you can do
+it:
 
 1. Open this repository in VS Code.
-2. Open a "JavaScript Debug Terminal" (e.g. by searching for it in the Command Palette (Shift-Cmd+P)). Every Node process that's opened in this terminal will have a debugger attached.
-3. Place a breakpoint somewhere in the CLI. You will have to place them in the compiled `.js` files as opposed to the `.ts` files.
+2. Open a "JavaScript Debug Terminal" (e.g. by searching for it in the Command Palette (Shift-Cmd+P)). Every Node
+   process that's opened in this terminal will have a debugger attached.
+3. Place a breakpoint somewhere in the CLI. You will have to place them in the compiled `.js` files as opposed to the
+   `.ts` files.
 4. In your JavaScript Debug Terminal, navigate to the project you'd like to debug.
 5. Run `/path/to/netlify/cli/bin/run.js`. The debugger should be connecting automatically.
 
@@ -113,9 +115,9 @@ A good place to start is reading the base command README and looking at the comm
 
 > If you’d like to learn more on how `netlify dev` works, check [here](./docs/netlify-dev.md)
 
-
 ### Adding or updating a command
-If you're adding a new command or updating an existing one, make sure to also add docs for it by running `npm run site:build`.
+
+If you're adding a new command or updating an existing one, make sure to also add docs for it by running `npm run docs`.
 
 This will automatically generate documentation for you that will look like the following:
 
@@ -130,17 +132,17 @@ description: A description.
 <!-- AUTO-GENERATED-CONTENT:START (GENERATE_COMMANDS_DOCS) -->
 
 <!-- AUTO-GENERATED-CONTENT:END -->
-
 ```
 
-When adding a new command, you will also need to add it to the nav sidebar manually by adding it to the `navOrder` array in `site/src/_app.js`
+When adding a new command, you will also need to add it to the nav sidebar manually by adding it to the `navOrder` array
+in `site/src/_app.js`
 
 ### Updating our documentation
 
 If documentation looks to be out of date, it is likely that the code for the command itself is not correct.
 
-To update the documentation, update the code (rather than the markdown files) and then run `npm run docs` to sync the docs. To confirm that the changes to the docs are correct, run `cd site && npm run dev:start` to run the docs locally.
-
+To update the documentation, update the code (rather than the markdown files) and then run `npm run docs` to sync the
+docs. To confirm that the changes to the docs are correct, run `cd site && npm run dev:start` to run the docs locally.
 
 ### Testing
 
@@ -200,7 +202,8 @@ We actively welcome your pull requests.
 
 ## Releasing
 
-Tag the 'release' pull request using the `automerge` label. This will merge the pull request on GitHub and publish the package to npm.
+Tag the 'release' pull request using the `automerge` label. This will merge the pull request on GitHub and publish the
+package to npm.
 
 ### Creating a prerelease
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bugsnag/js": "8.2.0",
         "@fastify/static": "7.0.4",
         "@netlify/blobs": "8.1.1",
         "@netlify/build": "29.59.2",
@@ -120,6 +119,7 @@
       },
       "devDependencies": {
         "@babel/preset-react": "7.26.3",
+        "@bugsnag/js": "8.2.0",
         "@eslint/compat": "^1.2.7",
         "@eslint/js": "^9.21.0",
         "@netlify/functions": "3.0.1",
@@ -625,6 +625,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.2.0.tgz",
       "integrity": "sha512-C4BfE3eVsjOAqoXbdrPXfKbgp/hz2H7mKBU0p11Jf9uz+5gUCfZK+39JLrQKvRXwqoDcTlBSfz9Xz5kXLyHg2Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bugsnag/core": "^8.2.0"
       }
@@ -633,6 +635,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.2.0.tgz",
       "integrity": "sha512-dFSs80ZwJ508nlC6UTLTUMdHgTaHY5UKvMiuHqstCQrQrOjqFcIv+x4o+l2WrSyOpoYhHAxDlKfzKN8AjwslQw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -650,6 +654,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.2.0.tgz",
       "integrity": "sha512-DTtQwV1Ly5VXSOnVtzW8gSwB+ld3qIc/h0yMS836DEYUfA3V9JPwJE3+2EbD8Ea2ogkDWZ+a0jl0SNSNGiOmfA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bugsnag/browser": "^8.2.0",
         "@bugsnag/node": "^8.2.0"
@@ -659,6 +665,8 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.2.0.tgz",
       "integrity": "sha512-6XC/KgX61m6YFgsBQP/GaH1UzlJkJmpi3AwlZQLsXloRh3O9lM/0EIk6+2sZm+vlz+GwxCFavcuIDgVmH/qi7Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bugsnag/core": "^8.2.0",
         "byline": "^5.0.0",
@@ -4567,7 +4575,6 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -20819,6 +20826,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.2.0.tgz",
       "integrity": "sha512-C4BfE3eVsjOAqoXbdrPXfKbgp/hz2H7mKBU0p11Jf9uz+5gUCfZK+39JLrQKvRXwqoDcTlBSfz9Xz5kXLyHg2Q==",
+      "dev": true,
       "requires": {
         "@bugsnag/core": "^8.2.0"
       }
@@ -20827,6 +20835,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.2.0.tgz",
       "integrity": "sha512-dFSs80ZwJ508nlC6UTLTUMdHgTaHY5UKvMiuHqstCQrQrOjqFcIv+x4o+l2WrSyOpoYhHAxDlKfzKN8AjwslQw==",
+      "dev": true,
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -20844,6 +20853,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.2.0.tgz",
       "integrity": "sha512-DTtQwV1Ly5VXSOnVtzW8gSwB+ld3qIc/h0yMS836DEYUfA3V9JPwJE3+2EbD8Ea2ogkDWZ+a0jl0SNSNGiOmfA==",
+      "dev": true,
       "requires": {
         "@bugsnag/browser": "^8.2.0",
         "@bugsnag/node": "^8.2.0"
@@ -20853,6 +20863,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.2.0.tgz",
       "integrity": "sha512-6XC/KgX61m6YFgsBQP/GaH1UzlJkJmpi3AwlZQLsXloRh3O9lM/0EIk6+2sZm+vlz+GwxCFavcuIDgVmH/qi7Q==",
+      "dev": true,
       "requires": {
         "@bugsnag/core": "^8.2.0",
         "byline": "^5.0.0",
@@ -23260,8 +23271,7 @@
       "dependencies": {
         "napi-wasm": {
           "version": "1.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,16 +54,12 @@
     "e2e": "node ./tools/e2e/run.js",
     "docs": "npm run --prefix=site build",
     "watch": "c8 --reporter=lcov vitest --watch",
-    "site:build": "run-s site:build:*",
-    "site:build:install": "cd site && npm install --no-audit",
-    "site:build:assets": "cd site && npm run build",
     "postinstall-pack": "node ./scripts/postinstall.js",
     "postinstall": "npm run build && node ./scripts/postinstall.js",
     "prepublishOnly": "node ./scripts/prepare-for-publish.js",
     "certs": "openssl req -x509 -out localhost.crt -keyout localhost.key -newkey rsa:2048 -nodes -sha256 -subj \"/CN=localhost\" -extensions EXT -config certconf"
   },
   "dependencies": {
-    "@bugsnag/js": "8.2.0",
     "@fastify/static": "7.0.4",
     "@netlify/blobs": "8.1.1",
     "@netlify/build": "29.59.2",
@@ -169,6 +165,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "7.26.3",
+    "@bugsnag/js": "8.2.0",
     "@eslint/compat": "^1.2.7",
     "@eslint/js": "^9.21.0",
     "@netlify/functions": "3.0.1",

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,14 +1,8 @@
 [build]
-  # This will be run the site build
-  command = "npm run site:build"
-  # This is the directory is publishing to netlify's CDN
-  publish = "site/dist"
+  command = "pushd .. && npm ci --no-verify && popd && npm run build"
+  publish = "dist"
 
 [functions]
-  # Sets a custom directory for Netlify Functions
-  directory = "functions"
-
-  # Specifies `esbuild` for functions bundling
   node_bundler = "esbuild"
 
 #####################

--- a/site/netlify/functions/error-reporting.ts
+++ b/site/netlify/functions/error-reporting.ts
@@ -1,7 +1,7 @@
 import process from 'process'
 
 import Bugsnag from '@bugsnag/js'
-import { Handler } from '@netlify/functions'
+import type { Handler } from '@netlify/functions'
 
 Bugsnag.start({
   apiKey: `${process.env.NETLIFY_BUGSNAG_API_KEY}`,

--- a/site/netlify/functions/telemetry.js
+++ b/site/netlify/functions/telemetry.js
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch'
-
 const TELEMETRY_SERVICE_URL = 'https://cli-telemetry.netlify.engineering'
 
 // This function is a workaround for our inability to redirect traffic to a ntl function in another site

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,10 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/starlight": "0.31.1",
+        "@bugsnag/js": "8.2.0",
         "astro": "5.2.5",
         "markdown-magic": "2.6.1",
         "sharp": "0.32.6",
         "strip-ansi": "7.1.0"
+      },
+      "devDependencies": {
+        "@netlify/functions": "^3.0.1",
+        "tsx": "^4.19.3"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -203,6 +208,64 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bugsnag/browser": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.2.0.tgz",
+      "integrity": "sha512-C4BfE3eVsjOAqoXbdrPXfKbgp/hz2H7mKBU0p11Jf9uz+5gUCfZK+39JLrQKvRXwqoDcTlBSfz9Xz5kXLyHg2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.2.0"
+      }
+    },
+    "node_modules/@bugsnag/core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.2.0.tgz",
+      "integrity": "sha512-dFSs80ZwJ508nlC6UTLTUMdHgTaHY5UKvMiuHqstCQrQrOjqFcIv+x4o+l2WrSyOpoYhHAxDlKfzKN8AjwslQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/cuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.2.1.tgz",
+      "integrity": "sha512-zpvN8xQ5rdRWakMd/BcVkdn2F8HKlDSbM3l7duueK590WmI1T0ObTLc1V/1e55r14WNjPd5AJTYX4yPEAFVi+Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bugsnag/js": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.2.0.tgz",
+      "integrity": "sha512-DTtQwV1Ly5VXSOnVtzW8gSwB+ld3qIc/h0yMS836DEYUfA3V9JPwJE3+2EbD8Ea2ogkDWZ+a0jl0SNSNGiOmfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/browser": "^8.2.0",
+        "@bugsnag/node": "^8.2.0"
+      }
+    },
+    "node_modules/@bugsnag/node": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.2.0.tgz",
+      "integrity": "sha512-6XC/KgX61m6YFgsBQP/GaH1UzlJkJmpi3AwlZQLsXloRh3O9lM/0EIk6+2sZm+vlz+GwxCFavcuIDgVmH/qi7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.2.0",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
+      "license": "MIT"
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.1.0",
@@ -1017,6 +1080,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@netlify/functions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-3.0.1.tgz",
+      "integrity": "sha512-KqVvGatPnn3lw80vXsFbYV3H2S9FI9TQHneFVR6BBvfHWiqTvs8NwUoBpnUWgqPKKeUMuynycDabeSi9CW2WWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/serverless-functions-api": "1.35.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@netlify/serverless-functions-api": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-1.35.0.tgz",
+      "integrity": "sha512-BH9eF3s7bUbqkcEUMR7dne/iCXSpZD10KVkGcs53eDrON5pKxsMdXvrdAx/q0HD24vJgHXGXObGSr5sjPllGEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2704,6 +2790,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3416,6 +3511,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.23.9",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
@@ -3994,6 +4098,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -5171,6 +5288,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7840,6 +7963,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -8326,6 +8459,21 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -8624,6 +8772,492 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
+      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/site/package.json
+++ b/site/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "npm run build:docs-md && npm run build:site",
     "build:docs-md": "npm run build:docs-md:gen && npm run build:docs-md:copy",
-    "build:docs-md:copy": "node ./scripts/sync.js",
-    "build:docs-md:gen": "node ./scripts/docs.js",
+    "build:docs-md:copy": "./scripts/sync.js",
+    "build:docs-md:gen": "./scripts/docs.js",
     "build:site": "astro build",
     "dev": "npm run build:docs-md:copy && astro dev",
     "preview": "npm run build:docs-md:copy && astro preview",
@@ -17,9 +17,14 @@
   "license": "MIT",
   "dependencies": {
     "@astrojs/starlight": "0.31.1",
+    "@bugsnag/js": "8.2.0",
     "astro": "5.2.5",
     "markdown-magic": "2.6.1",
     "sharp": "0.32.6",
     "strip-ansi": "7.1.0"
+  },
+  "devDependencies": {
+    "@netlify/functions": "^3.0.1",
+    "tsx": "^4.19.3"
   }
 }

--- a/site/scripts/docs.js
+++ b/site/scripts/docs.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env -S npx tsx
+
 import { basename } from 'node:path'
 import { env } from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -5,7 +7,7 @@ import { fileURLToPath } from 'node:url'
 import markdownMagic from 'markdown-magic'
 import stripAnsi from 'strip-ansi'
 
-import { normalizeBackslash } from '../../dist/lib/path.js'
+import { normalizeBackslash } from '../../src/lib/path.js'
 
 import { generateCommandData } from './util/generate-command-data.js'
 

--- a/site/scripts/sync.js
+++ b/site/scripts/sync.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env -S npx tsx
+
 import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 

--- a/site/scripts/util/generate-command-data.js
+++ b/site/scripts/util/generate-command-data.js
@@ -1,5 +1,5 @@
-import { createMainCommand } from '../../../dist/commands/index.js'
-import { sortOptions } from '../../../dist/utils/command-helpers.js'
+import { createMainCommand } from '../../../src/commands/index.js'
+import { sortOptions } from '../../../src/utils/command-helpers.js'
 
 const program = createMainCommand()
 


### PR DESCRIPTION
This change moves the site `netlify.toml` to the `site/` directory.

Previously, the site-build workflow went like this:

- Netlify Build executed `npm install` at the root of the project (by default)
- After package installation, the `postinstall` hook triggered a CLI build
- Netlify Build would execute `netlify.toml#build.command`, which:
  - Entered the docs directory
  - Ran `npm install` against `docs/package.json`
  - Ran a site build (which implicitly relied on the root directory `npm install` and `npm run build` steps)

To make this change, I modified the logic to:

- Netlify Build starts in the `site/` directory and executes `npm install`
- `site/netlify.toml#build.command`  enters the root and preps the CLI, then returns to the `docs/` directory
- We then build the site

In this way, the site's dependency on the CLI's source is more clear--we assume nothing about the state of the root directory before building the docs site.

Some other noteworthy changes here:

- While making these changes, I realized the (JavaScript) site build scripts assume that the CLI has been built to the `dist` directory. I modified them to be transpiled at runtime and to import from `src`.
  - I'm not particularly attached to this change, but it reduces the amount of setup steps required and will let us convert these scripts to TypeScript.
- I moved the site functions to the standard Netlify functions location, `site/netlify/functions`. Doing so also let me move a dependency that was only used on the site (`@bugsnag/js`) out of the root, which slims the CLI's dependency tree.
- I got rid of most of the `site:` tasks from the top-level `package.json`. (I left the `docs` task, though.)
- These changes require that we change the CLI site's [base directory](https://app.netlify.com/sites/cli/configuration/deploys) to `docs`. The site is refusing to build on `main` right now anyway, so I already made that change.