### PR TITLE
Update run-build.ts

### DIFF
--- a/src/utils/run-build.ts
+++ b/src/utils/run-build.ts
@@ -126,7 +126,8 @@ export async function runNetlifyBuild({
     })
 
     settings.frameworkHost = ipVersion === 6 ? '::1' : '127.0.0.1'
-    settings.detectFrameworkHost = options.skipWaitPort
+    // Enable IPv4/IPv6 auto-detection when port checking is enabled
+    settings.detectFrameworkHost = !options.skipWaitPort
   }
 
   if (timeline === 'build') {


### PR DESCRIPTION
Fixes #7747 Part 3

Problem: The original logic for detectFrameworkHost was inverted: it was set to true when skipWaitPort was true, meaning IPv4/IPv6 auto-detection was only enabled when port checking was skipped. This caused connection failures in Node.js 24.x environments where the framework server binds to IPv6 ([::1]) but the proxy attempts to connect via IPv4 (127.0.0.1).

Solution: Fixed the logic to:
settings.detectFrameworkHost = !options.skipWaitPort
Now IPv4/IPv6 auto-detection is correctly enabled when port checking is active (skipWaitPort = false), allowing the proxy to automatically switch between 127.0.0.1 and [::1] if connection attempts fail with ECONNREFUSED.

Impact:
When port checking is enabled → detectFrameworkHost = true → proxy can detect and switch IP versions ✓
When port checking is skipped → detectFrameworkHost = false → no auto-detection needed ✓

Testing:
✅ Tested with Nuxt 4.x on Node.js 24.6.0 where server binds to IPv6
✅ Verified proxy successfully switches from IPv4 to IPv6 on connection failure
✅ Maintains backward compatibility