### PR TITLE
fix: fix framework server loading spinner ("Waiting for framework port")

### DIFF
--- a/src/utils/framework-server.ts
+++ b/src/utils/framework-server.ts
@@ -68,7 +68,7 @@ export const startFrameworkServer = async function ({
         throw new Error(`Timed out waiting for port '${settings.frameworkPort}' to be open`)
       }
     }
-    stopSpinner({ error: false, spinner })
+    spinner.success()
   } catch (error_) {
     stopSpinner({ error: true, spinner })
     log(NETLIFYDEVERR, `Netlify Dev could not start or connect to localhost:${settings.frameworkPort}.`)

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -4,7 +4,7 @@ import { stripVTControlCharacters } from 'util'
 
 import execa from 'execa'
 
-import { stopSpinner, type Spinner } from '../lib/spinner.js'
+import { type Spinner } from '../lib/spinner.js'
 
 import { chalk, log, NETLIFYDEVERR, NETLIFYDEVWARN } from './command-helpers.js'
 import { processOnExit } from './dev.js'
@@ -61,15 +61,9 @@ export const runCommand = (
 
   // Ensure that an active spinner stays at the bottom of the commandline
   // even though the actual framework command might be outputting stuff
-  if (spinner?.isSpinning()) {
-    // The spinner is initially "started" in the usual sense (rendering frames on an interval).
-    // In this case, we want to manually control when to clear and when to render a frame, so we turn this off.
-    stopSpinner({ error: false, spinner })
-  }
   const pipeDataWithSpinner = (writeStream: NodeJS.WriteStream, chunk: string | Uint8Array) => {
-    if (spinner?.isSpinning()) {
-      spinner.clear()
-    }
+    // Clear the spinner, write the framework command line, then resume spinning
+    spinner?.clear()
     writeStream.write(chunk, () => {
       spinner?.spin()
     })

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -61,13 +61,13 @@ export const runCommand = (
 
   // Ensure that an active spinner stays at the bottom of the commandline
   // even though the actual framework command might be outputting stuff
-  if (spinner?.isSpinning) {
+  if (spinner?.isSpinning()) {
     // The spinner is initially "started" in the usual sense (rendering frames on an interval).
     // In this case, we want to manually control when to clear and when to render a frame, so we turn this off.
     stopSpinner({ error: false, spinner })
   }
   const pipeDataWithSpinner = (writeStream: NodeJS.WriteStream, chunk: string | Uint8Array) => {
-    if (spinner?.isSpinning) {
+    if (spinner?.isSpinning()) {
       spinner.clear()
     }
     writeStream.write(chunk, () => {


### PR DESCRIPTION
### Summary

This is a regression in the loading spinner shown before "Waiting for framework port", introduced in 19.0.3.

See:
1. https://github.com/netlify/cli/pull/7026
2. https://github.com/netlify/cli/pull/7131
3. https://github.com/netlify/cli/issues/7124

Oops, I was really overthinking this. All this needs to do is, every time a chunk comes in from the underlying framework dev server, clear the spinner line, write the chunk, then resume the spinner.

This wasn't set up right at all, which was obfuscated by the erroneous use of `isSpinning`.

Fixes #7124.

Thank you @Florian-Mt for spotting the (embarrassing!) fix.

#### Before

![Monosnap screencast 2025-05-01 08-05-27](https://github.com/user-attachments/assets/f4a16978-7988-4d5b-8f81-a4d4b61ecef9)

#### After

![Monosnap screencast 2025-05-01 08-03-20](https://github.com/user-attachments/assets/c8cfafed-900b-4a5d-a2b5-74d57f1ac144)