### PR TITLE
fix: patch fetch for older node

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { argv } from 'process'
 import EventEmitter from 'events'
+import nf, { Request, Response, Headers } from 'node-fetch'
 
 import { maybeEnableCompileCache } from '../dist/utils/nodejs-compile-cache.js'
 
@@ -12,12 +13,21 @@ const UPDATE_BOXEN_OPTIONS = {
   padding: 1,
   margin: 1,
   textAlignment: 'center',
-  borderStyle: 'round', 
+  borderStyle: 'round',
   borderColor: NETLIFY_CYAN_HEX,
   float: 'center',
   // This is an intentional half-width space to work around a unicode padding math bug in boxen
   title: '⬥ ',
   titleAlignment: 'center',
+}
+
+// patch fetch for node < 18
+if (!globalThis.fetch) {
+  globalThis.fetch = nf;
+  globalThis.Request = Request;
+  globalThis.Response = Response;
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  globalThis.Headers = Headers;
 }
 
 const main = async () => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

One of the customers forced to use older node (16), which doesn't have fetch support, which is being used by various things across the system.

This PR patches it.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
