### PR TITLE
refactor: fix `Account.capabilities` and `parseAllRemoteImages` types

### DIFF
--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,14 +1,7 @@
-/**
- * @param {any} account
- * @param {string} capability
- * @returns {boolean}
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'account' implicitly has an 'any' type.
-const supportsBooleanCapability = (account, capability) => Boolean(account?.capabilities?.[capability]?.included)
+import type { Account, Capability } from '../utils/dev.js'
 
-/**
- * @param {any} account
- * @returns {boolean}
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'account' implicitly has an 'any' type.
-export const supportsBackgroundFunctions = (account) => supportsBooleanCapability(account, 'background_functions')
+const supportsBooleanCapability = (account: Account | undefined, capability: Capability) =>
+  Boolean(account?.capabilities?.[capability]?.included)
+
+export const supportsBackgroundFunctions = (account?: Account): boolean =>
+  supportsBooleanCapability(account, 'background_functions')

--- a/src/lib/functions/server.ts
+++ b/src/lib/functions/server.ts
@@ -262,7 +262,7 @@ interface GetFunctionsServerOptions {
   functionsRegistry: FunctionsRegistry
   siteUrl: string
   siteInfo?: SiteInfo
-  accountId: string
+  accountId?: string | undefined
   geoCountry: string
   offline: boolean
   state: CLIState

--- a/src/lib/images/proxy.ts
+++ b/src/lib/images/proxy.ts
@@ -31,7 +31,7 @@ interface IpxParams {
   position?: string | null
 }
 
-export const parseAllRemoteImages = function (config: NormalizedCachedConfigConfig): {
+export const parseAllRemoteImages = function (config: Pick<NormalizedCachedConfigConfig, 'images'>): {
   errors: ErrorObject[]
   remotePatterns: RegExp[]
 } {

--- a/src/utils/proxy-server.ts
+++ b/src/utils/proxy-server.ts
@@ -63,7 +63,7 @@ export const startProxyServer = async ({
   siteInfo,
   state,
 }: {
-  accountId: string
+  accountId: string | undefined
   addonsUrls: $TSFixMe
   api?: NetlifyOptions['api']
   blobsContext?: BlobsContextWithEdgeAccess

--- a/tests/unit/lib/account.test.ts
+++ b/tests/unit/lib/account.test.ts
@@ -4,7 +4,6 @@ import { supportsBackgroundFunctions } from '../../../src/lib/account.js'
 
 describe('supportsBackgroundFunctions', () => {
   test(`should return false if no account`, () => {
-    // @ts-expect-error TS(2554) FIXME: Expected 1 arguments, but got 0.
     expect(supportsBackgroundFunctions()).toEqual(false)
   })
 
@@ -25,6 +24,7 @@ describe('supportsBackgroundFunctions', () => {
   })
 
   test(`should return true if included property is truthy`, () => {
+    // @ts-expect-error Intentional incorrect type. TODO(serhalp): Remove this test? Can this happen?
     expect(supportsBackgroundFunctions({ capabilities: { background_functions: { included: 'string' } } })).toEqual(
       true,
     )

--- a/tests/unit/lib/images/proxy.test.ts
+++ b/tests/unit/lib/images/proxy.test.ts
@@ -8,7 +8,6 @@ test('should parse all remote images correctly', () => {
       remote_images: ['https://example.com/*', 'https://test.com/*'],
     },
   }
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ images: { remote_images: strin... Remove this comment to see the full error message
   const { errors, remotePatterns } = parseAllRemoteImages(config)
   expect(errors).toEqual([])
   expect(remotePatterns).toEqual([/https:\/\/example.com\/*/, /https:\/\/test.com\/*/])
@@ -20,7 +19,6 @@ test('should report invalid remote images', () => {
       remote_images: ['*'],
     },
   }
-  // @ts-expect-error TS(2345) FIXME: Argument of type '{ images: { remote_images: strin... Remove this comment to see the full error message
   const { errors, remotePatterns } = parseAllRemoteImages(config)
   expect(errors).toEqual([
     {


### PR DESCRIPTION
#### Summary

Two small follow-ups to type fixes in https://github.com/netlify/cli/pull/7199