### PR TITLE
fix(deploy): make --create-site flag always work without interaction

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -932,9 +932,13 @@ const createSiteWithFlags = async (options: DeployOptionValues, command: BaseCom
   if (siteName) {
     body.name = siteName.trim()
   }
-  
+
+  if (!options.team) {
+    throw new Error('Team must be specified to create a site')
+  }
+
   const siteData = await api.createSiteInTeam({
-    accountSlug: options.team!,
+    accountSlug: options.team,
     body,
   })
   site.id = siteData.id

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -953,16 +953,19 @@ const promptForSiteAction = async (options: DeployOptionValues, command: BaseCom
     log(`\nYou must pick a --team: ${availableTeams.map((team) => team.slug).join(', ')}`)
   }
 
+  const NEW_SITE = '+  Create & configure a new project'
+  const EXISTING_SITE = '⇄  Link this directory to an existing project'
+
   const { initChoice } = await inquirer.prompt([
     {
       type: 'list',
       name: 'initChoice',
       message: 'What would you like to do?',
-      choices: ['Link this directory to an existing project', 'Create & configure a new project'],
+      choices: [EXISTING_SITE, NEW_SITE],
     },
   ])
 
-  const siteData = initChoice.startsWith('+') ? await sitesCreate({}, command) : await link({}, command)
+  const siteData = initChoice === NEW_SITE ? await sitesCreate({}, command) : await link({}, command)
 
   site.id = siteData.id
   return siteData

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -937,12 +937,23 @@ const createSiteWithFlags = async (options: DeployOptionValues, command: BaseCom
     throw new Error('Team must be specified to create a site')
   }
 
-  const siteData = await api.createSiteInTeam({
-    accountSlug: options.team,
-    body,
-  })
-  site.id = siteData.id
-  return siteData as SiteInfo
+  try {
+    const siteData = await api.createSiteInTeam({
+      accountSlug: options.team,
+      body,
+    })
+    site.id = siteData.id
+    return siteData as SiteInfo
+  } catch (error_) {
+    if ((error_ as APIError).status === 422) {
+      return logAndThrowError(
+        siteName
+          ? `Site name "${siteName}" is already taken. Please try a different name.`
+          : 'Unable to create site with a random name. Please try again or specify a different name.',
+      )
+    }
+    return logAndThrowError(`Failed to create site: ${(error_ as APIError).status}: ${(error_ as APIError).message}`)
+  }
 }
 
 const promptForSiteAction = async (options: DeployOptionValues, command: BaseCommand, site: $TSFixMe) => {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -926,15 +926,19 @@ const createSiteWithFlags = async (options: DeployOptionValues, command: BaseCom
     log(message)
   }
 
-  const siteData = await sitesCreate(
-    {
-      name: siteName,
-      accountSlug: options.team,
-    },
-    command,
-  )
+  // Create site directly via API to bypass interactive prompts
+  const { api } = command.netlify
+  const body: { name?: string } = {}
+  if (siteName) {
+    body.name = siteName.trim()
+  }
+  
+  const siteData = await api.createSiteInTeam({
+    accountSlug: options.team!,
+    body,
+  })
   site.id = siteData.id
-  return siteData
+  return siteData as SiteInfo
 }
 
 const promptForSiteAction = async (options: DeployOptionValues, command: BaseCommand, site: $TSFixMe) => {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -957,19 +957,25 @@ const promptForSiteAction = async (options: DeployOptionValues, command: BaseCom
     log(`\nYou must pick a --team: ${availableTeams.map((team) => team.slug).join(', ')}`)
   }
 
-  const NEW_SITE = '+  Create & configure a new project'
-  const EXISTING_SITE = '⇄  Link this directory to an existing project'
-
   const { initChoice } = await inquirer.prompt([
     {
       type: 'list',
       name: 'initChoice',
       message: 'What would you like to do?',
-      choices: [EXISTING_SITE, NEW_SITE],
+      choices: [
+        {
+          name: '⇄  Link this directory to an existing project',
+          value: 'link',
+        },
+        {
+          name: '+  Create & configure a new project',
+          value: 'create',
+        },
+      ],
     },
   ])
 
-  const siteData = initChoice === NEW_SITE ? await sitesCreate({}, command) : await link({}, command)
+  const siteData = initChoice === 'create' ? await sitesCreate({}, command) : await link({}, command)
 
   site.id = siteData.id
   return siteData


### PR DESCRIPTION
## Summary
- Fixed error where interactive prompt didn't let you select "Create new project"
- Fixed the --create-site flag to always work without requiring interaction

## Test plan
- [ ] Test --create-site flag with various scenarios
- [ ] Verify non-interactive behavior works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)