### PR TITLE
fix: improve link fallback when OSC 8 is not supported

### DIFF
--- a/src/commands/blobs/blobs.ts
+++ b/src/commands/blobs/blobs.ts
@@ -88,7 +88,7 @@ export const createBlobsCommand = (program: BaseCommand) => {
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/blobs/overview/'
       return `
-For more information about Netlify Blobs, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify Blobs, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .addExamples([

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -25,7 +25,7 @@ export const createBuildCommand = (program: BaseCommand) =>
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/configure-builds/overview/'
       return `
-For more information about Netlify builds, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify builds, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options, command) => {

--- a/src/commands/clone/index.ts
+++ b/src/commands/clone/index.ts
@@ -28,7 +28,7 @@ To specify a site, use --id or --name. By default, the Netlify site to link will
     ])
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/get-started/#link-and-unlink-sites'
-      return `For more information about linking sites, see ${terminalLink(docsUrl, docsUrl)}\n`
+      return `For more information about linking sites, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}\n`
     })
     .action(async (repo: string, targetDir: string | undefined, options: CloneOptionValues, command: BaseCommand) => {
       const { clone } = await import('./clone.js')

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -655,9 +655,9 @@ const printResults = ({
   runBuildCommand: boolean
 }): void => {
   const msgData: Record<string, string> = {
-    'Build logs': terminalLink(results.logsUrl, results.logsUrl),
-    'Function logs': terminalLink(results.functionLogsUrl, results.functionLogsUrl),
-    'Edge function Logs': terminalLink(results.edgeFunctionLogsUrl, results.edgeFunctionLogsUrl),
+    'Build logs': terminalLink(results.logsUrl, results.logsUrl, { fallback: false }),
+    'Function logs': terminalLink(results.functionLogsUrl, results.functionLogsUrl, { fallback: false }),
+    'Edge function Logs': terminalLink(results.edgeFunctionLogsUrl, results.edgeFunctionLogsUrl, { fallback: false }),
   }
 
   log('')
@@ -683,9 +683,9 @@ const printResults = ({
     exit(0)
   } else {
     const message = deployToProduction
-      ? `Deployed to production URL: ${terminalLink(results.siteUrl, results.siteUrl)}\n
-    Unique deploy URL: ${terminalLink(results.deployUrl, results.deployUrl)}`
-      : `Deployed draft to ${terminalLink(results.deployUrl, results.deployUrl)}`
+      ? `Deployed to production URL: ${terminalLink(results.siteUrl, results.siteUrl, { fallback: false })}\n
+    Unique deploy URL: ${terminalLink(results.deployUrl, results.deployUrl, { fallback: false })}`
+      : `Deployed draft to ${terminalLink(results.deployUrl, results.deployUrl, { fallback: false })}`
 
     log(
       boxen(message, {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -144,7 +144,7 @@ Support for package.json's main field, and intrinsic index.js entrypoints are co
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/site-deploys/overview/'
       return `
-For more information about Netlify deploys, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify deploys, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: DeployOptionValues, command: BaseCommand) => {

--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -109,7 +109,7 @@ export const createDevCommand = (program: BaseCommand) => {
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/local-development/'
       return `
-For more information about Netlify local development, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify local development, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: OptionValues, command: BaseCommand) => {

--- a/src/commands/env/env.ts
+++ b/src/commands/env/env.ts
@@ -164,7 +164,7 @@ export const createEnvCommand = (program: BaseCommand) => {
     .addHelpText('afterAll', () => {
       const docsUrl = 'https://docs.netlify.com/configure-builds/environment-variables/'
       return `
-For more information about environment variables on Netlify, see ${terminalLink(docsUrl, docsUrl)}
+For more information about environment variables on Netlify, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(env)

--- a/src/commands/functions/functions.ts
+++ b/src/commands/functions/functions.ts
@@ -123,7 +123,7 @@ The ${name} command will help you manage the functions in this site`,
     .addHelpText('afterAll', () => {
       const docsUrl = 'https://docs.netlify.com/functions/overview/'
       return `
-For more information about Netlify Functions, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify Functions, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(functions)

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -14,7 +14,7 @@ export const createInitCommand = (program: BaseCommand) =>
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/get-started/'
       return `
-For more information about getting started with Netlify CLI, see ${terminalLink(docsUrl, docsUrl)}
+For more information about getting started with Netlify CLI, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: OptionValues, command: BaseCommand) => {

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -20,7 +20,7 @@ export const createLinkCommand = (program: BaseCommand) =>
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/get-started/#link-and-unlink-sites'
       return `
-For more information about linking sites, see ${terminalLink(docsUrl, docsUrl)}
+For more information about linking sites, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: LinkOptionValues, command: BaseCommand) => {

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -14,7 +14,7 @@ Opens a web browser to acquire an OAuth token.`,
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/get-started/#authentication'
       return `
-For more information about Netlify authentication, see ${terminalLink(docsUrl, docsUrl)}
+For more information about Netlify authentication, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: OptionValues, command: BaseCommand) => {

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -252,10 +252,10 @@ export const createMainCommand = (): BaseCommand => {
       const docsUrl = 'https://docs.netlify.com'
       const bugsUrl = pkg.bugs?.url ?? ''
       return `→ For more help with the CLI, visit ${NETLIFY_CYAN(
-        terminalLink(cliDocsEntrypointUrl, cliDocsEntrypointUrl),
+        terminalLink(cliDocsEntrypointUrl, cliDocsEntrypointUrl, { fallback: false }),
       )}
-→ For help with Netlify, visit ${NETLIFY_CYAN(terminalLink(docsUrl, docsUrl))}
-→ To report a CLI bug, visit ${NETLIFY_CYAN(terminalLink(bugsUrl, bugsUrl))}\n`
+→ For help with Netlify, visit ${NETLIFY_CYAN(terminalLink(docsUrl, docsUrl, { fallback: false }))}
+→ To report a CLI bug, visit ${NETLIFY_CYAN(terminalLink(bugsUrl, bugsUrl, { fallback: false }))}\n`
     })
     .configureOutput({
       outputError: (message, write) => {

--- a/src/commands/unlink/index.ts
+++ b/src/commands/unlink/index.ts
@@ -10,7 +10,7 @@ export const createUnlinkCommand = (program: BaseCommand) =>
     .addHelpText('after', () => {
       const docsUrl = 'https://docs.netlify.com/cli/get-started/#link-and-unlink-sites'
       return `
-For more information about linking sites, see ${terminalLink(docsUrl, docsUrl)}
+For more information about linking sites, see ${terminalLink(docsUrl, docsUrl, { fallback: false })}
 `
     })
     .action(async (options: OptionValues, command: BaseCommand) => {

--- a/tests/integration/commands/help/__snapshots__/help.test.ts.snap
+++ b/tests/integration/commands/help/__snapshots__/help.test.ts.snap
@@ -38,9 +38,9 @@ COMMANDS
   $ unlink       Unlink a local folder from a Netlify site
   $ watch        Watch for site deploy to finish
 
-→ For more help with the CLI, visit https://developers.netlify.com/cli (​https://developers.netlify.com/cli​)
-→ For help with Netlify, visit https://docs.netlify.com (​https://docs.netlify.com​)
-→ To report a CLI bug, visit https://github.com/netlify/cli/issues (​https://github.com/netlify/cli/issues​)"
+→ For more help with the CLI, visit https://developers.netlify.com/cli
+→ For help with Netlify, visit https://docs.netlify.com
+→ To report a CLI bug, visit https://github.com/netlify/cli/issues"
 `;
 
 exports[`help command > netlify help completion 1`] = `


### PR DESCRIPTION
#### Summary

The `terminal-link` package uses [OSC 8](https://github.com/Alhadis/OSC8-Adoption/) link formatting when running in a terminal that supports it. When it isn't supported, by default it falls back to rendering the text followed by the link in parens. This is fine, but when we pass the full URL as the text, it's unnecessarily noisy, e.g.:

```
Deployed to draft URL: https://my-example-site.netlify.app (https://my-example-site.netlify.app)
```

Passing `fallback: false` toggles the fallback behaviour to just render the text as-is, e.g.:

```
Deployed to draft URL: https://my-example-site.netlify.app
```

This wasn't clear previously from the docs: https://github.com/sindresorhus/terminal-link/pull/26.