### PR TITLE
feat: add internal functions:serve load-dist-functions knob

### DIFF
--- a/src/commands/functions/functions-serve.ts
+++ b/src/commands/functions/functions-serve.ts
@@ -50,6 +50,7 @@ export const functionsServe = async (options: OptionValues, command: BaseCommand
   })
 
   await startFunctionsServer({
+    loadDistFunctions: process.env.NETLIFY_FUNCTIONS_SERVE_LOAD_DIST_FUNCTIONS === 'true',
     blobsContext,
     config,
     debug: options.debug,


### PR DESCRIPTION
This adds an unstable, undocumented configuration knob that instructs `netlify functions:serve` to load dist bundles, rather than to build and serve local functions.

This configuration knob is useful for internal testing of SDK-injected functions.
