### PR TITLE
fix: notify activity should not be called for the HEAD requests

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -859,7 +859,8 @@ const onRequest = async (
   }
 
   const maybeNotifyActivity = () => {
-    if (api && process.env.NETLIFY_DEV_SERVER_ID && (req.method === 'GET' || req.url?.startsWith('/.ntlfy-dev/'))) {
+    const isInternalRequest = req.url?.startsWith('/.ntlfy-dev/') && req.method !== 'HEAD'
+    if (api && process.env.NETLIFY_DEV_SERVER_ID && (req.method === 'GET' || isInternalRequest)) {
       notifyActivity(api, siteInfo.id, process.env.NETLIFY_DEV_SERVER_ID)
     }
   }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Some requests might come as HEAD and spamming them might create a lot of activity calls - this PR prevents it.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
