### PR TITLE
fix: set same Node.js options locally as AWS Lambda does in production

### DIFF
--- a/src/lib/functions/runtimes/js/index.ts
+++ b/src/lib/functions/runtimes/js/index.ts
@@ -89,16 +89,22 @@ export const invokeFunction = async ({
       ...process.env,
       // AWS Lambda disables these Node.js experimental features, even in Node.js versions where they are enabled by
       // default: https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html#w292aac41c19.
-      // Replace this here to match production as closely as possible.
+      // They also allow users to re-enable (i.e. not disable) these by co-opting the positive flag (which in reality
+      // may or may not exist depending on the exact node.js version). We replicate all this behavior here.
       NODE_OPTIONS: [
         ...(process.env.NODE_OPTIONS?.split(' ') ?? []),
-        '--no-experimental-require-module',
-        '--no-experimental-detect-module',
-      ]
-        // Unfortunately Node.js throws if `NODE_OPTIONS` contains any unsupported flags and these flags have been added
-        // and removed in various specific versions in each major line. Luckily Node.js has an API just for this!
-        .filter((flag) => process.allowedNodeEnvironmentFlags.has(flag))
-        .join(' '),
+        ...[
+          ...(process.env.NODE_OPTIONS?.includes('--experimental-require-module')
+            ? []
+            : ['--no-experimental-require-module']),
+          ...(process.env.NODE_OPTIONS?.includes('--experimental-detect-module')
+            ? []
+            : ['--no-experimental-detect-module']),
+        ]
+          // Unfortunately Node.js throws if `NODE_OPTIONS` contains any unsupported flags and these flags have been
+          // added and removed in various specific versions in each major line. Luckily Node.js has an API just for this!
+          .filter((flag) => process.allowedNodeEnvironmentFlags.has(flag)),
+      ].join(' '),
     },
     workerData,
   })


### PR DESCRIPTION
#### Summary

Despite these Node.js features being enabled by default on some subset of these Node.js 20 and 22 versions, AWS Lambda always disables them explicitly via flags: https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html#w292aac41c19.

This leads to a mismatch between the local dev Netlify Functions environment and the production (AWS Lambda) environment, leading to confusing bugs like this: https://github.com/netlify/react-router-template/issues/10#issuecomment-3411177684.

This PR replicates the production Netlify Functions behaviour in the local execution environment.

Following the repro steps from the React Router 7 bug above, I've confirmed this fixes it ✅. ~~It would be nice to add test coverage but I failed to write a failing test 😓.~~ Woo, I did it.