### PR TITLE
ci(e2e): add same Windows perf config as for integration tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,12 @@ jobs:
         node-version: ['18.14.0', '20.12.2', '22']
       fail-fast: false
     steps:
+      # This improves Windows network performance. We need this since we open many ports in our tests.
+      - name: Increase Windows port limit and reduce time wait delay
+        run: |
+          netsh int ipv4 set dynamicport tcp start=1025 num=64511
+          REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP\Parameters /v TcpTimedWaitDelay /t REG_DWORD /d 30 /f
+
       - name: Git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,8 +17,6 @@ jobs:
     name: E2E Windows tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    env:
-      DEBUG: true
     strategy:
       matrix:
         os: [windows-latest]
@@ -72,8 +70,6 @@ jobs:
     name: E2E
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    env:
-      DEBUG: true
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]


### PR DESCRIPTION
#### Summary

We have this incantation in the integration test setup, and e2e tests are _excruciatingly_ slow on Windows (4-7 mins PER TEST, vs. 400-900ms for Ubuntu/macOS), so let's give this a try.