### PR TITLE
ci: simplify release-please conditionals

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
   schedule:
     # check daily to notice potential package manager issues
     - cron: '0 1 * * *' # At 01:00 daily

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   format:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   integration:
@@ -28,27 +31,17 @@ jobs:
             node-version: '22'
       fail-fast: false
     steps:
-      # Sets an output parameter if this is a release PR
-      - name: Check for release
-        id: release-check
-        # For windows we have to use $env:
-        run: |-
-          echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
-          echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
-        if: "${{ startsWith(github.head_ref, 'release-') }}"
-
       # This improves Windows network performance, we need this since we open many ports in our tests
       - name: Increase Windows port limit and reduce time wait delay
         run: |
           netsh int ipv4 set dynamicport tcp start=1025 num=64511
           REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP\Parameters /v TcpTimedWaitDelay /t REG_DWORD /d 30 /f
-        if: "${{ matrix.os == 'windows-latest' && !steps.release-check.outputs.IS_RELEASE }}"
+        if: "${{ matrix.os == 'windows-latest' }}"
 
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -56,23 +49,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           check-latest: true
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Install PNPM
         run: |
           corepack enable
           corepack prepare pnpm@9.14.2 --activate
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
         with:
           deno-version: v1.44.4
 
       - name: Install core dependencies
         run: npm ci --no-audit
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Build project
         run: npm run build
@@ -80,11 +69,9 @@ jobs:
 
       - name: Prepare tests
         run: npm run test:init
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
 
       - name: Tests
         uses: nick-fields/retry@v3
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -113,7 +100,6 @@ jobs:
           echo "node=node_${node/.*.*/}" >> $GITHUB_OUTPUT
           echo "node=node_${node/.*.*/}" >> $env:GITHUB_OUTPUT
         shell: bash
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
 
       - name: Sanitize shard for artefact name
         id: sanitize-shard-name
@@ -132,7 +118,6 @@ jobs:
         with:
           flags: ${{ steps.test-coverage-flags.outputs.os }},${{ steps.test-coverage-flags.outputs.node }}
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
   # Specific tests for known test that failed on windows using node 23.
   # Can be replaced with larger node 23 tests in the future.
   integration-win-node-23:
@@ -140,15 +125,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 40
     steps:
-      # Sets an output parameter if this is a release PR
-      - name: Check for release
-        id: release-check
-        # For windows we have to use $env:
-        run: |-
-          echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
-          echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
-        if: "${{ startsWith(github.head_ref, 'release-') }}"
-
       # This improves Windows network performance, we need this since we open many ports in our tests
       - name: Increase Windows port limit and reduce time wait delay
         run: |
@@ -159,7 +135,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -167,23 +142,19 @@ jobs:
           node-version: '23.x'
           cache: npm
           check-latest: true
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Install PNPM
         run: |
           corepack enable
           corepack prepare pnpm@9.14.2 --activate
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
         with:
           deno-version: v1.44.4
 
       - name: Install core dependencies
         run: npm ci --no-audit
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Build project
         run: npm run build
@@ -191,11 +162,9 @@ jobs:
 
       - name: Prepare tests
         run: npm run test:init
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
 
       - name: Tests
         uses: nick-fields/retry@v3
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -224,7 +193,6 @@ jobs:
           echo "node=node_${node/.*.*/}" >> $GITHUB_OUTPUT
           echo "node=node_${node/.*.*/}" >> $env:GITHUB_OUTPUT
         shell: bash
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'
 
       - name: Store npm error artefacts
         uses: actions/upload-artifact@v4
@@ -239,4 +207,3 @@ jobs:
         with:
           flags: ${{ steps.test-coverage-flags.outputs.os }},${{ steps.test-coverage-flags.outputs.node }}
           token: ${{ secrets.CODECOV_TOKEN }}
-        if: '${{ !steps.release-check.outputs.IS_RELEASE }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   lint:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   typecheck:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,8 +3,12 @@ name: Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   unit:
@@ -19,18 +23,8 @@ jobs:
             node-version: '22.x'
       fail-fast: false
     steps:
-      # Sets an output parameter if this is a release PR
-      - name: Check for release
-        id: release-check
-        # For windows we have to use $env:
-        run: |-
-          echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
-          echo "IS_RELEASE=true" >> $env:GITHUB_OUTPUT
-        if: "${{ startsWith(github.head_ref, 'release-') }}"
-
       - name: Git checkout
         uses: actions/checkout@v4
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -38,15 +32,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           check-latest: true
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Install core dependencies
         run: npm ci --no-audit
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Build project
         run: npm run build
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Run unit tests
         uses: nick-fields/retry@v3
@@ -55,4 +46,3 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: npm run test:ci:vitest:unit
-        if: '${{!steps.release-check.outputs.IS_RELEASE}}'

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -3,8 +3,12 @@ name: Lint Docs
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 permissions:
   checks: write

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -3,8 +3,12 @@ name: Verify Docs
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
+    branches:
+      - '**'
+      - '!release-please--**'
 
 jobs:
   verify-docs:


### PR DESCRIPTION
This changeset modifies the CI test workflows to not run on release PRs.

One effect this PR will have is that these workflows will no longer
report a status on release-please PRs. Because we have our repo rules
configured to require these workflows' jobs to block merges to main
unless these workflows are in a passing state, merging this as is will
break release-please branches. To fix this, we'll modify the
merge-to-main ruleset to exclude the release-please bot user from the
ruleset's requirements.