### PR TITLE
fix: use env from cachedConfig when offlineEnv is set

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -620,10 +620,7 @@ export default class BaseCommand extends Command {
       ...apiUrlOpts,
     })
     const { accounts = [], buildDir, config, configPath, repositoryRoot, siteInfo } = cachedConfig
-    let { env } = cachedConfig
-    if (flags.offlineEnv) {
-      env = {}
-    }
+    const env = cachedConfig?.env ?? {}
     env.NETLIFY_CLI_VERSION = { sources: ['internal'], value: version }
     const normalizedConfig = normalizeConfig(config)
 


### PR DESCRIPTION
This changeset modifies the `dev` command's behavior when the `--offlineEnv` flag is set: Previously, passing `offlineEnv` would ignore any environment variable data from the cached configuration file by setting `env` data to an empty object before passing it around. The unintended consequence of this is that environment variable data set via the config file is ignored when running Preview Servers. Environment variable data is not passed to edge functions, and only build-time variables are passed to functions.

With this change, we'll only default to an empty object when `cachedConfig.env` is not set. (I don't know if this is a realistic scenario, but I'm doing it this way to lower the risk of this change.)