### PR TITLE
fix: providing cwd matching the root dir and filter option conflicted…

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -500,9 +500,21 @@ export default class BaseCommand extends Command {
   private async init(actionCommand: BaseCommand) {
     debug(`${actionCommand.name()}:init`)('start')
     const flags = actionCommand.opts()
+
     // here we actually want to use the process.cwd as we are setting the workingDir
     // eslint-disable-next-line no-restricted-properties
-    this.workingDir = flags.cwd ? resolve(flags.cwd) : process.cwd()
+    const processCwd = process.cwd()
+
+    if (flags.cwd) {
+      const resolvedCwd = resolve(flags.cwd)
+      this.workingDir = resolvedCwd
+
+      // if cwd matches process.cwd, act like cwd wasn't provided
+      if (resolvedCwd === processCwd) {
+        delete flags.cwd
+        this.workingDir = processCwd
+      }
+    }
 
     // ==================================================
     // Create a Project and run the Heuristics to detect


### PR DESCRIPTION
… preventing functions to be discovered

🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fixes EX_184
Preview Server always provides a `cwd` matching the root dir. But since it was provided - the `filter` option started to conflict, so edge function dir never set hence functions are never "discovered".

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
