### PR TITLE
fix: have login attempt to use browser and fallback to ticket instead of forcing tickets

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -519,8 +519,8 @@ export default class BaseCommand extends Command {
     log(`Opening ${authLink}`)
     const browserOpened = await openBrowser({ url: authLink })
 
-    if (!browserOpened && !isInteractive()) {
-      const ticketId = ticket.id!
+    if (!browserOpened && !isInteractive() && ticket.id) {
+      const ticketId = ticket.id
       logJson({
         ticket_id: ticketId,
         url: authLink,

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -23,6 +23,7 @@ import {
   USER_AGENT,
   chalk,
   logAndThrowError,
+  logJson,
   exit,
   getToken,
   log,
@@ -516,7 +517,26 @@ export default class BaseCommand extends Command {
     const authLink = `${webUI}/authorize?response_type=ticket&ticket=${ticket.id}`
 
     log(`Opening ${authLink}`)
-    await openBrowser({ url: authLink })
+    const browserOpened = await openBrowser({ url: authLink })
+
+    if (!browserOpened && !isInteractive()) {
+      const ticketId = ticket.id!
+      logJson({
+        ticket_id: ticketId,
+        url: authLink,
+        check_command: `netlify login --check ${ticketId}`,
+        agent_next_steps:
+          'Give the URL to the user so they can authorize. Then poll the check_command for up to ten minutes to see if the user has logged in, or wait for them to tell you and then use check_command after.',
+      })
+      log(`Ticket ID: ${ticketId}`)
+      log(`Authorize URL: ${authLink}`)
+      log()
+      log(`After authorizing, run: netlify login --check ${ticketId}`)
+      log()
+      log('After user opens the authorization URL and approves, the login will be complete.')
+      return exit()
+    }
+
     log()
     log(`To request authorization from a human, run: ${chalk.cyanBright('netlify login --request "<msg>"')}`)
     log()

--- a/src/commands/login/login.ts
+++ b/src/commands/login/login.ts
@@ -1,7 +1,6 @@
 import { OptionValues } from 'commander'
 
 import { chalk, exit, getToken, log, logAndThrowError } from '../../utils/command-helpers.js'
-import { isInteractive } from '../../utils/scripted-commands.js'
 import { TokenLocation } from '../../utils/types.js'
 import BaseCommand from '../base-command.js'
 
@@ -49,12 +48,6 @@ export const login = async (options: OptionValues, command: BaseCommand) => {
     log(`To see all available commands run: ${chalk.cyanBright('netlify help')}`)
     log()
     return exit()
-  }
-
-  if (!isInteractive()) {
-    const { loginRequest } = await import('./login-request.js')
-    await loginRequest('CLI session', command.netlify.apiOpts)
-    return
   }
 
   await command.expensivelyAuthenticate()

--- a/src/utils/open-browser.ts
+++ b/src/utils/open-browser.ts
@@ -23,24 +23,26 @@ type OpenBrowsrProps = {
   url: string
 }
 
-const openBrowser = async function ({ silentBrowserNoneError, url }: OpenBrowsrProps) {
+const openBrowser = async function ({ silentBrowserNoneError, url }: OpenBrowsrProps): Promise<boolean> {
   if (isDockerContainer()) {
     unableToOpenBrowserMessage({ url, message: 'Running inside a docker container' })
-    return
+    return false
   }
   if (process.env.BROWSER === 'none') {
     if (!silentBrowserNoneError) {
       unableToOpenBrowserMessage({ url, message: "BROWSER environment variable is set to 'none'" })
     }
-    return
+    return false
   }
 
   try {
     await open(url)
+    return true
   } catch (error) {
     if (error instanceof Error) {
       unableToOpenBrowserMessage({ url, message: error.message })
     }
+    return false
   }
 }
 


### PR DESCRIPTION

Try browser-based auth first in non-interactive environments before falling back to the agent copy/paste flow. Previously, non-interactive sessions (CI, piped input, etc.) skipped the browser entirely and went straight to the ticket/URL output. Now we attempt to open the browser and only fall back to the agent-friendly flow if it fails.

This should help agents that allow a graceful timeout situation to have a good experience 

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
