### PR TITLE
fix: include sourceZipFileName in results for printing results if available

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -1120,6 +1120,7 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
     }
     const deployId = deployMetadata.id || ''
     const skewProtectionToken = deployMetadata.skew_protection_token
+    let sourceZipFileName: string | undefined
 
     if (
       options.uploadSourceZip &&
@@ -1133,6 +1134,7 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
         filename: deployMetadata.source_zip_filename,
         statusCb: options.json || options.silent ? () => {} : deployProgressCb(),
       })
+      sourceZipFileName = deployMetadata.source_zip_filename
     }
     try {
       const settings = await detectFrameworkSettings(command, 'build')
@@ -1161,6 +1163,11 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
         deployId,
         skewProtectionToken,
       })
+
+      // Ensure source zip filename is included in results for JSON output
+      if (sourceZipFileName) {
+        results.sourceZipFileName = sourceZipFileName
+      }
     } catch (error) {
       // The build has failed, so let's cancel the deploy we created.
       await cancelDeploy({ api, deployId })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

In [this PR](https://github.com/netlify/cli/pull/7768) and CLI v.23.11.0 a change was introduced that stopped the `source_zip_filename` field from being printed in the json output. 

**Why**
The results object used is no longer the one from the deploy, which would have contained the sourceZipFilename. 

This PR ensures we print that field again.

The agent runner parses that JSON output and looks for `source_zip_filename` to set `result_zip_file_name` on the session, but since it's not there, it stays `null`, and the Publish button doesn't show in our UI.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
