### PR TITLE
test: pin @netlify/blobs deps in test fixtures

### DIFF
--- a/tests/integration/commands/dev/dev.test.ts
+++ b/tests/integration/commands/dev/dev.test.ts
@@ -40,7 +40,7 @@ const withServeBlobsFunction = (builder: SiteBuilder): SiteBuilder =>
       path: 'package.json',
       content: JSON.stringify({
         dependencies: {
-          '@netlify/blobs': '*',
+          '@netlify/blobs': '^8.0.0',
         },
       }),
     })

--- a/tests/integration/commands/dev/serve.test.ts
+++ b/tests/integration/commands/dev/serve.test.ts
@@ -90,7 +90,7 @@ test.skipIf(process.env.NETLIFY_TEST_DISABLE_LIVE === 'true')(
           path: 'package.json',
           content: JSON.stringify({
             dependencies: {
-              '@netlify/blobs': '*',
+              '@netlify/blobs': '^8.0.0',
             },
           }),
         })


### PR DESCRIPTION
#### Summary

These suddenly started failing when a new major was published.

I don't think there's any particular reason to use `*` here. It just adds nondeterminism to our CI.