### PR TITLE
fix: run E2E tests before publishing package

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Run E2E tests
+        run: npm run e2e
+
       - name: Publish package
         run: npm publish --provenance
         env:


### PR DESCRIPTION
This is technically a `test` scope, but I'm giving it a fix so it triggers a release.