### PR TITLE
build: do not typecheck when building

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./tsconfig.base.json"
+  "extends": "./tsconfig.base.json",
+  "noCheck": true
 }


### PR DESCRIPTION
#### Summary

Continuing to un-revert https://github.com/netlify/cli/pull/7085

This lets all the other CI jobs actually run when you have type errors — only the typechecking job should fail.