### PR TITLE
Update proxy.ts

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -492,12 +492,32 @@ const initializeProxy = async function ({
   projectDir,
   siteInfo,
 }: { config: NormalizedCachedConfigConfig } & Record<string, $TSFixMe>) {
+  const agent = new http.Agent({ 
+    keepAlive: false,
+    maxSockets: Infinity,
+  })
+  const originalCreateConnection = agent.createConnection.bind(agent)
+  agent.createConnection = function (options, callback) {
+    const socket = originalCreateConnection(options, callback)
+    
+    if (socket) {
+      socket.on('error', (error) => {
+        if ('code' in error && error.code === 'ECONNRESET') {
+          socket.destroy()
+        }
+      })
+    }
+    
+    return socket
+  }
+
   const proxy = httpProxy.createProxyServer({
     selfHandleResponse: true,
     target: {
       host,
       port,
     },
+    agent,
   })
   const headersFiles = [...new Set([path.resolve(projectDir, '_headers'), path.resolve(distDir, '_headers')])]
 


### PR DESCRIPTION
Fixes #7747 Part 2

Problem: Node.js 24.x triggers unhandled ECONNRESET errors at the socket level when the HTTP proxy attempts to connect to framework dev servers. The default HTTP agent's keepAlive behavior exacerbates these errors, causing the Netlify CLI proxy to crash when handling requests to the framework server.

Solution: Replaced the default HTTP agent with a custom agent that:
Disables keepAlive to prevent connection pooling issues that trigger ECONNRESET
Sets maxSockets: Infinity to avoid socket exhaustion
Wraps createConnection to add socket-level error handlers
Catches and destroys sockets on ECONNRESET before the error can crash the process
The custom agent is passed to httpProxy.createProxyServer() to ensure all proxy connections use the resilient socket handling.

Testing:
✅ Tested with Nuxt 4.x on Node.js 24.6.0 (previously crashed, now works)
✅ Verified proxy requests succeed without ECONNRESET crashes
✅ Maintains backward compatibility with earlier Node.js versions