### PR TITLE
fix: notify activity was called for internal endpoints

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -859,8 +859,10 @@ const onRequest = async (
   }
 
   const maybeNotifyActivity = () => {
-    const isInternalRequest = req.url?.startsWith('/.ntlfy-dev/') && req.method !== 'HEAD'
-    if (api && process.env.NETLIFY_DEV_SERVER_ID && (req.method === 'GET' || isInternalRequest)) {
+    const skipInternalUrls = ['/.ntlfy-dev/up', '/.ntlfy-dev/health']
+    const isInternalRequest = req.url?.startsWith('/.ntlfy-dev/')
+    const trackRequest = isInternalRequest ? !skipInternalUrls.includes(req.url ?? '') : req.method === 'GET'
+    if (api && process.env.NETLIFY_DEV_SERVER_ID && trackRequest) {
       notifyActivity(api, siteInfo.id, process.env.NETLIFY_DEV_SERVER_ID)
     }
   }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Found another issue where liveness check was triggering notify activity, which made the preview server never auto shutdown

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
