### PR TITLE
build: remove test hook timeout override

### DIFF
--- a/tests/integration/utils/fixture.ts
+++ b/tests/integration/utils/fixture.ts
@@ -12,7 +12,6 @@ import { MockApi, Route, getCLIOptions, startMockApi } from './mock-api-vitest.j
 import { SiteBuilder } from './site-builder.js'
 
 const FIXTURES_DIRECTORY = fileURLToPath(new URL('../__fixtures__/', import.meta.url))
-const HOOK_TIMEOUT = 30_000
 
 interface MockApiOptions {
   routes: Route[]
@@ -175,7 +174,7 @@ export async function setupFixtureTests(
 
         await options.setupAfterDev?.({ fixture, mockApi, devServer })
       }
-    }, HOOK_TIMEOUT)
+    })
 
     beforeEach<FixtureTestContext>((context) => {
       if (fixture) context.fixture = fixture
@@ -200,6 +199,6 @@ export async function setupFixtureTests(
       if (devServer) await devServer.close()
       if (mockApi) await mockApi.close()
       if (fixture) await fixture.cleanup()
-    }, HOOK_TIMEOUT)
+    })
   })
 }


### PR DESCRIPTION
#### Summary

We [bumped this up globally here](https://github.com/netlify/cli/pull/7154) but it didn't take everywhere because of this override.

You can see this run timing out after 30s for example: https://github.com/netlify/cli/actions/runs/14249390219/job/39938265313#step:10:381.

This should help with flakiness, especially since integration tests that use fixtures can be quite slow on Windows.