### PR TITLE
chore: remove dead AVA config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,11 +218,5 @@
     "verdaccio": "6.3.2",
     "vitest": "3.2.4"
   },
-  "ava": {
-    "files": [
-      "tools/**/*.test.js",
-      "tests/**/*.test.cjs"
-    ]
-  },
   "packageManager": "npm@10.9.4+sha512.3a7506f37e85c1ba1021baad79f0cd9724748131f321fc117c4dc3ba235ec01be7327584a41d15117c01945560aa9373220628fcc1e1dddd877a5fe9b336a900"
 }


### PR DESCRIPTION
## Summary

- Removes the leftover `"ava"` config block from `package.json`. The test suite migrated to Vitest; AVA is not a dependency and the glob patterns (`tools/**/*.test.js`, `tests/**/*.test.cjs`) match zero files.

## Test plan

- [x] `npm install` succeeds
- [x] `npm run build` succeeds
- [x] `npm run test:unit` results identical to main (same 5 pre-existing failures)

Made with [Cursor](https://cursor.com)