### PR TITLE
fix: actually stop spinning on success/failure

### DIFF
--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -65,9 +65,13 @@ export const runCommand = (
   // even though the actual framework command might be outputting stuff
   const pipeDataWithSpinner = (writeStream: NodeJS.WriteStream, chunk: string | Uint8Array) => {
     // Clear the spinner, write the framework command line, then resume spinning
-    spinner?.clear()
+    if (spinner?.isSpinning()) {
+      spinner.clear()
+    }
     writeStream.write(chunk, () => {
-      spinner?.spin()
+      if (spinner?.isSpinning()) {
+        spinner.spin()
+      }
     })
   }
 


### PR DESCRIPTION
### Summary

Even after we've called `.success()` or `.stop()` on this spinner, we were continuing to render it when we receive output from the framework server.

#### Before

![Screenshot 2025-05-06 at 13 17 24](https://github.com/user-attachments/assets/5c287e4d-55b6-4329-aa96-a2d18e0fe2a4)

#### After

![image](https://github.com/user-attachments/assets/544e8304-75d1-4003-9830-e601d9fde09f)