### PR TITLE
test: don't reset workspace when running E2E tests

### DIFF
--- a/tools/e2e/setup.js
+++ b/tools/e2e/setup.js
@@ -134,8 +134,6 @@ export const setup = async () => {
       cwd: rootDir,
     })
 
-    // Reset the workspace, as npm publish does patch package.json etc
-    await execa('git', ['checkout', '.'], { cwd: rootDir })
     await execa('npm', ['install', '--no-audit'], { cwd: rootDir })
 
     console.log(`------------------------------------------


### PR DESCRIPTION
The E2E test script unexpectedly runs a `git checkout .` on the CLI repository. If you run it locally and have any uncommitted changes, oops! It just discarded your work.

https://github.com/netlify/cli/pull/7119 removes the `package.json#scripts` pre-publish mangling that we used to do, which is ostensibly why we needed this in the first place.