### PR TITLE
fix: upgrade vulnerable lodash, picomatch, and defu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "jwt-decode": "4.0.0",
         "lambda-local": "2.2.0",
         "locate-path": "8.0.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "log-update": "7.2.0",
         "maxstache": "1.0.7",
         "maxstache-stream": "1.0.4",
@@ -7564,6 +7564,13 @@
         "url": "https://opencollective.com/verdaccio"
       }
     },
+    "node_modules/@verdaccio/auth/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@verdaccio/config": {
       "version": "8.0.0-next-8.33",
       "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.0.0-next-8.33.tgz",
@@ -7583,6 +7590,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
       }
+    },
+    "node_modules/@verdaccio/config/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@verdaccio/core": {
       "version": "8.0.0-next-8.33",
@@ -7727,6 +7741,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
       }
+    },
+    "node_modules/@verdaccio/loaders/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@verdaccio/local-storage-legacy": {
       "version": "11.1.1",
@@ -7995,6 +8016,13 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/@verdaccio/middleware/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@verdaccio/middleware/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -8122,6 +8150,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/verdaccio"
       }
+    },
+    "node_modules/@verdaccio/utils/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@verdaccio/utils/node_modules/minimatch": {
       "version": "7.4.9",
@@ -8655,7 +8690,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10522,7 +10559,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -14382,7 +14421,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -14900,7 +14941,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -19126,6 +19169,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/verdaccio/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/verdaccio/node_modules/lru-cache": {
       "version": "7.18.3",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "jwt-decode": "4.0.0",
     "lambda-local": "2.2.0",
     "locate-path": "8.0.0",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "log-update": "7.2.0",
     "maxstache": "1.0.7",
     "maxstache-stream": "1.0.4",


### PR DESCRIPTION
#### Summary

ensure all production dependencies are free of known vulnerabilities.

with this patch, it's back to 0 vulnerabilities:

```sh
$ npm audit --omit=dev
found 0 vulnerabilities
```