### PR TITLE
fix: don't cause fatal issues when doing update checks inside of agent sandbox

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import { argv } from 'process'
+import { accessSync, constants } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
 import EventEmitter from 'events'
 
 import { maybeEnableCompileCache } from '../dist/utils/nodejs-compile-cache.js'
@@ -35,18 +38,30 @@ const main = async () => {
   const { default: getPackageJson } = await import('../dist/utils/get-cli-package-json.js')
   const { runProgram } = await import('../dist/utils/run-program.js')
 
-  try {
-    const pkg = await getPackageJson()
-    const message = `Update available ${chalk.dim('{currentVersion}')} → ${chalk.green('{latestVersion}')}
+  const canWriteConfigStore = () => {
+    try {
+      const configDir = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'configstore')
+      accessSync(configDir, constants.W_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  if (canWriteConfigStore()) {
+    try {
+      const pkg = await getPackageJson()
+      const message = `Update available ${chalk.dim('{currentVersion}')} → ${chalk.green('{latestVersion}')}
 See what's new in the ${terminalLink('release notes', 'https://ntl.fyi/cli-versions')}
 
 Run ${chalk.inverse.hex(NETLIFY_CYAN_HEX)('{updateCommand}')} to update`
-    updateNotifier({
-      pkg,
-      updateCheckInterval: UPDATE_CHECK_INTERVAL,
-    }).notify({ message, boxenOptions: UPDATE_BOXEN_OPTIONS })
-  } catch (error) {
-    logError(`Error checking for updates: ${error?.toString()}`)
+      updateNotifier({
+        pkg,
+        updateCheckInterval: UPDATE_CHECK_INTERVAL,
+      }).notify({ message, boxenOptions: UPDATE_BOXEN_OPTIONS })
+    } catch (error) {
+      logError(`Error checking for updates: ${error?.toString()}`)
+    }
   }
 
   const program = createMainCommand()

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { argv } from 'process'
-import { accessSync, constants } from 'node:fs'
-import { join } from 'node:path'
+import { accessSync, existsSync, constants } from 'node:fs'
+import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import EventEmitter from 'events'
 
@@ -40,8 +40,13 @@ const main = async () => {
 
   const canWriteConfigStore = () => {
     try {
-      const configDir = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'configstore')
-      accessSync(configDir, constants.W_OK)
+      let dir = join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'configstore')
+      while (!existsSync(dir)) {
+        const parent = dirname(dir)
+        if (parent === dir) return false
+        dir = parent
+      }
+      accessSync(dir, constants.W_OK)
       return true
     } catch {
       return false


### PR DESCRIPTION


🎉 Thanks for submitting a pull request! 🎉

#### Summary

Fix: gracefully handle update check when config store is not writable                             

When the CLI runs with restricted permissions, update-notifier's internal configstore fails with EPERM and registers a process.on('exit') handler that prints a scary error box — which we can't catch or suppress. It also causes unrecoverable errors in clis like codex. This skips the update check entirely when the config directory isn't writable, avoiding the error without affecting normal usage. 

Fixes #<replace_with_issue_number>

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
