### PR TITLE
fix: filter out intentional user-input errors from report-error

### DIFF
--- a/src/utils/telemetry/report-error.ts
+++ b/src/utils/telemetry/report-error.ts
@@ -25,9 +25,15 @@ export const reportError = async function (error, config = {}) {
   if (isCI) {
     return
   }
-
   // convert a NotifiableError to an error class
   const err = error instanceof Error ? error : typeof error === 'string' ? new Error(error) : error
+
+  // `@netlify/config` tags intentional user-input errors (malformed netlify.toml,
+  // invalid redirects, etc.) with this shape. See @netlify/config/lib/error.js.
+  // These are not CLI bugs and don't belong in Bugsnag.
+  if (error?.customErrorInfo?.type === 'resolveConfig') {
+    return
+  }
 
   const globalConfig = await getGlobalConfigStore()
 


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

In our error report tool I'm seeing a lot of toml configuration errors. In my opinion our bug reporting should contain events that an engineer on-call could investigate as a potential bug. Everything currently in there that doesn't meet that bar is pollution. We should filter intentional user-input errors out in our error reporting.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
