### PR TITLE
ci: don't build project in integration test workflow during release

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Build project
         run: npm run build
+        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Prepare tests
         run: npm run test:init
@@ -186,6 +187,7 @@ jobs:
 
       - name: Build project
         run: npm run build
+        if: '${{!steps.release-check.outputs.IS_RELEASE}}'
 
       - name: Prepare tests
         run: npm run test:init


### PR DESCRIPTION
Regression introduced in 4571be31; we skip all other steps during the integration test workflow (git checkout, etc.), so the build step will always fail.