### PR TITLE
fix(docs): remove beta indicator from stable commands

### DIFF
--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -23,8 +23,8 @@ netlify logs
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`logs:deploy`](/commands/logs#logsdeploy) | (Beta) Stream the logs of deploys currently being built to the console  |
-| [`logs:function`](/commands/logs#logsfunction) | (Beta) Stream netlify function logs to the console  |
+| [`logs:deploy`](/commands/logs#logsdeploy) | Stream the logs of deploys currently being built to the console  |
+| [`logs:function`](/commands/logs#logsfunction) | Stream netlify function logs to the console  |
 
 
 **Examples**
@@ -38,7 +38,7 @@ netlify logs:function my-function
 ---
 ## `logs:deploy`
 
-(Beta) Stream the logs of deploys currently being built to the console
+Stream the logs of deploys currently being built to the console
 
 **Usage**
 
@@ -55,7 +55,7 @@ netlify logs:deploy
 ---
 ## `logs:function`
 
-(Beta) Stream netlify function logs to the console
+Stream netlify function logs to the console
 
 **Usage**
 

--- a/docs/commands/serve.md
+++ b/docs/commands/serve.md
@@ -2,7 +2,9 @@
 title: Netlify CLI serve command
 sidebar:
   label: serve
-description: (Beta) Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild your site then you must exit and run `serve` again.
+description:
+  Build the site for production and serve locally. This does not watch the code for changes, so if you need to rebuild
+  your site then you must exit and run `serve` again.
 ---
 
 # `serve`

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ Stream logs from your site
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
-| [`logs:deploy`](/commands/logs#logsdeploy) | (Beta) Stream the logs of deploys currently being built to the console  |
-| [`logs:function`](/commands/logs#logsfunction) | (Beta) Stream netlify function logs to the console  |
+| [`logs:deploy`](/commands/logs#logsdeploy) | Stream the logs of deploys currently being built to the console  |
+| [`logs:function`](/commands/logs#logsfunction) | Stream netlify function logs to the console  |
 
 
 ### [open](/commands/open)

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -8,7 +8,7 @@ export const createLogsBuildCommand = (program: BaseCommand) => {
   program
     .command('logs:deploy')
     .alias('logs:build')
-    .description('(Beta) Stream the logs of deploys currently being built to the console')
+    .description('Stream the logs of deploys currently being built to the console')
     .action(async (options: OptionValues, command: BaseCommand) => {
       const { logsBuild } = await import('./build.js')
       await logsBuild(options, command)
@@ -28,7 +28,7 @@ export const createLogsFunctionCommand = (program: BaseCommand) => {
       'netlify logs:function my-function',
       'netlify logs:function my-function -l info warn',
     ])
-    .description('(Beta) Stream netlify function logs to the console')
+    .description('Stream netlify function logs to the console')
     .action(async (functionName: string | undefined, options: OptionValues, command: BaseCommand) => {
       const { logsFunction } = await import('./functions.js')
       await logsFunction(functionName, options, command)


### PR DESCRIPTION
#### Summary

These have all been stable for a while. We just forgot to remove these beta indicators.