### PR TITLE
perf!: perform minimal accounts query when loading config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@netlify/blobs": "8.1.2",
         "@netlify/build": "30.1.1",
         "@netlify/build-info": "9.0.2",
-        "@netlify/config": "21.0.6",
+        "@netlify/config": "21.0.7",
         "@netlify/edge-bundler": "12.4.0",
         "@netlify/edge-functions": "2.11.1",
         "@netlify/headers-parser": "8.0.0",
@@ -784,6 +784,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -799,6 +800,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -814,6 +816,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -829,6 +832,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -844,6 +848,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -859,6 +864,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -874,6 +880,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -889,6 +896,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -904,6 +912,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -919,6 +928,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -934,6 +944,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -949,6 +960,7 @@
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -964,6 +976,7 @@
       "cpu": [
         "mips64el"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -979,6 +992,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -994,6 +1008,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1009,6 +1024,7 @@
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1024,6 +1040,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1039,6 +1056,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -1054,6 +1072,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1069,6 +1088,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -1084,6 +1104,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1099,6 +1120,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1114,6 +1136,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1506,6 +1529,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
       "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.10.0"
       }
@@ -1532,7 +1556,8 @@
     "node_modules/@import-maps/resolve": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@import-maps/resolve/-/resolve-1.0.1.tgz",
-      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA=="
+      "integrity": "sha512-tWZNBIS1CoekcwlMuyG2mr0a1Wo5lb5lEHwwWvZo+5GLgr3e9LLDTtmgtCWEwBpXMkxn9D+2W9j2FY6eZQq0tA==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1828,6 +1853,7 @@
       "version": "30.1.1",
       "resolved": "https://registry.npmjs.org/@netlify/build/-/build-30.1.1.tgz",
       "integrity": "sha512-iPGaFjDOE7FDt9xskCLaYlXcbwlQuoDZ0votmr2CQWfrNSnXAP8f44kPPSEzaLqyeQwRjmsrBUKqJ0Q3NCTLPA==",
+      "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
         "@netlify/blobs": "^8.1.2",
@@ -2167,6 +2193,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
       "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -2189,6 +2216,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
       "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
       }
@@ -2197,6 +2225,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2222,6 +2251,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -2236,6 +2266,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -2264,6 +2295,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -2278,6 +2310,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -2292,6 +2325,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -2338,6 +2372,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2361,6 +2396,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
       "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -2418,9 +2454,10 @@
       }
     },
     "node_modules/@netlify/config": {
-      "version": "21.0.6",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-21.0.6.tgz",
-      "integrity": "sha512-zie9e/lKvdZ88Heduu5X6v+CvhcU1e9notQtugc3Hg60NWfXgRr1Z11opOeD/hh2GmoLkr6f1HBjndyKEFSZJA==",
+      "version": "21.0.7",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-21.0.7.tgz",
+      "integrity": "sha512-B4SBC1a6TB2bIafJvUnF9RViVYn2QDSW96majr7XkG8kgdd5DbOjKyERHaQ8F2912lpg0pp3izlofERuGkDx9A==",
+      "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@netlify/headers-parser": "^8.0.0",
@@ -2614,6 +2651,7 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-12.4.0.tgz",
       "integrity": "sha512-UESSjInC554A97VkxDnv4MZKK6Nk9JLHzuvoMfqHB0biht0J5rvXk+EcAjgfaaVJezOTQb45XMiH5lqJFVe6HQ==",
+      "license": "MIT",
       "dependencies": {
         "@import-maps/resolve": "^1.0.1",
         "@vercel/nft": "0.27.7",
@@ -2646,6 +2684,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2661,6 +2700,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
       "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.0.1"
       }
@@ -2669,6 +2709,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
       "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -2700,12 +2741,14 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@netlify/edge-bundler/node_modules/find-up": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -2721,6 +2764,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
       "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2732,6 +2776,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
       "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
       }
@@ -2740,6 +2785,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2750,12 +2796,14 @@
     "node_modules/@netlify/edge-bundler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@netlify/edge-bundler/node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -2770,6 +2818,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -2784,6 +2833,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -2792,6 +2842,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2807,6 +2858,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5299,7 +5351,8 @@
     "node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -7767,6 +7820,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-1.2.0.tgz",
       "integrity": "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@humanwhocodes/momoa": "^2.0.2",
@@ -7785,6 +7839,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -7799,6 +7854,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7814,6 +7870,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -7824,12 +7881,14 @@
     "node_modules/better-ajv-errors/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/better-ajv-errors/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10434,6 +10493,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.2.tgz",
       "integrity": "sha512-LmHPAa5h4tSxz+g/D8IHY6wCjtIiFx8I7/Q0Aq+NmvtoYvyMnJU0KQJcqB6QH30X9x/W4CemgUtPgQDZFca5SA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11984,6 +12044,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/get-package-name/-/get-package-name-2.2.0.tgz",
       "integrity": "sha512-LmCKVxioe63Fy6KDAQ/mmCSOSSRUE/x4zdrMD+7dU8quF3bGpzvP8mOmq4Dgce3nzU9AgkVDotucNOOg7c27BQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -13652,6 +13713,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15130,6 +15192,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
       "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       },
@@ -15599,6 +15662,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
       "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
@@ -16966,6 +17030,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -22114,9 +22179,9 @@
       }
     },
     "@netlify/config": {
-      "version": "21.0.6",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-21.0.6.tgz",
-      "integrity": "sha512-zie9e/lKvdZ88Heduu5X6v+CvhcU1e9notQtugc3Hg60NWfXgRr1Z11opOeD/hh2GmoLkr6f1HBjndyKEFSZJA==",
+      "version": "21.0.7",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-21.0.7.tgz",
+      "integrity": "sha512-B4SBC1a6TB2bIafJvUnF9RViVYn2QDSW96majr7XkG8kgdd5DbOjKyERHaQ8F2912lpg0pp3izlofERuGkDx9A==",
       "requires": {
         "@iarna/toml": "^2.2.5",
         "@netlify/headers-parser": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@netlify/blobs": "8.1.2",
     "@netlify/build": "30.1.1",
     "@netlify/build-info": "9.0.2",
-    "@netlify/config": "21.0.6",
+    "@netlify/config": "21.0.7",
     "@netlify/edge-bundler": "12.4.0",
     "@netlify/edge-functions": "2.11.1",
     "@netlify/headers-parser": "8.0.0",

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -581,7 +581,7 @@ export default class BaseCommand extends Command {
       token,
       ...apiUrlOpts,
     })
-    const { accounts, buildDir, config, configPath, repositoryRoot, siteInfo } = cachedConfig
+    const { accounts = [], buildDir, config, configPath, repositoryRoot, siteInfo } = cachedConfig
     let { env } = cachedConfig
     if (flags.offlineEnv) {
       env = {}

--- a/src/commands/sites/sites-create-template.ts
+++ b/src/commands/sites/sites-create-template.ts
@@ -25,7 +25,7 @@ import { configureRepo } from '../../utils/init/config.js'
 import { deployedSiteExists, getGitHubLink, getTemplateName } from '../../utils/sites/create-template.js'
 import { callLinkSite, createRepo, validateTemplate } from '../../utils/sites/utils.js'
 import { track } from '../../utils/telemetry/index.js'
-import type { Account, SiteInfo } from '../../utils/types.js'
+import type { SiteInfo } from '../../utils/types.js'
 import type BaseCommand from '../base-command.js'
 
 import { getSiteNameInput } from './sites-create.js'
@@ -60,7 +60,7 @@ export const sitesCreateTemplate = async (repository: string, options: OptionVal
         type: 'list',
         name: 'accountSlug',
         message: 'Team:',
-        choices: accounts.map((account: Account) => ({
+        choices: accounts.map((account) => ({
           value: account.slug,
           name: account.name,
         })),

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -42,16 +42,8 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
     Name: user.full_name,
     Email: user.email,
     GitHub: ghuser,
+    Teams: accounts.map(({ name }) => name),
   }
-  const teamsData = {}
-
-  accounts.forEach((team) => {
-    // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    teamsData[team.name] = team.roles_allowed.join(' ')
-  })
-
-  // @ts-expect-error TS(2339) FIXME: Property 'Teams' does not exist on type '{ Name: a... Remove this comment to see the full error message
-  accountData.Teams = teamsData
 
   // @ts-expect-error
   const cleanAccountData = clean(accountData)

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -2,7 +2,7 @@ import type { NetlifyAPI } from 'netlify'
 
 import type { FrameworksAPIPaths } from '../utils/frameworks-api.ts'
 import type CLIState from '../utils/cli-state.js'
-import type { Account, GlobalConfigStore, SiteInfo } from '../utils/types.ts'
+import type { MinimalAccount, GlobalConfigStore, SiteInfo } from '../utils/types.ts'
 import type { NormalizedCachedConfigConfig } from '../utils/command-helpers.js'
 import type { CachedConfig } from '../lib/build.js'
 
@@ -22,7 +22,7 @@ export type NetlifySite = {
  * TODO(serhalp): Rename. These aren't options. They're more like context.
  */
 export type NetlifyOptions = {
-  accounts: Account[]
+  accounts: MinimalAccount[]
   api: NetlifyAPI
   apiOpts: {
     userAgent: string

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -7,14 +7,14 @@ import tomlify from 'tomlify-j0.4'
 import type { OptionValues } from 'commander'
 
 import { getFeatureFlagsFromSiteInfo } from '../utils/feature-flags.js'
-import type { Account, EnvironmentVariables, Plugin, SiteInfo } from '../utils/types.js'
+import type { MinimalAccount, EnvironmentVariables, Plugin, SiteInfo } from '../utils/types.js'
 
 import { getBootstrapURL } from './edge-functions/bootstrap.js'
 import { featureFlags as edgeFunctionsFeatureFlags } from './edge-functions/consts.js'
 import type { EdgeFunctionDeclaration } from './edge-functions/proxy.js'
 
 export interface CachedConfig {
-  accounts: Account[]
+  accounts: MinimalAccount[] | undefined
   buildDir: string
   env: EnvironmentVariables
   repositoryRoot: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -184,23 +184,17 @@ type EnvVarValue = {
   context: string
 }
 
-export interface Account {
+export type MinimalAccount = {
   id: string
   name: string
   slug: string
-  type: string
-  capabilities: Record<string, { included: string; used: string }>
-  billing_name: string
-  billing_email: string
-  billing_details: string
-  billing_period: string
-  payment_method_id: string
+  default: boolean
+  team_logo_url: string | null
+  on_pro_trial: boolean
+  organization_id: string | null
   type_name: string
-  type_id: string
-  owner_ids: string[]
-  roles_allowed: string[]
-  created_at: string
-  updated_at: string
+  type_slug: string
+  members_count: number
 }
 
 export interface GitHubRepo {

--- a/tests/integration/commands/status/__snapshots__/status.test.ts.snap
+++ b/tests/integration/commands/status/__snapshots__/status.test.ts.snap
@@ -13,5 +13,8 @@ exports[`fixture: empty-project > should print status for a linked site 2`] = `
 {
   "Email": "test@netlify.com",
   "Name": "Test User",
+  "Teams": [
+    "Test User",
+  ],
 }
 `;

--- a/tests/integration/commands/status/status.test.ts
+++ b/tests/integration/commands/status/status.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 
 import { FixtureTestContext, setupFixtureTests } from '../../utils/fixture.js'
 import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
+import type { MinimalAccount } from '../../../../src/utils/types.js'
 
 const siteInfo = {
   account_slug: 'test-account',
@@ -13,7 +14,20 @@ const siteInfo = {
 
 const user = { full_name: 'Test User', email: 'test@netlify.com' }
 
-const accounts = [{ slug: siteInfo.account_slug, name: user.full_name, roles_allowed: [] }]
+const accounts: MinimalAccount[] = [
+  {
+    id: 'user-id',
+    name: user.full_name,
+    slug: siteInfo.account_slug,
+    default: true,
+    team_logo_url: null,
+    on_pro_trial: false,
+    organization_id: null,
+    type_name: 'placeholder',
+    type_slug: 'placeholder',
+    members_count: 1,
+  },
+]
 
 const routes = [
   { path: 'sites/site_id', response: siteInfo },


### PR DESCRIPTION
:warning: Depends on https://github.com/netlify/build/pull/6184. Merge and release that change first, and update the `@netlify/config` dependency in this PR to a non-RC release.

---

We've done this performance improvement many times elsewhere, but for posterity:

When we load a user's configuration, we perform a query to the Netlify API requesting information about which accounts a user is a member of. To do this, we query the `/accounts` endpoint, which is an expensive operation: It frequently takes 4+ seconds to get a response from this endpoint. This query happens as part of every CLI startup cycle.

By requesting a more minimal set of `accounts` data, we reduce almost every command's startup time.

Non-scientific testing shows this reduces `netlify status` runtime (on a Netlify dev's MacBook Pro M-something) from 3.907s to 2.001s, wall time. For longer-running commands the impact won't be so dramatic, proportionally speaking, but this is a nice perf bump anyway.