### PR TITLE
fix(deps): remove or type last remaining untyped deps

### DIFF
--- a/eslint_temporary_suppressions.js
+++ b/eslint_temporary_suppressions.js
@@ -1057,19 +1057,6 @@ export default [
     },
   },
   {
-    files: ['src/utils/shell.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-return': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      'n/no-process-exit': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-floating-promises': 'off',
-      '@typescript-eslint/restrict-template-expressions': 'off',
-    },
-  },
-  {
     files: ['src/utils/sign-redirect.ts'],
     rules: {
       '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "readdirp": "4.1.2",
         "semver": "7.7.1",
         "source-map-support": "0.5.21",
-        "strip-ansi-control-characters": "2.0.0",
         "tempy": "3.1.0",
         "terminal-link": "4.0.0",
         "toml": "3.0.0",
@@ -17397,11 +17396,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi-control-characters": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi-control-characters/-/strip-ansi-control-characters-2.0.0.tgz",
-      "integrity": "sha512-Q0/k5orrVGeaOlIOUn1gybGU0IcAbgHQT1faLo5hik4DqClKVSaka5xOhNNoRgtfztHVxCYxi7j71mrWom0bIw=="
-    },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -31340,11 +31334,6 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strip-ansi-control-characters": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi-control-characters/-/strip-ansi-control-characters-2.0.0.tgz",
-      "integrity": "sha512-Q0/k5orrVGeaOlIOUn1gybGU0IcAbgHQT1faLo5hik4DqClKVSaka5xOhNNoRgtfztHVxCYxi7j71mrWom0bIw=="
     },
     "strip-dirs": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "readdirp": "4.1.2",
     "semver": "7.7.1",
     "source-map-support": "0.5.21",
-    "strip-ansi-control-characters": "2.0.0",
     "tempy": "3.1.0",
     "terminal-link": "4.0.0",
     "toml": "3.0.0",

--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -4,7 +4,6 @@ import type { IncomingHttpHeaders } from 'http'
 import path from 'path'
 
 import express, { type Request, type RequestHandler } from 'express'
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'expr... Remove this comment to see the full error message
 import expressLogging from 'express-logging'
 import { jwtDecode } from 'jwt-decode'
 

--- a/src/utils/copy-template-dir/copy-template-dir.ts
+++ b/src/utils/copy-template-dir/copy-template-dir.ts
@@ -24,13 +24,9 @@ import path from 'path'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
 
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'maxstache... Remove this comment to see the full error message
 import maxstache from 'maxstache'
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'maxstache-stream... Remove this comment to see the full error message
 import maxstacheStream from 'maxstache-stream'
 import { readdirp, EntryInfo, ReaddirpStream } from 'readdirp'
-
-const noop = (): void => undefined
 
 // Remove a leading underscore
 function removeUnderscore(filepath: string): string {
@@ -56,9 +52,7 @@ async function writeFile(outDir: string, vars: Record<string, string>, file: Ent
 }
 
 // High throughput template dir writes
-export async function copyTemplateDir(srcDir: string, outDir: string, vars: any): Promise<string[]> {
-  if (!vars) vars = noop
-
+export async function copyTemplateDir(srcDir: string, outDir: string, vars: Record<string, string>): Promise<string[]> {
   assert.strictEqual(typeof srcDir, 'string')
   assert.strictEqual(typeof outDir, 'string')
   assert.strictEqual(typeof vars, 'object')

--- a/types/express-logging/index.d.ts
+++ b/types/express-logging/index.d.ts
@@ -1,0 +1,17 @@
+declare module 'express-logging' {
+  import { RequestHandler } from 'express';
+  
+  interface LoggerOptions {blacklist?: string[]}
+  
+  interface Logger {
+    info(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+    debug?(...args: unknown[]): void;
+    log(...args: unknown[]): void;
+  }
+  
+  function expressLogging(logger?: Logger, options?: LoggerOptions): RequestHandler;
+  
+  export default expressLogging;
+}

--- a/types/maxstache-stream/index.d.ts
+++ b/types/maxstache-stream/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'maxstache-stream' {
+  import { Transform } from 'stream';
+
+  function maxstacheStream(vars: Record<string, string>): Transform;
+  
+  export default maxstacheStream;
+}

--- a/types/maxstache/index.d.ts
+++ b/types/maxstache/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'maxstache' {
+  function maxstache(str: string, ctx: Record<string, string>): string;
+  
+  export default maxstache;
+}


### PR DESCRIPTION
### Summary

### 10b297c5 add type declaration files for untyped `maxstache` and `maxstache-stream`

### 563e0b4b add type declaration for untyped `express-logging`

There's also https://github.com/netlify/cli/pull/7050 that removes it entirely, but I don't want to be blocked on this to continue improving type safety.

### fe8e4a05 remove untyped `strip-ansi-control-characters` dep

`stripVTControlCharacters` was added in 16.11.0 (we support >+18.14.0), so we don't need this tiny transform stream wrapper anyway

### 1049c9a1 fix types and eslint errors in `utils/shell.ts`