### PR TITLE
fix: mark `siteInfo.published_deploy` as optional

### DIFF
--- a/eslint_temporary_suppressions.js
+++ b/eslint_temporary_suppressions.js
@@ -244,13 +244,6 @@ export default [
     },
   },
   {
-    files: ['src/commands/functions/functions-list.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
-    },
-  },
-  {
     files: ['src/commands/functions/functions-serve.ts'],
     rules: {
       '@typescript-eslint/no-unsafe-assignment': 'off',
@@ -429,14 +422,6 @@ export default [
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
-  {
-    files: ['src/commands/status/status.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
-      '@typescript-eslint/ban-ts-comment': 'off',
     },
   },
   {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -841,7 +841,7 @@ export const deploy = async (options: OptionValues, command: BaseCommand) => {
     return triggerDeploy({ api, options, siteData, siteId })
   }
 
-  const deployToProduction = options.prod || (options.prodIfUnlocked && !siteData.published_deploy.locked)
+  const deployToProduction = options.prod || (options.prodIfUnlocked && siteData.published_deploy?.locked !== true)
 
   let results = {} as Awaited<ReturnType<typeof prepAndRunDeploy>>
 

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -841,7 +841,7 @@ export const deploy = async (options: OptionValues, command: BaseCommand) => {
     return triggerDeploy({ api, options, siteData, siteId })
   }
 
-  const deployToProduction = options.prod || (options.prodIfUnlocked && siteData.published_deploy?.locked !== true)
+  const deployToProduction = options.prod || (options.prodIfUnlocked && !(siteData.published_deploy?.locked ?? false))
 
   let results = {} as Awaited<ReturnType<typeof prepAndRunDeploy>>
 

--- a/src/commands/functions/functions-list.ts
+++ b/src/commands/functions/functions-list.ts
@@ -35,7 +35,7 @@ export const functionsList = async (options: OptionValues, command: BaseCommand)
     log('Functions directory is undefined')
     log(`Please verify that 'functions.directory' is set in your Netlify configuration file ${relConfigFilePath}`)
     log('Refer to https://ntl.fyi/file-based-build-config for more information')
-    exit(1)
+    return exit(1)
   }
 
   const functions = await getFunctions(functionsDir)
@@ -43,12 +43,12 @@ export const functionsList = async (options: OptionValues, command: BaseCommand)
 
   if (normalizedFunctions.length === 0) {
     log(`No functions found in ${functionsDir}`)
-    exit()
+    return exit()
   }
 
   if (options.json) {
     logJson(normalizedFunctions)
-    exit()
+    return exit()
   }
 
   // Make table

--- a/src/commands/functions/functions-list.ts
+++ b/src/commands/functions/functions-list.ts
@@ -26,10 +26,8 @@ const normalizeFunction = function (
 export const functionsList = async (options: OptionValues, command: BaseCommand) => {
   const { config, relConfigFilePath, siteInfo } = command.netlify
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- XXX(serhalp): fixed in stacked PR.
-  const deploy = siteInfo.published_deploy ?? {}
-  // @ts-expect-error(serhalp) Investigate. Either dead code or a type error in the API client package.
-  const deployedFunctions = deploy.available_functions || []
+  // @ts-expect-error FIXME(serhalp): Investigate. This is either dead code or a type error in the API client package.
+  const deployedFunctions = (siteInfo.published_deploy?.available_functions as DeployedFunction[] | undefined) ?? []
 
   const functionsDir = getFunctionsDir({ options, config })
 

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -16,14 +16,14 @@ import type BaseCommand from '../base-command.js'
 
 export const status = async (options: OptionValues, command: BaseCommand) => {
   const { accounts, api, globalConfig, site, siteInfo } = command.netlify
-  const current = globalConfig.get('userId') as string
+  const currentUserId = globalConfig.get('userId') as string | undefined
   const [accessToken] = await getToken()
 
   if (!accessToken) {
     log(`Not logged in. Please log in to see site status.`)
     log()
     log('Login with "netlify login" command')
-    exit()
+    return exit()
   }
 
   const siteId = site.id
@@ -46,7 +46,10 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
     }
   }
 
-  const ghuser = command.netlify.globalConfig.get(`users.${current}.auth.github.user`) as string
+  const ghuser =
+    currentUserId != null
+      ? (globalConfig.get(`users.${currentUserId}.auth.github.user`) as string | undefined)
+      : undefined
   const accountData = {
     Name: user.full_name,
     Email: user.email,

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -55,11 +55,6 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
     return logAndThrowError(`You don't appear to be in a folder that is linked to a site`)
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- XXX(serhalp): fixed in stacked PR.
-  if (!siteInfo) {
-    return logAndThrowError(`No site info found for site ${siteId}`)
-  }
-
   // Json only logs out if --json flag is passed
   if (options.json) {
     logJson({

--- a/src/commands/status/status.ts
+++ b/src/commands/status/status.ts
@@ -1,13 +1,22 @@
 import clean from 'clean-deep'
-import { OptionValues } from 'commander'
+import type { OptionValues } from 'commander'
 import prettyjson from 'prettyjson'
 
-import { chalk, logAndThrowError, exit, getToken, log, logJson, warn, APIError } from '../../utils/command-helpers.js'
-import BaseCommand from '../base-command.js'
+import {
+  chalk,
+  logAndThrowError,
+  exit,
+  getToken,
+  log,
+  logJson,
+  warn,
+  type APIError,
+} from '../../utils/command-helpers.js'
+import type BaseCommand from '../base-command.js'
 
 export const status = async (options: OptionValues, command: BaseCommand) => {
   const { accounts, api, globalConfig, site, siteInfo } = command.netlify
-  const current = globalConfig.get('userId')
+  const current = globalConfig.get('userId') as string
   const [accessToken] = await getToken()
 
   if (!accessToken) {
@@ -37,7 +46,7 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
     }
   }
 
-  const ghuser = command.netlify.globalConfig.get(`users.${current}.auth.github.user`)
+  const ghuser = command.netlify.globalConfig.get(`users.${current}.auth.github.user`) as string
   const accountData = {
     Name: user.full_name,
     Email: user.email,
@@ -45,8 +54,10 @@ export const status = async (options: OptionValues, command: BaseCommand) => {
     Teams: accounts.map(({ name }) => name),
   }
 
-  // @ts-expect-error
-  const cleanAccountData = clean(accountData)
+  const cleanAccountData =
+    // TODO(serhalp) `deep-clean` type declaration is invalid (this is obscured by `skipLibCheck`). Open a PR or use
+    // another lib.
+    (clean as unknown as <T extends Record<string | number | symbol, unknown>>(obj: T) => Partial<T>)(accountData)
 
   log(prettyjson.render(cleanAccountData))
 

--- a/src/recipes/blobs-migrate/index.ts
+++ b/src/recipes/blobs-migrate/index.ts
@@ -23,8 +23,7 @@ export const run = async ({ args, command }: Options) => {
   const { api, siteInfo } = command.netlify
   const clientOptions = {
     apiURL: `${api.scheme}://${api.host}`,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- XXX(serhalp): fixed in stacked PR.
-    siteID: siteInfo.id ?? '',
+    siteID: siteInfo.id,
     token: api.accessToken ?? '',
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -129,36 +129,38 @@ export interface SiteInfo {
     }
     skip: boolean
   }
-  published_deploy: {
-    admin_url: string
-    branch: string
-    build_id: string
-    commit_ref: string
-    commit_url: string
-    context: string
-    created_at: string
-    deploy_ssl_url: string
-    deploy_url: string
-    draft: boolean
-    error_message: string
-    id: string
-    locked: boolean
-    name: string
-    published_at: string
-    required: string[]
-    required_functions: string[]
-    review_id: number
-    review_url: string
-    screenshot_url: string
-    site_id: string
-    skipped: boolean
-    ssl_url: string
-    state: string
-    title: string
-    updated_at: string
-    url: string
-    user_id: string
-  }
+  published_deploy:
+    | {
+        admin_url: string
+        branch: string
+        build_id: string
+        commit_ref: string
+        commit_url: string
+        context: string
+        created_at: string
+        deploy_ssl_url: string
+        deploy_url: string
+        draft: boolean
+        error_message: string
+        id: string
+        locked: boolean
+        name: string
+        published_at: string
+        required: string[]
+        required_functions: string[]
+        review_id: number
+        review_url: string
+        screenshot_url: string
+        site_id: string
+        skipped: boolean
+        ssl_url: string
+        state: string
+        title: string
+        updated_at: string
+        url: string
+        user_id: string
+      }
+    | undefined
   screenshot_url: string
   session_id: string
   ssl: boolean


### PR DESCRIPTION
#### Summary

The types fixes in https://github.com/netlify/cli/pull/7130 identified a number of issues. This fixes a couple of issues.

- mark `siteInfo.published_deploy` as optional
- remove unnecessary handling of nullish `siteInfo`
- fix some nearby eslint suppressions