### PR TITLE
fix(npm-shrinkwrap.json): re-remove dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:integration": "vitest run tests/integration/",
     "test:unit": "vitest run tests/unit/",
     "postinstall": "node ./scripts/postinstall.js",
-    "prepublishOnly": "npm shrinkwrap",
+    "prepublishOnly": "node ./scripts/prepublishOnly.js",
     "typecheck": "tsc",
     "typecheck:watch": "tsc --watch"
   },

--- a/scripts/prepublishOnly.js
+++ b/scripts/prepublishOnly.js
@@ -1,0 +1,35 @@
+import * as cp from 'node:child_process'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+const main = async () => {
+  // It's best practice to include a shrinkwrap when shipping a CLI. npm has a bug that makes it
+  // not ignore development dependencies in an installed package's shrinkwrap, though:
+  //
+  // https://github.com/npm/cli/issues/4323
+  //
+  // Leaving development dependencies makes the CLI installation significantly larger and increases
+  // the risk of platform-specific dependency installation issues.
+  // eslint-disable-next-line no-restricted-properties
+  const packageJSONPath = path.join(process.cwd(), 'package.json')
+  const rawPackageJSON = await fs.readFile(packageJSONPath, 'utf8')
+
+  try {
+    // Remove dev dependencies from the package.json...
+    const packageJSON = JSON.parse(rawPackageJSON)
+    Reflect.deleteProperty(packageJSON, 'devDependencies')
+    await fs.writeFile(packageJSONPath, JSON.stringify(packageJSON, null, 2))
+
+    // Prune out dev dependencies (this updates the `package-lock.json` lockfile)
+    cp.spawnSync('npm', ['prune'], { stdio: 'inherit' })
+
+    // Convert `package-lock.json` lockfile to `npm-shrinkwrap.json`
+    cp.spawnSync('npm', ['shrinkwrap'], { stdio: 'inherit' })
+  } finally {
+    // Restore the original `package.json`. (This makes no functional difference in a publishing
+    // environment, it's purely to minimize how destructive this script is.)
+    await fs.writeFile(packageJSONPath, rawPackageJSON)
+  }
+}
+
+await main()


### PR DESCRIPTION
#### Summary

We accidentally reintroduced dev dependencies in the `npm-shrinkwrap.json` file here: https://github.com/netlify/cli/pull/7119/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md&file-filters%5B%5D=.yml&show-viewed-files=true&show-deleted-files=false#diff-3d80e6f9eb8af7a28cbe2209d086150e29b68f860376ee618a0041ca9b5c786dL18-L49.

The deleted script was deleting `package.json#devDependencies` before running `npm i && npm shrinkwrap`, which resulted in the shrinkwrap being built from a modified `package-lock.json` with dev deps removed 😓.

cc @ndhoule