### PR TITLE
fix: temporarily remove broken postinstal hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "test:init:next-deps": "npm ci --prefix tests/integration/__fixtures__/next-app-without-config --no-audit && npm ci --prefix tests/integration/__fixtures__/next-app --no-audit",
     "test:ci:vitest:integration": "vitest run --coverage tests/integration/",
     "test:ci:vitest:unit": "vitest run --coverage tests/unit/",
-    "postinstall": "node ./scripts/postinstall.js",
     "prepublishOnly": "npm shrinkwrap",
     "typecheck": "tsc",
     "typecheck:watch": "tsc --watch",


### PR DESCRIPTION
#### Summary

See https://github.com/netlify/cli/issues/7141.

This will be faster than reverting a bunch of stacked PRs, and it's been too long to unpublish from the NPM registry.