### PR TITLE
test: increase test timeouts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.js', 'tests/**/*.test.ts'],
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    testTimeout: 90_000,
+    hookTimeout: 90_000,
     deps: {
       external: ['**/fixtures/**', '**/node_modules/**'],
       interopDefault: false,


### PR DESCRIPTION
I'm pretty sure part of why our integration tests are so flaky is because e.g. the Next.js tests frequently take about 60s in CI. I think by increasing the timeout, we'll greatly reduce the amount of times our test suites flake due to timeout (when they'd pass if we just gave them more time), triggering a full-suite retry.