### PR TITLE
chore: add conventional commit PR title linter

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,0 +1,13 @@
+name: PR Title - Conventional Commit
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: npm install @commitlint/config-conventional
+    - uses: JulienKode/pull-request-name-linter-action@v19.0.0


### PR DESCRIPTION
#### Summary

The bot we were using to do this PR title linting [is deprecated now](https://github.com/apps/conventional-commit-lint-gcf) so this is a replacement.