### PR TITLE
refactor: remove unused args in calls to `getBuildSettings`

### DIFF
--- a/eslint_temporary_suppressions.js
+++ b/eslint_temporary_suppressions.js
@@ -973,19 +973,11 @@ export default [
     files: ['src/utils/init/config-github.ts'],
     rules: {
       '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/prefer-optional-chain': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
-    },
-  },
-  {
-    files: ['src/utils/init/config-manual.ts'],
-    rules: {
-      '@typescript-eslint/restrict-template-expressions': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   },
   {

--- a/src/utils/init/config-github.ts
+++ b/src/utils/init/config-github.ts
@@ -19,11 +19,11 @@ const PAGE_SIZE = 100
  * Get a valid GitHub token
  */
 export const getGitHubToken = async ({ globalConfig }: { globalConfig: GlobalConfigStore }): Promise<string> => {
-  const userId = globalConfig.get('userId')
+  const userId: string = globalConfig.get('userId')
 
   const githubToken: Token = globalConfig.get(`users.${userId}.auth.github`)
 
-  if (githubToken && githubToken.user && githubToken.token) {
+  if (githubToken.user && githubToken.token) {
     try {
       const octokit = getGitHubClient(githubToken.token)
       const { status } = await octokit.rest.users.getAuthenticated()

--- a/src/utils/init/config-github.ts
+++ b/src/utils/init/config-github.ts
@@ -229,16 +229,11 @@ export const configGithub = async ({
     config,
     globalConfig,
     repositoryRoot,
-    site: { root: siteRoot },
   } = netlify
 
   const token = await getGitHubToken({ globalConfig })
 
   const { baseDir, buildCmd, buildDir, functionsDir, pluginsToInstall } = await getBuildSettings({
-    // @ts-expect-error -- XXX(serhalp): unused - removed in stacked PR
-    repositoryRoot,
-    // XXX(serhalp): unused - removed in stacked PR
-    siteRoot,
     config,
     command,
   })

--- a/src/utils/init/config-github.ts
+++ b/src/utils/init/config-github.ts
@@ -21,9 +21,9 @@ const PAGE_SIZE = 100
 export const getGitHubToken = async ({ globalConfig }: { globalConfig: GlobalConfigStore }): Promise<string> => {
   const userId: string = globalConfig.get('userId')
 
-  const githubToken: Token = globalConfig.get(`users.${userId}.auth.github`)
+  const githubToken: Token | undefined = globalConfig.get(`users.${userId}.auth.github`)
 
-  if (githubToken.user && githubToken.token) {
+  if (githubToken?.user && githubToken.token) {
     try {
       const octokit = getGitHubClient(githubToken.token)
       const { status } = await octokit.rest.users.getAuthenticated()

--- a/src/utils/init/config-manual.ts
+++ b/src/utils/init/config-manual.ts
@@ -11,19 +11,21 @@ import { createDeployKey, type DeployKey, getBuildSettings, saveNetlifyToml, set
  */
 const addDeployKey = async (deployKey: DeployKey) => {
   log('\nGive this Netlify SSH public key access to your repository:\n')
+  // FIXME(serhalp): Handle nullish `deployKey.public_key` by throwing user-facing error or fixing upstream type.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   log(`\n${deployKey.public_key}\n\n`)
 
-  const { sshKeyAdded } = await inquirer.prompt([
+  const { sshKeyAdded } = (await inquirer.prompt([
     {
       type: 'confirm',
       name: 'sshKeyAdded',
       message: 'Continue?',
       default: true,
     },
-  ])
+  ])) as { sshKeyAdded: boolean }
 
   if (!sshKeyAdded) {
-    exit()
+    return exit()
   }
 }
 
@@ -43,6 +45,8 @@ const getRepoPath = async ({ repoData }: { repoData: RepoData }): Promise<string
 
 const addDeployHook = async (deployHook: string | undefined): Promise<boolean> => {
   log('\nConfigure the following webhook for your repository:\n')
+  // FIXME(serhalp): Handle nullish `deployHook` by throwing user-facing error or fixing upstream type.
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   log(`\n${deployHook}\n\n`)
   const { deployHookAdded } = (await inquirer.prompt([
     {

--- a/src/utils/init/config-manual.ts
+++ b/src/utils/init/config-manual.ts
@@ -71,14 +71,9 @@ export default async function configManual({
     cachedConfig: { configPath },
     config,
     repositoryRoot,
-    site: { root: siteRoot },
   } = netlify
 
   const { baseDir, buildCmd, buildDir, functionsDir, pluginsToInstall } = await getBuildSettings({
-    // @ts-expect-error -- XXX(serhalp): unused - removed in stacked PR
-    repositoryRoot,
-    // XXX(serhalp): unused - removed in stacked PR
-    siteRoot,
     config,
     command,
   })


### PR DESCRIPTION
#### Summary

The types fixes in https://github.com/netlify/cli/pull/7130 identified a number of issues. This fixes one of those — just some unused args passed to a function.