### PR TITLE
fix: ensure we pass build_data in the calls to the deploys api

### DIFF
--- a/src/utils/deploy/hash-fns.ts
+++ b/src/utils/deploy/hash-fns.ts
@@ -157,6 +157,16 @@ const hashFns = async (
     statusCb,
     tmpDir,
   })
+
+  for (const func of functionZips) {
+    if (!func.buildData) {
+      func.buildData = {
+        bootstrapVersion: func.bootstrapVersion,
+        runtimeAPIVersion: func.runtimeAPIVersion,
+      }
+    }
+  }
+
   const fileObjs = functionZips.map(
     ({
       buildData,


### PR DESCRIPTION
#### Summary

This ensures that the bundle will have the correct metadata applied to the deployment. previously this metadata would only get applied for CLI deployments that included the `--build` flag (unless the `--skip-functions-cache` flag was also applied)
