### PR TITLE
ci: use windows-2025 image

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2025]
         # Pinning 20.x version as a temporary workaround due to this https://github.com/nodejs/node/issues/52884
         node-version: ['20.12.2', '22']
       fail-fast: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,13 +17,13 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2025]
         # Pinning 20.x version as a temporary workaround due to this https://github.com/nodejs/node/issues/52884
         node-version: ['20.12.2', '22']
         shard: ['1/4', '2/4', '3/4', '4/4']
 
         exclude:
-          - os: windows-latest
+          - os: windows-2025
             node-version: '22'
       fail-fast: false
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: |
           netsh int ipv4 set dynamicport tcp start=1025 num=64511
           REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP\Parameters /v TcpTimedWaitDelay /t REG_DWORD /d 30 /f
-        if: "${{ matrix.os == 'windows-latest' }}"
+        if: "${{ matrix.os == 'windows-2025' }}"
 
       - name: Git checkout
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
   # Can be replaced with larger node 23 tests in the future.
   integration-win-node-23:
     name: Integration test windows latest node23 specific
-    runs-on: windows-latest
+    runs-on: windows-2025
     timeout-minutes: 40
     steps:
       # This improves Windows network performance, we need this since we open many ports in our tests
@@ -172,7 +172,7 @@ jobs:
         id: test-coverage-flags
         # For windows we have to use $env:
         run: |-
-          os=windows-latest
+          os=windows-2025
           node=$(node --version)
           echo "os=${os/-latest/}" >> $GITHUB_OUTPUT
           echo "os=${os/-latest/}" >> $env:GITHUB_OUTPUT
@@ -184,7 +184,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: npm-logs--windows-latest--23x
+          name: npm-logs--windows-2025--23x
           path: |
             ~/.npm/_logs/**/*
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2025]
         node-version: ['20.12.2', '22.x']
         exclude:
-          - os: windows-latest
+          - os: windows-2025
             node-version: '22.x'
       fail-fast: false
     steps:


### PR DESCRIPTION
#### Summary

Update CI to use the latest windows runner available
Seems to have a positive impact on the flakiness of the e2e tests
Ran a few times without hitting a time out, meanwhile in another branch without this change I'm on attempt 20 in a row

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
