### PR TITLE
fix(db): check if db is running when executing migrations

### DIFF
--- a/src/commands/database/migrate.ts
+++ b/src/commands/database/migrate.ts
@@ -22,6 +22,7 @@ export const migrate = async (options: MigrateOptions, command: BaseCommand) => 
     )
   }
 
+  const runningDbUrl = command.netlify.state.get('db.url') as string | undefined
   const netlifyDev = new NetlifyDev({
     projectRoot: buildDir,
     aiGateway: { enabled: false },
@@ -35,6 +36,7 @@ export const migrate = async (options: MigrateOptions, command: BaseCommand) => 
     redirects: { enabled: false },
     staticFiles: { enabled: false },
     serverAddress: null,
+    ...(runningDbUrl ? { db: { connectionString: runningDbUrl } } : {}),
   })
 
   try {
@@ -46,18 +48,21 @@ export const migrate = async (options: MigrateOptions, command: BaseCommand) => 
     }
 
     const applied = await db.applyMigrations(migrationsDirectory, name)
-
-    if (json) {
-      logJson({ migrations_applied: applied })
-    } else if (applied.length === 0) {
-      log('No pending migrations to apply.')
-    } else {
-      log(`Applied ${String(applied.length)} migration${applied.length === 1 ? '' : 's'}:`)
-      for (const migration of applied) {
-        log(`  - ${migration}`)
-      }
-    }
+    logAppliedMigrations(applied, json)
   } finally {
     await netlifyDev.stop()
+  }
+}
+
+function logAppliedMigrations(applied: string[], json?: boolean) {
+  if (json) {
+    logJson({ migrations_applied: applied })
+  } else if (applied.length === 0) {
+    log('No pending migrations to apply.')
+  } else {
+    log(`Applied ${String(applied.length)} migration${applied.length === 1 ? '' : 's'}:`)
+    for (const migration of applied) {
+      log(`  - ${migration}`)
+    }
   }
 }

--- a/src/commands/database/reset.ts
+++ b/src/commands/database/reset.ts
@@ -14,6 +14,7 @@ export const reset = async (options: ResetOptions, command: BaseCommand) => {
     throw new Error('Could not determine the project root directory.')
   }
 
+  const runningDbUrl = command.netlify.state.get('db.url') as string | undefined
   const netlifyDev = new NetlifyDev({
     projectRoot: buildDir,
     aiGateway: { enabled: false },
@@ -27,6 +28,7 @@ export const reset = async (options: ResetOptions, command: BaseCommand) => {
     redirects: { enabled: false },
     staticFiles: { enabled: false },
     serverAddress: null,
+    ...(runningDbUrl ? { db: { connectionString: runningDbUrl } } : {}),
   })
 
   try {
@@ -38,13 +40,13 @@ export const reset = async (options: ResetOptions, command: BaseCommand) => {
     }
 
     await db.reset()
-
-    if (json) {
-      logJson({ reset: true })
-    } else {
-      log('Local development database has been reset.')
-    }
   } finally {
     await netlifyDev.stop()
+  }
+
+  if (json) {
+    logJson({ reset: true })
+  } else {
+    log('Local development database has been reset.')
   }
 }

--- a/tests/unit/commands/database/migrate.test.ts
+++ b/tests/unit/commands/database/migrate.test.ts
@@ -30,11 +30,14 @@ vi.mock('../../../../src/utils/command-helpers.js', async () => ({
 
 import { migrate } from '../../../../src/commands/database/migrate.js'
 
-function createMockCommand(overrides: { buildDir?: string; projectRoot?: string; migrationsPath?: string } = {}) {
+function createMockCommand(
+  overrides: { buildDir?: string; projectRoot?: string; migrationsPath?: string; dbUrl?: string } = {},
+) {
   const {
     buildDir = '/project',
     projectRoot = '/project',
     migrationsPath = '/project/netlify/db/migrations',
+    dbUrl,
   } = overrides
 
   return {
@@ -42,6 +45,7 @@ function createMockCommand(overrides: { buildDir?: string; projectRoot?: string;
     netlify: {
       site: { root: buildDir },
       config: { db: { migrations: { path: migrationsPath } } },
+      state: { get: (key: string) => (key === 'db.url' ? dbUrl : undefined) },
     },
   } as unknown as Parameters<typeof migrate>[1]
 }
@@ -73,6 +77,24 @@ describe('migrate', () => {
         serverAddress: null,
       }),
     )
+  })
+
+  test('passes db connection string to NetlifyDev when running db is detected', async () => {
+    const dbUrl = 'postgres://localhost:54321/postgres'
+    await migrate({}, createMockCommand({ dbUrl }))
+
+    expect(MockNetlifyDev).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: { connectionString: dbUrl },
+      }),
+    )
+  })
+
+  test('does not pass db option when no running db is detected', async () => {
+    await migrate({}, createMockCommand())
+
+    const constructorArg = MockNetlifyDev.mock.calls[0][0] as Record<string, unknown>
+    expect(constructorArg).not.toHaveProperty('db')
   })
 
   test('starts and stops NetlifyDev', async () => {
@@ -109,7 +131,7 @@ describe('migrate', () => {
   test('throws when no migrations directory is configured', async () => {
     const command = {
       project: { root: '/project', baseDirectory: undefined },
-      netlify: { site: { root: '/project' }, config: {} },
+      netlify: { site: { root: '/project' }, config: {}, state: { get: () => undefined } },
     } as unknown as Parameters<typeof migrate>[1]
 
     await expect(migrate({}, command)).rejects.toThrow('No migrations directory found')
@@ -172,7 +194,7 @@ describe('migrate', () => {
   test('throws when project root cannot be determined', async () => {
     const command = {
       project: { root: undefined, baseDirectory: undefined },
-      netlify: { site: { root: undefined }, config: {} },
+      netlify: { site: { root: undefined }, config: {}, state: { get: () => undefined } },
     } as unknown as Parameters<typeof migrate>[1]
 
     await expect(migrate({}, command)).rejects.toThrow('Could not determine the project root directory.')

--- a/tests/unit/commands/database/reset.test.ts
+++ b/tests/unit/commands/database/reset.test.ts
@@ -30,14 +30,15 @@ vi.mock('../../../../src/utils/command-helpers.js', async () => ({
 
 import { reset } from '../../../../src/commands/database/reset.js'
 
-function createMockCommand(overrides: { buildDir?: string; projectRoot?: string } = {}) {
-  const { buildDir = '/project', projectRoot = '/project' } = overrides
+function createMockCommand(overrides: { buildDir?: string; projectRoot?: string; dbUrl?: string } = {}) {
+  const { buildDir = '/project', projectRoot = '/project', dbUrl } = overrides
 
   return {
     project: { root: projectRoot, baseDirectory: undefined },
     netlify: {
       site: { root: buildDir },
       config: {},
+      state: { get: (key: string) => (key === 'db.url' ? dbUrl : undefined) },
     },
   } as unknown as Parameters<typeof reset>[1]
 }
@@ -55,6 +56,24 @@ describe('reset', () => {
     expect(mockStart).toHaveBeenCalledOnce()
     expect(mockReset).toHaveBeenCalledOnce()
     expect(mockStop).toHaveBeenCalledOnce()
+  })
+
+  test('passes db connection string to NetlifyDev when running db is detected', async () => {
+    const dbUrl = 'postgres://localhost:54321/postgres'
+    await reset({}, createMockCommand({ dbUrl }))
+
+    expect(MockNetlifyDev).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db: { connectionString: dbUrl },
+      }),
+    )
+  })
+
+  test('does not pass db option when no running db is detected', async () => {
+    await reset({}, createMockCommand())
+
+    const constructorArg = MockNetlifyDev.mock.calls[0][0] as Record<string, unknown>
+    expect(constructorArg).not.toHaveProperty('db')
   })
 
   test('logs success message after reset', async () => {
@@ -91,7 +110,7 @@ describe('reset', () => {
   test('throws when project root cannot be determined', async () => {
     const command = {
       project: { root: undefined, baseDirectory: undefined },
-      netlify: { site: { root: undefined }, config: {} },
+      netlify: { site: { root: undefined }, config: {}, state: { get: () => undefined } },
     } as unknown as Parameters<typeof reset>[1]
 
     await expect(reset({}, command)).rejects.toThrow('Could not determine the project root directory.')


### PR DESCRIPTION
#### Summary

Follow-up to https://github.com/netlify/cli/pull/7994

Now, if a DB is already running, instead of starting a new DB on a separate process, we try to connect to the existing one.