### PR TITLE
fix: load correct environment variables in Preview Server context

### DIFF
--- a/src/commands/dev/dev.ts
+++ b/src/commands/dev/dev.ts
@@ -137,7 +137,7 @@ export const dev = async (options: OptionValues, command: BaseCommand) => {
 
   env[BLOBS_CONTEXT_VARIABLE] = { sources: ['internal'], value: encodeBlobsContext(blobsContext) }
 
-  if (!options.offline && !options.offlineEnv) {
+  if (!(options.offline || options.offlineEnv)) {
     env = await getEnvelopeEnv({ api, context: options.context, env, siteInfo })
     log(`${NETLIFYDEVLOG} Injecting environment variable values for ${chalk.yellow('all scopes')}`)
   }

--- a/tests/integration/commands/env/env-set.test.ts
+++ b/tests/integration/commands/env/env-set.test.ts
@@ -196,7 +196,7 @@ describe('env:set command', async () => {
         (request) => request.method === 'PUT' && request.path === '/api/v1/accounts/test-account/env/OTHER_VAR',
       )
       expect(putRequest).toHaveProperty('body.is_secret', true)
-      expect(putRequest).toHaveProperty('body.values.length', 4)
+      expect(putRequest).toHaveProperty('body.values.length', 5)
       expect(putRequest).toHaveProperty('body.values[0].context', 'production')
       expect(putRequest).toHaveProperty('body.values[0].value', 'envelope-all-value')
       expect(putRequest).toHaveProperty('body.values[1].context', 'deploy-preview')

--- a/tests/integration/commands/env/env-unset.test.ts
+++ b/tests/integration/commands/env/env-unset.test.ts
@@ -72,7 +72,7 @@ describe('env:unset command', async () => {
         (request) => request.method === 'PATCH' && request.path === '/api/v1/accounts/test-account/env/OTHER_VAR',
       )
 
-      expect(patchRequests).toHaveLength(3)
+      expect(patchRequests).toHaveLength(4)
     })
   })
 

--- a/tests/unit/utils/env/index.test.ts
+++ b/tests/unit/utils/env/index.test.ts
@@ -23,9 +23,14 @@ test('should return a matching value from a given context', () => {
       context: 'dev',
       value: 'bar',
     },
+    {
+      context: 'dev-server',
+      value: 'bar',
+    },
   ])
-  const result = getValueForContext(values, 'dev')
-  expect(result).toHaveProperty('value', 'bar')
+  expect(getValueForContext(values, 'production')).toHaveProperty('value', 'foo')
+  expect(getValueForContext(values, 'dev')).toHaveProperty('value', 'bar')
+  expect(getValueForContext(values, 'dev-server')).toHaveProperty('value', 'bar')
 })
 
 test('should return a value from the `branch` context with a matching `context_parameter` given a branch', () => {


### PR DESCRIPTION
This changeset fixes environment-variable loading a Preview Server context.

Previously, we were missing `dev-server` from the CLI's list of
supported contexts. Because of a variable that (unnecessarily) mixes the
concept of branches and contexts, when we run into an unsupported
context, we assume we must be running a branch preview, and try to find
variables for the branch named `dev-server`. For the majority of users,
variables for that branch won't exist, and they'll end up with an
unexpectedly empty variable.

Why do we assume it's a branch preview when we have enough information
available to us to know it's not one? Why do we throw away the type
information that would have caught this? Why do we load environment
variables from the API in the CLI even though `@netlify/config` already
does this?

These are the mysteries of the universe.
