### PR TITLE
refactor: type deploy command input args

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -148,6 +148,15 @@ async function getRepositoryRoot(cwd?: string): Promise<string | undefined> {
   }
 }
 
+export type BaseOptionValues = {
+  auth?: string
+  cwd?: string
+  debug?: boolean
+  filter?: string
+  httpProxy?: string
+  silent?: string
+}
+
 /** Base command class that provides tracking and config initialization */
 export default class BaseCommand extends Command {
   /** The netlify object inside each command with the state */

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -809,14 +809,6 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
 
   command.setAnalyticsPayload({ open: options.open, prod: options.prod, json: options.json, alias: Boolean(alias) })
 
-  if (options.branch) {
-    warn('--branch flag has been renamed to --alias and will be removed in future versions')
-  }
-
-  if (options.context && !options.build) {
-    return logAndThrowError('--context flag is only available when using the --build flag')
-  }
-
   await command.authenticate(options.auth)
 
   let siteId = site.id || options.site

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,8 +1,9 @@
 import { env } from 'process'
 
-import { Option, OptionValues } from 'commander'
+import { Option } from 'commander'
 
 import BaseCommand from '../base-command.js'
+import type { DeployOptionValues } from './option_values.js'
 
 export const createDeployCommand = (program: BaseCommand) =>
   program
@@ -107,7 +108,7 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
         'build',
       ),
     )
-    .option('--build', 'Run build command before deploying')
+    .option('--build', 'Run build command before deploying', false)
     .option('--context <context>', 'Context to use when resolving build configuration')
     .option(
       '--skip-functions-cache',
@@ -125,7 +126,7 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
       'netlify deploy --trigger',
       'netlify deploy --build --context deploy-preview',
     ])
-    .action(async (options: OptionValues, command: BaseCommand) => {
+    .action(async (options: DeployOptionValues, command: BaseCommand) => {
       const { deploy } = await import('./deploy.js')
       await deploy(options, command)
     })

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -3,6 +3,7 @@ import { env } from 'process'
 import { Option } from 'commander'
 
 import BaseCommand from '../base-command.js'
+import { logAndThrowError, warn } from '../../utils/command-helpers.js'
 import type { DeployOptionValues } from './option_values.js'
 
 export const createDeployCommand = (program: BaseCommand) =>
@@ -127,6 +128,14 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
       'netlify deploy --build --context deploy-preview',
     ])
     .action(async (options: DeployOptionValues, command: BaseCommand) => {
+      if (options.branch) {
+        warn('--branch flag has been renamed to --alias and will be removed in future versions')
+      }
+
+      if (options.context && !options.build) {
+        return logAndThrowError('--context flag is only available when using the --build flag')
+      }
+
       const { deploy } = await import('./deploy.js')
       await deploy(options, command)
     })

--- a/src/commands/deploy/option_values.ts
+++ b/src/commands/deploy/option_values.ts
@@ -1,0 +1,21 @@
+// This type lives in a separate file to prevent import cycles.
+
+import type { BaseOptionValues } from '../base-command.js'
+
+export type DeployOptionValues = BaseOptionValues & {
+  alias?: string
+  build: boolean
+  branch?: string
+  context?: string
+  dir?: string
+  functions?: string
+  json: boolean
+  message?: string
+  open: boolean
+  prod: boolean
+  prodIfUnlocked: boolean
+  site?: string
+  skipFunctionsCache: boolean
+  timeout?: number
+  trigger?: boolean
+}

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -115,7 +115,7 @@ interface HandlerResult {
   status?: string
 }
 // The @netlify/build type incorrectly states a `void | Promise<void>` return type.
-type PatchedHandlerType<T extends (opts: any) => void | Promise<void>> = (
+export type PatchedHandlerType<T extends (opts: any) => void | Promise<void>> = (
   opts: Parameters<T>[0],
 ) => HandlerResult | Promise<HandlerResult>
 


### PR DESCRIPTION
This change adds basic TypeScript types to the `deploy` command's input arguments (i.e. the command-line flags that a user passes to the `netlify deploy` command).

I also lifted some input argument validation out of the `deploy` command's business logic into the `createDeployCommand` function as a minor optimization so we don't pull in the full deploy dependency tree when we know we can't service a user's request.
