### PR TITLE
feat: show local db url

### DIFF
--- a/src/commands/dev/programmatic-netlify-dev.ts
+++ b/src/commands/dev/programmatic-netlify-dev.ts
@@ -2,7 +2,7 @@ import process from 'process'
 
 import { NetlifyDev } from '@netlify/dev'
 
-import { NETLIFYDEVWARN, log } from '../../utils/command-helpers.js'
+import { NETLIFYDEVLOG, NETLIFYDEVWARN, log } from '../../utils/command-helpers.js'
 import type { EnvironmentVariables } from '../../utils/types.js'
 
 interface StartNetlifyDevOptions {
@@ -56,6 +56,7 @@ export const startNetlifyDev = async ({
 
   if (process.env.NETLIFY_DB_URL) {
     env.NETLIFY_DB_URL = { sources: ['internal'], value: process.env.NETLIFY_DB_URL }
+    log(`${NETLIFYDEVLOG} Local DB ready: ${process.env.NETLIFY_DB_URL}`)
   }
 
   return netlifyDev

--- a/tests/integration/commands/dev/dev.programmatic-netlify-dev.test.ts
+++ b/tests/integration/commands/dev/dev.programmatic-netlify-dev.test.ts
@@ -40,7 +40,7 @@ describe('@netlify/dev integration', () => {
         const body = await response.text()
         console.log(body)
         t.expect(body).toEqual(JSON.stringify({ sum: 2 }))
-        t.expect(server.output).toMatch(/Local DB ready: http:\/\/localhost:\d+/)
+        t.expect(server.output).toMatch(/Local DB ready: postgres:\/\/localhost:\d+\/postgres/)
       })
     })
   })

--- a/tests/integration/commands/dev/dev.programmatic-netlify-dev.test.ts
+++ b/tests/integration/commands/dev/dev.programmatic-netlify-dev.test.ts
@@ -40,6 +40,7 @@ describe('@netlify/dev integration', () => {
         const body = await response.text()
         console.log(body)
         t.expect(body).toEqual(JSON.stringify({ sum: 2 }))
+        t.expect(server.output).toMatch(/Local DB ready: http:\/\/localhost:\d+/)
       })
     })
   })
@@ -63,6 +64,7 @@ describe('@netlify/dev integration', () => {
 
         t.expect(response.status).toBe(200)
         t.expect(body).toEqual(JSON.stringify({ url: '' }))
+        t.expect(server.output).not.toContain('Local DB ready:')
       })
     })
   })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary
When using Netlify database, this displays the database connection URL in the dev server output, making it easier to run migrations or connect with external tools.

Eg:
  ⬥ Local DB ready: postgres://localhost:51766/postgres
  
 I found this helpful when I was using the feature locally and wanted to run migrations myself, e.g. `psql "postgres://localhost:51766/postgres" -f netlify/db/migrations/001_create-user.sql`.


<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
