### PR TITLE
feat: beautify CLI update available notification and link to release notes

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -6,20 +6,37 @@ import { maybeEnableCompileCache } from '../dist/utils/nodejs-compile-cache.js'
 // 12 hours
 const UPDATE_CHECK_INTERVAL = 432e5
 
+const NETLIFY_CYAN_HEX = '#28b5ac'
+const UPDATE_BOXEN_OPTIONS = {
+  padding: 1,
+  margin: 1,
+  textAlignment: 'center',
+  borderStyle: 'round', 
+  borderColor: NETLIFY_CYAN_HEX,
+  float: 'center',
+  title: '⬥ ',
+  titleAlignment: 'center',
+}
+
 const main = async () => {
+  const { default: chalk } = await import('chalk')
   const { default: updateNotifier } = await import('update-notifier')
+  const { default: terminalLink } = await import('terminal-link')
   const { createMainCommand } = await import('../dist/commands/main.js')
   const { logError } = await import('../dist/utils/command-helpers.js')
   const { default: getPackageJson } = await import('../dist/utils/get-cli-package-json.js')
   const { runProgram } = await import('../dist/utils/run-program.js')
 
-  const pkg = await getPackageJson()
-
   try {
+    const pkg = await getPackageJson()
+    const message = `Update available ${chalk.dim('{currentVersion}')} → ${chalk.green('{latestVersion}')}
+See what's new in the ${terminalLink('release notes', 'https://ntl.fyi/cli-versions')}
+
+Run ${chalk.inverse.hex(NETLIFY_CYAN_HEX)('{updateCommand}')} to update`
     updateNotifier({
       pkg,
       updateCheckInterval: UPDATE_CHECK_INTERVAL,
-    }).notify()
+    }).notify({ message, boxenOptions: UPDATE_BOXEN_OPTIONS })
   } catch (error) {
     logError(`Error checking for updates: ${error?.toString()}`)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
         "@types/semver": "7.7.0",
         "@types/serialize-javascript": "^5.0.4",
         "@types/source-map-support": "0.5.10",
+        "@types/update-notifier": "^6.0.8",
         "@types/write-file-atomic": "4.0.3",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "3.1.1",
@@ -5316,6 +5317,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/configstore": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.2.tgz",
+      "integrity": "sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -5640,6 +5648,112 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/update-notifier": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-6.0.8.tgz",
+      "integrity": "sha512-IlDFnfSVfYQD+cKIg63DEXn3RFmd7W1iYtKQsJodcHK9R1yr8aKbKaPKfBxzPpcHCq2DU8zUq4PIPmy19Thjfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/configstore": "*",
+        "boxen": "^7.1.1"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/boxen": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
+      "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.1",
+        "chalk": "^5.2.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/update-notifier/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@types/write-file-atomic": {
@@ -23091,6 +23205,12 @@
         "@types/node": "*"
       }
     },
+    "@types/configstore": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.2.tgz",
+      "integrity": "sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -23408,6 +23528,77 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/update-notifier": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-6.0.8.tgz",
+      "integrity": "sha512-IlDFnfSVfYQD+cKIg63DEXn3RFmd7W1iYtKQsJodcHK9R1yr8aKbKaPKfBxzPpcHCq2DU8zUq4PIPmy19Thjfg==",
+      "dev": true,
+      "requires": {
+        "@types/configstore": "*",
+        "boxen": "^7.1.1"
+      },
+      "dependencies": {
+        "boxen": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
+          "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+          "dev": true,
+          "requires": {
+            "ansi-align": "^3.0.1",
+            "camelcase": "^7.0.1",
+            "chalk": "^5.2.0",
+            "cli-boxes": "^3.0.0",
+            "string-width": "^5.1.2",
+            "type-fest": "^2.13.0",
+            "widest-line": "^4.0.1",
+            "wrap-ansi": "^8.1.0"
+          }
+        },
+        "camelcase": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+          "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "widest-line": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+          "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+          "dev": true,
+          "requires": {
+            "string-width": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
       }
     },
     "@types/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "@types/semver": "7.7.0",
     "@types/serialize-javascript": "^5.0.4",
     "@types/source-map-support": "0.5.10",
+    "@types/update-notifier": "^6.0.8",
     "@types/write-file-atomic": "4.0.3",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "3.1.1",


### PR DESCRIPTION
### Summary

This polishes the look and brand of the CLI update available notification and adds a link to release notes.

When looking at the screenshots below, keep in mind they just show my own terminal background and colour configuration. These can vary, but we do use libraries that automatically adapt to available color space, support for OSC 8 terminal links, etc.

#### Before

![before](https://github.com/user-attachments/assets/aef6e9fb-d76b-4c74-ac6e-9462ac3aea5c)

#### After

![Screenshot 2025-04-24 at 16 55 36](https://github.com/user-attachments/assets/59152025-4193-47e7-81f1-a0d8cad120dd)