### PR TITLE
feat: publish `netlify` package

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,7 +54,18 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
-      - name: Publish package
+      - name: Publish netlify-cli package
         run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Prepare netlify package
+        run: node scripts/netlifyPackage.js prepare
+
+      - name: Publish netlify package
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Verify netlify package
+        run: node scripts/netlifyPackage.js verify

--- a/scripts/netlifyPackage.js
+++ b/scripts/netlifyPackage.js
@@ -1,0 +1,54 @@
+// @ts-check
+import assert from 'node:assert'
+import { basename, dirname, resolve } from 'node:path'
+import { argv } from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { readFile, writeFile } from 'node:fs/promises'
+
+import execa from 'execa'
+
+const packageJSON = await getPackageJSON()
+
+async function getPackageJSON() {
+  const packageJSONPath = resolve(fileURLToPath(import.meta.url), '../../package.json')
+  const contents = JSON.parse(await readFile(packageJSONPath, 'utf8'))
+
+  return {
+    contents,
+    path: packageJSONPath,
+  }
+}
+
+/**
+ * @type {Record<string, function>}
+ */
+const commands = {
+  prepare: async () => {
+    const newPackageJSON = {
+      ...packageJSON.contents,
+      main: './dist/index.js',
+      name: 'netlify',
+    }
+
+    console.log(`Writing updated package.json to ${packageJSON.path}...`)
+    await writeFile(packageJSON.path, `${JSON.stringify(newPackageJSON, null, 2)}\n`)
+
+    console.log('Re-installing dependencies to update lockfile...')
+    await execa('npm', ['install'], {
+      cwd: dirname(packageJSON.path),
+    })
+  },
+
+  verify: async () => {
+    const { stdout } = await execa('npx', ['-y', 'netlify', '--version'])
+    const version = stdout.match(/netlify-cli\/(\d+\.\d+\.\d+)/)
+
+    assert.equal(version, packageJSON.contents.version, 'Version installed via npx matches latest version')
+  },
+}
+
+if (typeof commands[argv[2]] === 'function') {
+  commands[argv[2]]()
+} else {
+  console.error(`Usage: node ${basename(argv[1])} <command> (available commands: ${Object.keys(commands).join(', ')})`)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+// This is an entrypoint that mirrors the interface that the `netlify` package
+// used to have, before it was renamed to `@netlify/api`. We keep it for
+// backwards-compatibility.
+export { NetlifyAPI, methods } from '@netlify/api'


### PR DESCRIPTION
#### Summary

Adds a script that publishes the same code as a second package (`netlify`). We have different options to make this happen, like making `netlify-cli` a dependency of `netlify`. But to minimise the changes to `netlify-cli` (which doesn't even have a `main` field at the moment), I went for a script that is meant to be run in the CI and patches `package.json` with the new name and `main` before publishing it.