### PR TITLE
refactor: use getAPIToken from @netlify/dev-utils

### DIFF
--- a/src/utils/command-helpers.ts
+++ b/src/utils/command-helpers.ts
@@ -5,7 +5,7 @@ import process from 'process'
 import { format, inspect } from 'util'
 
 import type { NetlifyAPI } from '@netlify/api'
-import { getGlobalConfigStore } from '@netlify/dev-utils'
+import { getAPIToken } from '@netlify/dev-utils'
 import { Chalk } from 'chalk'
 import chokidar from 'chokidar'
 import decache from 'decache'
@@ -142,9 +142,7 @@ export const getToken = async (tokenFromOptions?: string): Promise<TokenTuple> =
     return [NETLIFY_AUTH_TOKEN, 'env']
   }
   // 3. If no env var use global user setting
-  const globalConfig = await getGlobalConfigStore()
-  const userId = globalConfig.get('userId')
-  const tokenFromConfig = globalConfig.get(`users.${userId}.auth.token`)
+  const tokenFromConfig = await getAPIToken()
   if (tokenFromConfig) {
     return [tokenFromConfig, 'config']
   }


### PR DESCRIPTION
#### Summary

Fixes #EX-386

Replaced logic that gets API token from global config store with `getAPIToken`. 

Ref: https://github.com/netlify/primitives/blob/main/packages/dev-utils/src/lib/api-token.ts#L3