### PR TITLE
fix(deploy): fix typo in post-deploy message

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -706,7 +706,7 @@ const printResults = ({
     if (!deployToProduction) {
       log()
       log('If everything looks good on your draft URL, deploy it to your main site URL with the --prod flag:')
-      log(chalk.cyanBright.bold(`netlify deploy${runBuildCommand ? '' : '--no-build'} --prod`))
+      log(chalk.cyanBright.bold(`netlify deploy${runBuildCommand ? '' : ' --no-build'} --prod`))
       log()
     }
   }


### PR DESCRIPTION
#### Summary

Fix missing space in message shown after non-prod deploy.

Fixes https://github.com/netlify/cli/issues/7285.