### PR TITLE
refactor(utils/env): rename variables, add comments, and clarify intent

### DIFF
--- a/src/commands/env/env-get.ts
+++ b/src/commands/env/env-get.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
 import { chalk, log, logJson } from '../../utils/command-helpers.js'
-import { AVAILABLE_CONTEXTS, getEnvelopeEnv } from '../../utils/env/index.js'
+import { SUPPORTED_CONTEXTS, getEnvelopeEnv } from '../../utils/env/index.js'
 import BaseCommand from '../base-command.js'
 
 export const envGet = async (name: string, options: OptionValues, command: BaseCommand) => {
@@ -27,7 +27,7 @@ export const envGet = async (name: string, options: OptionValues, command: BaseC
   }
 
   if (!value) {
-    const contextType = AVAILABLE_CONTEXTS.includes(context) ? 'context' : 'branch'
+    const contextType = SUPPORTED_CONTEXTS.includes(context) ? 'context' : 'branch'
     const withContext = `in the ${chalk.magenta(context)} ${contextType}`
     const withScope = scope === 'any' ? '' : ` and the ${chalk.magenta(scope)} scope`
     log(`No value set ${withContext}${withScope} for environment variable ${chalk.yellow(name)}`)

--- a/src/commands/env/env-list.ts
+++ b/src/commands/env/env-list.ts
@@ -6,7 +6,7 @@ import inquirer from 'inquirer'
 import logUpdate from 'log-update'
 
 import { chalk, log, logJson } from '../../utils/command-helpers.js'
-import { AVAILABLE_CONTEXTS, getEnvelopeEnv, getHumanReadableScopes } from '../../utils/env/index.js'
+import { SUPPORTED_CONTEXTS, getEnvelopeEnv, getHumanReadableScopes } from '../../utils/env/index.js'
 import type BaseCommand from '../base-command.js'
 import { EnvironmentVariables } from '../../utils/types.js'
 
@@ -81,7 +81,7 @@ export const envList = async (options: OptionValues, command: BaseCommand) => {
   }
 
   const forSite = `for site ${chalk.green(siteInfo.name)}`
-  const contextType = AVAILABLE_CONTEXTS.includes(context) ? 'context' : 'branch'
+  const contextType = SUPPORTED_CONTEXTS.includes(context) ? 'context' : 'branch'
   const withContext = `in the ${chalk.magenta(options.context)} ${contextType}`
   const withScope = scope === 'any' ? '' : `and ${chalk.yellow(options.scope)} scope`
   if (Object.keys(environment).length === 0) {

--- a/src/commands/env/env-set.ts
+++ b/src/commands/env/env-set.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
 import { chalk, logAndThrowError, log, logJson } from '../../utils/command-helpers.js'
-import { AVAILABLE_CONTEXTS, AVAILABLE_SCOPES, translateFromEnvelopeToMongo } from '../../utils/env/index.js'
+import { SUPPORTED_CONTEXTS, ALL_ENVELOPE_SCOPES, translateFromEnvelopeToMongo } from '../../utils/env/index.js'
 import { promptOverwriteEnvVariable } from '../../utils/prompts/env-set-prompts.js'
 import BaseCommand from '../base-command.js'
 
@@ -30,7 +30,7 @@ const setInEnvelope = async ({ api, context, force, key, scope, secret, siteInfo
   // fetch envelope env vars
   const envelopeVariables = await api.getEnvVars({ accountId, siteId })
   const contexts = context || ['all']
-  let scopes = scope || AVAILABLE_SCOPES
+  let scopes = scope || ALL_ENVELOPE_SCOPES
 
   if (secret) {
     // post_processing (aka post-processing) scope is not allowed with secrets
@@ -41,7 +41,7 @@ const setInEnvelope = async ({ api, context, force, key, scope, secret, siteInfo
   // if the passed context is unknown, it is actually a branch name
   // @ts-expect-error TS(7006) FIXME: Parameter 'ctx' implicitly has an 'any' type.
   let values = contexts.map((ctx) =>
-    AVAILABLE_CONTEXTS.includes(ctx) ? { context: ctx, value } : { context: 'branch', context_parameter: ctx, value },
+    SUPPORTED_CONTEXTS.includes(ctx) ? { context: ctx, value } : { context: 'branch', context_parameter: ctx, value },
   )
 
   // @ts-expect-error TS(7006) FIXME: Parameter 'envVar' implicitly has an 'any' type.
@@ -78,7 +78,7 @@ const setInEnvelope = async ({ api, context, force, key, scope, secret, siteInfo
           if (values.some((val) => val.context === 'all')) {
             log(`This secret's value will be empty in the dev context.`)
             log(`Run \`netlify env:set ${key} <value> --context dev\` to set a new value for the dev context.`)
-            values = AVAILABLE_CONTEXTS.filter((ctx) => ctx !== 'all').map((ctx) => ({
+            values = SUPPORTED_CONTEXTS.filter((ctx) => ctx !== 'all').map((ctx) => ({
               context: ctx,
               // empty out dev value so that secret is indeed secret
               // @ts-expect-error TS(7006) FIXME: Parameter 'val' implicitly has an 'any' type.
@@ -132,7 +132,7 @@ export const envSet = async (key: string, value: string, options: OptionValues, 
 
   const withScope = scope ? ` scoped to ${chalk.white(scope)}` : ''
   const withSecret = secret ? ` as a ${chalk.blue('secret')}` : ''
-  const contextType = AVAILABLE_CONTEXTS.includes(context || 'all') ? 'context' : 'branch'
+  const contextType = SUPPORTED_CONTEXTS.includes(context || 'all') ? 'context' : 'branch'
   log(
     `Set environment variable ${chalk.yellow(
       `${key}${value && !secret ? `=${value}` : ''}`,

--- a/src/commands/env/env-unset.ts
+++ b/src/commands/env/env-unset.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
 import { chalk, log, logJson, exit } from '../../utils/command-helpers.js'
-import { AVAILABLE_CONTEXTS, translateFromEnvelopeToMongo } from '../../utils/env/index.js'
+import { SUPPORTED_CONTEXTS, translateFromEnvelopeToMongo } from '../../utils/env/index.js'
 import { promptOverwriteEnvVariable } from '../../utils/prompts/env-unset-prompts.js'
 import BaseCommand from '../base-command.js'
 /**
@@ -43,7 +43,7 @@ const unsetInEnvelope = async ({ api, context, force, key, siteInfo }) => {
         await Promise.all(values.map((value) => api.deleteEnvVarValue({ ...params, id: value.id })))
         // if this was the `all` context, we need to create 3 values in the other contexts
         if (values.length === 1 && values[0].context === 'all') {
-          const newContexts = AVAILABLE_CONTEXTS.filter((ctx) => !context.includes(ctx))
+          const newContexts = SUPPORTED_CONTEXTS.filter((ctx) => !context.includes(ctx))
           const allValue = values[0].value
           await Promise.all(
             newContexts
@@ -87,6 +87,6 @@ export const envUnset = async (key: string, options: OptionValues, command: Base
     return false
   }
 
-  const contextType = AVAILABLE_CONTEXTS.includes(context || 'all') ? 'context' : 'branch'
+  const contextType = SUPPORTED_CONTEXTS.includes(context || 'all') ? 'context' : 'branch'
   log(`Unset environment variable ${chalk.yellow(key)} in the ${chalk.magenta(context || 'all')} ${contextType}`)
 }

--- a/src/utils/env/index.ts
+++ b/src/utils/env/index.ts
@@ -100,15 +100,18 @@ export const getValueForContext = (
   /**
    * The deploy context or branch of the environment variable value
    */
-  context: string,
-): EnvelopeEnvVarValue | undefined =>
-  values.find((val) => {
-    if (!(SUPPORTED_CONTEXTS as readonly string[]).includes(context)) {
+  contextOrBranch: ContextOrBranch,
+): EnvelopeEnvVarValue | undefined => {
+  const valueForContext = values.find((val) => {
+    const isSupportedContext = (SUPPORTED_CONTEXTS as readonly string[]).includes(contextOrBranch)
+    if (!isSupportedContext) {
       // the "context" option passed in is actually the name of a branch
-      return val.context === 'all' || val.context_parameter === context
+      return val.context === 'all' || val.context_parameter === contextOrBranch
     }
-    return val.context === 'all' || val.context === context
+    return val.context === 'all' || val.context === contextOrBranch
   })
+  return valueForContext ?? undefined
+}
 
 /**
  * Finds environment variables that match a given source

--- a/src/utils/env/index.ts
+++ b/src/utils/env/index.ts
@@ -31,7 +31,7 @@ type EnvelopeEnvVar = Awaited<ReturnType<NetlifyAPI['getEnvVars']>>[number] & {
   scopes: EnvelopeEnvVarScope[]
 }
 type EnvelopeEnvVarContext = NonNullable<EnvelopeEnvVar['values']>[number]['context']
-type EnvelopeEnvVarValue = {
+export type EnvelopeEnvVarValue = {
   /**
    * The deploy context of the this env var value
    */
@@ -47,7 +47,7 @@ type EnvelopeEnvVarValue = {
   value?: string | undefined
 }
 
-type EnvelopeItem = {
+export type EnvelopeItem = {
   // FIXME(serhalp) Netlify API types claim this is optional. Investigate and fix here or there.
   key: string
   scopes: EnvelopeEnvVarScope[]

--- a/src/utils/env/index.ts
+++ b/src/utils/env/index.ts
@@ -30,12 +30,12 @@ type EnvelopeEnvVarScope =
 type EnvelopeEnvVar = Awaited<ReturnType<NetlifyAPI['getEnvVars']>>[number] & {
   scopes: EnvelopeEnvVarScope[]
 }
-type EnvelopeEnvVarContext = NonNullable<EnvelopeEnvVar['values']>[number]['context']
+type EnvelopeEnvVarContext = NonNullable<NonNullable<EnvelopeEnvVar['values']>[number]['context']>
 export type EnvelopeEnvVarValue = {
   /**
    * The deploy context of the this env var value
    */
-  context: EnvelopeEnvVarContext
+  context?: EnvelopeEnvVarContext
   /**
    * For parameterized contexts (i.e. only `branch`), context parameter (i.e. the branch name)
    */

--- a/tests/unit/utils/env/index.test.ts
+++ b/tests/unit/utils/env/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 import {
   filterEnvBySource,
-  findValueInValues,
+  getValueForContext,
   formatEnvelopeData,
   getHumanReadableScopes,
   normalizeContext,
@@ -21,7 +21,7 @@ test('should find a value from a given context', () => {
       value: 'bar',
     },
   ]
-  const result = findValueInValues(values, 'dev')
+  const result = getValueForContext(values, 'dev')
   expect(result).toHaveProperty('value', 'bar')
 })
 
@@ -37,7 +37,7 @@ test('should find a value from a given branch', () => {
       value: 'bar',
     },
   ]
-  const result = findValueInValues(values, 'staging')
+  const result = getValueForContext(values, 'staging')
   expect(result).toHaveProperty('value', 'foo')
 })
 

--- a/tests/unit/utils/env/index.test.ts
+++ b/tests/unit/utils/env/index.test.ts
@@ -65,24 +65,24 @@ test("should filter, sort, and format Envelope's response correctly", () => {
   const envelopeItems = [
     {
       key: 'FOO',
-      scopes: ['functions'],
+      scopes: ['functions' as const],
       values: [
         {
-          context: 'all',
+          context: 'all' as const,
           value: 'bar',
         },
       ],
     },
     {
       key: 'BAZ',
-      scopes: ['builds', 'functions', 'runtime', 'post_processing'],
+      scopes: ['builds' as const, 'functions' as const, 'runtime' as const, 'post_processing' as const],
       values: [
         {
-          context: 'production',
+          context: 'production' as const,
           value: 'bang',
         },
         {
-          context: 'branch',
+          context: 'branch' as const,
           context_parameter: 'staging',
           value: 'blah',
         },
@@ -118,10 +118,8 @@ test('should convert scope keys into a human-readable list', () => {
   expect(getHumanReadableScopes([])).toBe('')
   expect(getHumanReadableScopes()).toBe('Builds, Post processing')
   expect(getHumanReadableScopes(['post_processing'])).toBe('Post processing')
-  expect(getHumanReadableScopes(['post-processing'])).toBe('Post processing')
   expect(getHumanReadableScopes(['builds', 'functions'])).toBe('Builds, Functions')
   expect(getHumanReadableScopes(['builds', 'functions', 'runtime', 'post_processing'])).toBe('All')
-  expect(getHumanReadableScopes(['builds', 'functions', 'runtime', 'post-processing'])).toBe('All')
 })
 
 test('should normalize a branch name or context', () => {

--- a/tests/unit/utils/env/index.test.ts
+++ b/tests/unit/utils/env/index.test.ts
@@ -8,16 +8,18 @@ import {
   normalizeContext,
   translateFromEnvelopeToMongo,
   translateFromMongoToEnvelope,
+  type EnvelopeItem,
+  type EnvelopeEnvVarValue,
 } from '../../../../src/utils/env/index.js'
 
 test('should find a value from a given context', () => {
-  const values = [
+  const values: EnvelopeEnvVarValue[] = [
     {
-      context: 'production' as const,
+      context: 'production',
       value: 'foo',
     },
     {
-      context: 'dev' as const,
+      context: 'dev',
       value: 'bar',
     },
   ]
@@ -26,14 +28,14 @@ test('should find a value from a given context', () => {
 })
 
 test('should find a value from a given branch', () => {
-  const values = [
+  const values: EnvelopeEnvVarValue[] = [
     {
-      context: 'branch-deploy' as const,
+      context: 'branch-deploy',
       context_parameter: 'staging',
       value: 'foo',
     },
     {
-      context: 'dev' as const,
+      context: 'dev',
       value: 'bar',
     },
   ]
@@ -62,27 +64,27 @@ test('should filter an env from a given source', () => {
 })
 
 test("should filter, sort, and format Envelope's response correctly", () => {
-  const envelopeItems = [
+  const envelopeItems: EnvelopeItem[] = [
     {
       key: 'FOO',
-      scopes: ['functions' as const],
+      scopes: ['functions'],
       values: [
         {
-          context: 'all' as const,
+          context: 'all',
           value: 'bar',
         },
       ],
     },
     {
       key: 'BAZ',
-      scopes: ['builds' as const, 'functions' as const, 'runtime' as const, 'post_processing' as const],
+      scopes: ['builds', 'functions', 'runtime', 'post_processing'],
       values: [
         {
-          context: 'production' as const,
+          context: 'production',
           value: 'bang',
         },
         {
-          context: 'branch' as const,
+          context: 'branch',
           context_parameter: 'staging',
           value: 'blah',
         },


### PR DESCRIPTION
#### Summary

In preparation for a bug fix, this refactors code paths related to fetching and filtering environment variables for the optionally user-specified context and/or scope.

This should be pretty self-explanatory. I just renamed variables for clarity, fixed some missing types, added some inline doc comments, and did some minor refactoring.

Feel free to review commit by commit.