### PR TITLE
fix: notify activity called for any proxied request

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -859,15 +859,13 @@ const onRequest = async (
   }
 
   const maybeNotifyActivity = () => {
-    if (req.method === 'GET' && api && process.env.NETLIFY_DEV_SERVER_ID) {
+    if (api && process.env.NETLIFY_DEV_SERVER_ID && (req.method === 'GET' || req.url?.startsWith('/.ntlfy-dev/'))) {
       notifyActivity(api, siteInfo.id, process.env.NETLIFY_DEV_SERVER_ID)
     }
   }
 
   if (match) {
-    if (!isExternal(match)) {
-      maybeNotifyActivity()
-    }
+    maybeNotifyActivity()
 
     // We don't want to generate an ETag for 3xx redirects.
     // @ts-expect-error TS(7031) FIXME: Binding element 'statusCode' implicitly has an 'an... Remove this comment to see the full error message


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

If preview server does the proxy e.g. to internal routes or the user site proxy-all `*` - we not notifying activity.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
