### PR TITLE
fix: show deploy errors when `--json` is used

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -687,10 +687,12 @@ const handleBuild = async ({
     currentDir,
     deployHandler,
   })
-  const { configMutations, exitCode, newConfig } = await runBuild(resolvedOptions)
+  const { configMutations, exitCode, newConfig, logs } = await runBuild(resolvedOptions)
   // Without this, the deploy command fails silently
   if (options.json && exitCode !== 0) {
-    logAndThrowError('Error while running build')
+    const message = logs?.stderr.length ? `: ${logs.stderr.join('')}` : ''
+
+    logAndThrowError(`Error while running build${message}`)
   }
   if (exitCode !== 0) {
     exit(exitCode)

--- a/src/lib/build.ts
+++ b/src/lib/build.ts
@@ -194,7 +194,14 @@ export const getRunBuildOptions = async ({
   }
 }
 
-export const runBuild = async (options: RunBuildOptions) => {
+export const runBuild = async (
+  options: RunBuildOptions,
+): Promise<{
+  exitCode: number
+  newConfig: NetlifyConfig
+  configMutations: Record<string, string>
+  logs?: { stdout: string[]; stderr: string[] }
+}> => {
   // If netlify NETLIFY_API_URL is set we need to pass this information to @netlify/build
   // TODO don't use testOpts, but add real properties to do this.
   if (process.env.NETLIFY_API_URL) {
@@ -212,7 +219,8 @@ export const runBuild = async (options: RunBuildOptions) => {
     configMutations,
     netlifyConfig: newConfig,
     severityCode: exitCode,
+    logs,
     // TODO(serhalp): Upstream the type fixes above into @netlify/build and remove this type assertion
   } = await (build as unknown as (opts: RunBuildOptions) => Promise<ReturnType<typeof build>>)(options)
-  return { exitCode, newConfig, configMutations }
+  return { exitCode, newConfig, configMutations, logs }
 }

--- a/tests/integration/commands/deploy/deploy.test.ts
+++ b/tests/integration/commands/deploy/deploy.test.ts
@@ -462,6 +462,33 @@ describe.skipIf(process.env.NETLIFY_TEST_DISABLE_LIVE === 'true').concurrent('co
           config: {
             build: {
               publish: 'public',
+              command: 'echo "Build failed with custom error" >&2 && exit 1',
+            },
+          },
+        })
+
+      await builder.build()
+
+      await expect(
+        callCli(['deploy', '--json'], {
+          cwd: builder.directory,
+          env: { NETLIFY_SITE_ID: context.siteId },
+        }),
+      ).rejects.toThrow('Error while running build: Build failed with custom error')
+    })
+  })
+
+  test('should throw error without stderr details when build fails with --json option and no stderr output', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
+      builder
+        .withContentFile({
+          path: 'public/index.html',
+          content: '<h1>Test content</h1>',
+        })
+        .withNetlifyToml({
+          config: {
+            build: {
+              publish: 'public',
               command: 'exit 1',
             },
           },


### PR DESCRIPTION
#### Summary

When the `deploy` command is used with the `--json` flag, we're currently omitting any errors from stderr and just showing a generic _Error while running build_ message.

This PR extends that message with the contents of stderr resulting from the build stage.