### PR TITLE
fix: polish and improve deploy command output

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { argv } from 'process'
+import EventEmitter from 'events'
 
 import { maybeEnableCompileCache } from '../dist/utils/nodejs-compile-cache.js'
 
@@ -20,6 +21,12 @@ const UPDATE_BOXEN_OPTIONS = {
 }
 
 const main = async () => {
+  // TODO(serhalp) Investigate and fix this at the root instead.
+  // This avoids `MaxListenersExceededWarning` warnings during Edge Functions bundling,
+  // from somewhere around here:
+  // https://github.com/netlify/build/blob/ca0bb348b3d7437d2418526f49b803a3db4e5ac2/packages/build/src/steps/run_step.ts.
+  EventEmitter.defaultMaxListeners = 25
+
   const { default: chalk } = await import('chalk')
   const { default: updateNotifier } = await import('update-notifier')
   const { default: terminalLink } = await import('terminal-link')

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -26,6 +26,7 @@ import { BACKGROUND_FUNCTIONS_WARNING } from '../../lib/log.js'
 import { type Spinner, startSpinner, stopSpinner } from '../../lib/spinner.js'
 import { detectFrameworkSettings, getDefaultConfig } from '../../utils/build-info.js'
 import {
+  NETLIFY_CYAN_HEX,
   NETLIFYDEVERR,
   NETLIFYDEVLOG,
   chalk,
@@ -50,8 +51,6 @@ import { SiteInfo } from '../../utils/types.js'
 import type { DeployOptionValues } from './option_values.js'
 import boxen from 'boxen'
 import terminalLink from 'terminal-link'
-
-const NETLIFY_CYAN_HEX = '#28b5ac'
 
 const triggerDeploy = async ({
   api,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -702,7 +702,7 @@ const printResults = ({
     if (!deployToProduction) {
       log()
       log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag:')
-      log(chalk.cyanBright.bold(`netlify deploy${runBuildCommand ? ' --build' : ''} --prod`))
+      log(chalk.cyanBright.bold(`netlify deploy${runBuildCommand ? '' : '--no-build'} --prod`))
       log()
     }
   }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -345,7 +345,7 @@ const deployProgressCb = function () {
         return
       case 'stop':
       default: {
-        stopSpinner({ spinner: spinnersByType[event.type], text: event.msg })
+        spinnersByType[event.type].success(event.msg)
         delete spinnersByType[event.type]
       }
     }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -653,12 +653,14 @@ const printResults = ({
   runBuildCommand: boolean
 }): void => {
   const msgData: Record<string, string> = {
-    'Build logs': results.logsUrl,
-    'Function logs': results.functionLogsUrl,
-    'Edge function Logs': results.edgeFunctionLogsUrl,
+    'Build logs': terminalLink(results.logsUrl, results.logsUrl),
+    'Function logs': terminalLink(results.functionLogsUrl, results.functionLogsUrl),
+    'Edge function Logs': terminalLink(results.edgeFunctionLogsUrl, results.edgeFunctionLogsUrl),
   }
 
-  log()
+  log('')
+  // Note: this is leakily mimicking the @netlify/build heading style
+  log(chalk.cyanBright.bold(`🚀 Deploy complete\n${'─'.repeat(64)}`))
 
   // Json response for piping commands
   if (json) {
@@ -678,8 +680,6 @@ const printResults = ({
     logJson(jsonData)
     exit(0)
   } else {
-    log(prettyjson.render(msgData))
-
     const message = deployToProduction
       ? `Deployed to production URL: ${terminalLink(results.siteUrl, results.siteUrl)}\n
     Unique deploy URL: ${terminalLink(results.deployUrl, results.deployUrl)}`
@@ -694,10 +694,12 @@ const printResults = ({
         borderColor: NETLIFY_CYAN_HEX,
         // This is an intentional half-width space to work around a unicode padding math bug in boxen
         // eslint-disable-next-line no-irregular-whitespace
-        title: `⬥ ${deployToProduction ? 'Production deploy' : 'Draft deploy'} is live ⬥`,
+        title: `⬥  ${deployToProduction ? 'Production deploy' : 'Draft deploy'} is live ⬥ `,
         titleAlignment: 'center',
       }),
     )
+
+    log(prettyjson.render(msgData))
 
     if (!deployToProduction) {
       log()
@@ -746,6 +748,10 @@ const prepAndRunDeploy = async ({
   if (!options.build && edgeFunctionsConfig && edgeFunctionsConfig.length !== 0) {
     await bundleEdgeFunctions(options, command)
   }
+
+  log('')
+  // Note: this is leakily mimicking the @netlify/build heading style
+  log(chalk.cyanBright.bold(`Deploying to Netlify\n${'─'.repeat(64)}`))
 
   log('')
   log(

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -645,13 +645,11 @@ interface JsonData {
 
 const printResults = ({
   deployToProduction,
-  isIntegrationDeploy,
   json,
   results,
   runBuildCommand,
 }: {
   deployToProduction: boolean
-  isIntegrationDeploy: boolean
   json: boolean
   results: Awaited<ReturnType<typeof prepAndRunDeploy>>
   runBuildCommand: boolean
@@ -697,7 +695,7 @@ const printResults = ({
       log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag.')
       log(
         chalk.cyanBright.bold(
-          `netlify ${isIntegrationDeploy ? 'integration:' : ''}deploy${runBuildCommand ? ' --build' : ''} --prod`,
+          `netlify deploy${runBuildCommand ? ' --build' : ''} --prod`,
         ),
       )
       log()
@@ -893,11 +891,8 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
       deployToProduction,
     })
   }
-  const isIntegrationDeploy = command.name() === 'integration:deploy'
-
   printResults({
     runBuildCommand: options.build,
-    isIntegrationDeploy,
     json: options.json,
     results,
     deployToProduction,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -280,7 +280,6 @@ const prepareProductionDeploy = async ({ api, siteData }) => {
     await api.unlockDeploy({ deploy_id: siteData.published_deploy.id })
     log(`\n${NETLIFYDEVLOG} "Auto publishing" has been enabled for production context\n`)
   }
-  log('Deploying to main site URL...')
 }
 
 // @ts-expect-error TS(7006) FIXME: Parameter 'actual' implicitly has an 'any' type.
@@ -460,8 +459,6 @@ const runDeploy = async ({
   try {
     if (deployToProduction) {
       await prepareProductionDeploy({ siteData, api })
-    } else {
-      log('Deploying to draft URL...')
     }
 
     const draft = !deployToProduction && !alias

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -609,6 +609,9 @@ const bundleEdgeFunctions = async (options: DeployOptionValues, command: BaseCom
     packagePath: command.workspacePackage,
     buffer: true,
     featureFlags: edgeFunctionsFeatureFlags,
+    // We log our own progress so we don't want this as well. Plus, this logs much of the same
+    // information as the build that (likely) came before this as part of the deploy build.
+    quiet: options.debug ?? true,
     // @ts-expect-error FIXME(serhalp): This is missing from the `runCoreSteps` type in @netlify/build
     edgeFunctionsBootstrapURL: await getBootstrapURL(),
   })

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -380,7 +380,9 @@ const uploadDeployBlobs = async ({
   const blobsToken = token || undefined
   const { success } = await runCoreSteps(['blobs_upload'], {
     ...options,
-    quiet: silent,
+    // We log our own progress so we don't want this as well. Plus, this logs much of the same
+    // information as the build that (likely) came before this as part of the deploy build.
+    quiet: options.debug ?? true,
     // @ts-expect-error(serhalp) -- Untyped in `@netlify/build`
     cachedConfig,
     packagePath,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -736,6 +736,7 @@ const prepAndRunDeploy = async ({
     await bundleEdgeFunctions(options, command)
   }
 
+  log('')
   log(
     prettyjson.render({
       'Deploy path': deployFolder,
@@ -743,6 +744,7 @@ const prepAndRunDeploy = async ({
       'Configuration path': configPath,
     }),
   )
+  log()
 
   const { functionsFolderStat } = await validateFolders({
     deployFolder,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -48,6 +48,10 @@ import { sitesCreate } from '../sites/sites-create.js'
 import type { $TSFixMe } from '../types.js'
 import { SiteInfo } from '../../utils/types.js'
 import type { DeployOptionValues } from './option_values.js'
+import boxen from 'boxen'
+import terminalLink from 'terminal-link'
+
+const NETLIFY_CYAN_HEX = '#28b5ac'
 
 const triggerDeploy = async ({
   api,
@@ -654,14 +658,6 @@ const printResults = ({
     'Edge function Logs': results.edgeFunctionLogsUrl,
   }
 
-  if (deployToProduction) {
-    msgData['Unique deploy URL'] = results.deployUrl
-    msgData['Website URL'] = results.siteUrl
-  } else {
-    msgData['Website draft URL'] = results.deployUrl
-  }
-
-  // Spacer
   log()
 
   // Json response for piping commands
@@ -684,14 +680,29 @@ const printResults = ({
   } else {
     log(prettyjson.render(msgData))
 
+    const message = deployToProduction
+      ? `Deployed to production URL: ${terminalLink(results.siteUrl, results.siteUrl)}\n
+    Unique deploy URL: ${terminalLink(results.deployUrl, results.deployUrl)}`
+      : `Deployed draft to ${terminalLink(results.deployUrl, results.deployUrl)}`
+
+    log(
+      boxen(message, {
+        padding: 1,
+        margin: 1,
+        textAlignment: 'center',
+        borderStyle: 'round',
+        borderColor: NETLIFY_CYAN_HEX,
+        // This is an intentional half-width space to work around a unicode padding math bug in boxen
+        // eslint-disable-next-line no-irregular-whitespace
+        title: `⬥ ${deployToProduction ? 'Production deploy' : 'Draft deploy'} is live ⬥`,
+        titleAlignment: 'center',
+      }),
+    )
+
     if (!deployToProduction) {
       log()
-      log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag.')
-      log(
-        chalk.cyanBright.bold(
-          `netlify deploy${runBuildCommand ? ' --build' : ''} --prod`,
-        ),
-      )
+      log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag:')
+      log(chalk.cyanBright.bold(`netlify deploy${runBuildCommand ? ' --build' : ''} --prod`))
       log()
     }
   }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -589,13 +589,7 @@ const handleBuild = async ({
   return { newConfig, configMutations }
 }
 
-/**
- *
- * @param {*} options Bundling options
- * @returns
- */
-// @ts-expect-error TS(7006) FIXME: Parameter 'options' implicitly has an 'any' type.
-const bundleEdgeFunctions = async (options, command: BaseCommand) => {
+const bundleEdgeFunctions = async (options: DeployOptionValues, command: BaseCommand): Promise<void> => {
   const argv = process.argv.slice(2)
   const statusCb =
     options.silent || argv.includes('--json') || argv.includes('--silent') ? () => {} : deployProgressCb()
@@ -611,6 +605,7 @@ const bundleEdgeFunctions = async (options, command: BaseCommand) => {
     packagePath: command.workspacePackage,
     buffer: true,
     featureFlags: edgeFunctionsFeatureFlags,
+    // @ts-expect-error FIXME(serhalp): This is missing from the `runCoreSteps` type in @netlify/build
     edgeFunctionsBootstrapURL: await getBootstrapURL(),
   })
 
@@ -703,24 +698,21 @@ const printResults = ({
 }
 
 const prepAndRunDeploy = async ({
-  // @ts-expect-error TS(7031) FIXME: Binding element 'api' implicitly has an 'any' type... Remove this comment to see the full error message
   api,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'command' implicitly has an 'any' ... Remove this comment to see the full error message
   command,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'config' implicitly has an 'any' t... Remove this comment to see the full error message
   config,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'deployToProduction' implicitly ha... Remove this comment to see the full error message
   deployToProduction,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'options' implicitly has an 'any' ... Remove this comment to see the full error message
   options,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'site' implicitly has an 'any' typ... Remove this comment to see the full error message
   site,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'siteData' implicitly has an 'any'... Remove this comment to see the full error message
   siteData,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'siteId' implicitly has an 'any' t... Remove this comment to see the full error message
   siteId,
-  // @ts-expect-error TS(7031) FIXME: Binding element 'workingDir' implicitly has an 'an... Remove this comment to see the full error message
   workingDir,
+}: {
+  options: DeployOptionValues
+  command: BaseCommand
+  workingDir: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME(serhalp)
+  [key: string]: any
 }) => {
   const alias = options.alias || options.branch
   // if a context is passed besides dev, we need to pull env vars from that specific context
@@ -779,7 +771,7 @@ const prepAndRunDeploy = async ({
     command,
     config,
     deployFolder,
-    deployTimeout: options.timeout * SEC_TO_MILLISEC || DEFAULT_DEPLOY_TIMEOUT,
+    deployTimeout: options.timeout ? options.timeout * SEC_TO_MILLISEC : DEFAULT_DEPLOY_TIMEOUT,
     deployToProduction,
     functionsConfig,
     // pass undefined functionsFolder if doesn't exist

--- a/src/commands/sites/sites-list.ts
+++ b/src/commands/sites/sites-list.ts
@@ -1,7 +1,7 @@
 import { OptionValues } from 'commander'
 
 import { listSites } from '../../lib/api.js'
-import { startSpinner, stopSpinner } from '../../lib/spinner.js'
+import { startSpinner } from '../../lib/spinner.js'
 import { chalk, log, logJson } from '../../utils/command-helpers.js'
 import { SiteInfo } from '../../utils/types.js'
 import BaseCommand from '../base-command.js'
@@ -16,7 +16,7 @@ export const sitesList = async (options: OptionValues, command: BaseCommand) => 
 
   const sites = await listSites({ api, options: { filter: 'all' } })
   if (spinner) {
-    stopSpinner({ spinner })
+    spinner.success()
   }
 
   if (sites && sites.length !== 0) {


### PR DESCRIPTION
### Summary

As in https://github.com/netlify/cli/pull/7249, this makes misc. improvements to the output of `ntl deploy`, in order to improve the signal-to-noise ratio, improve clarity, and make it a little more pleasant to look at:
- Move deploy URL to its own primary section in a Netlify-cyan callout box with distinctive diamond
  - It's the primary call-to-action, so it should be the primary focus rather than be buried with the three other URLs
  - It's a little more celebratory/satisfying
- Remove redundant "draft" vs. "production" line (mentioned in new box now)
  - This incidentally fixes a rendering bug, where "Uploading blobs to deploy store" with a spinner gets frozen in a weird place
- Use OSC 8 "terminal links" when supported
- Suppress redundant blobs upload build output
  - This was basically printing the huge "Netlify Build" section a second time for no benefit (see gifs below)
- Improve spacing between sections
- Add "Deploying to Netlify" and "Deploy complete" section headers to improve visual grouping
- Fix edge function step node.js warnings
- Fix deploy progress spinners' final states (regressed 1-2 months ago I believe)

#### Before

![Monosnap screencast 2025-05-01 17-34-21](https://github.com/user-attachments/assets/6ddd5c93-8cc1-4786-94bf-bd3451bce890)

#### After

(the first few seconds are the same, but the full log is relevant to understand redundancy and consistency)
![Monosnap screencast 2025-05-01 17-15-59](https://github.com/user-attachments/assets/83ebc98b-d8d9-4b0c-8fac-c7be6326a42f)

and for completeness here's a production deploy:
![image](https://github.com/user-attachments/assets/a7759355-51ff-4194-a39e-102d51abdfb2)

### Notes

Reviewer, I suggest reviewing by commit!