### PR TITLE
feat: various improvements to `database` commands

### DIFF
--- a/src/commands/database/db-migration-pull.ts
+++ b/src/commands/database/db-migration-pull.ts
@@ -6,6 +6,7 @@ import inquirer from 'inquirer'
 import { log, logJson } from '../../utils/command-helpers.js'
 import execa from '../../utils/execa.js'
 import BaseCommand from '../base-command.js'
+import { readApiErrorMessage } from './util/api-errors.js'
 import { PRODUCTION_BRANCH } from './util/constants.js'
 import { resolveMigrationsDirectory } from './util/migrations-path.js'
 
@@ -87,8 +88,8 @@ const fetchMigrations = async (ctx: ApiContext, branch: string | undefined): Pro
   })
 
   if (!response.ok) {
-    const text = await response.text()
-    throw new Error(`Failed to fetch migrations (${String(response.status)}): ${text}`)
+    const message = await readApiErrorMessage(response)
+    throw new Error(`Failed to fetch migrations (${String(response.status)}): ${message}`)
   }
 
   const data = (await response.json()) as ListMigrationsResponse
@@ -108,8 +109,8 @@ const fetchMigrationContent = async (ctx: ApiContext, name: string, branch: stri
   })
 
   if (!response.ok) {
-    const text = await response.text()
-    throw new Error(`Failed to fetch content for migration "${name}" (${String(response.status)}): ${text}`)
+    const message = await readApiErrorMessage(response)
+    throw new Error(`Failed to fetch content for migration "${name}" (${String(response.status)}): ${message}`)
   }
 
   const data = (await response.json()) as MigrationDetailResponse

--- a/src/commands/database/db-migration-pull.ts
+++ b/src/commands/database/db-migration-pull.ts
@@ -15,15 +15,28 @@ export interface MigrationPullOptions {
   json?: boolean
 }
 
-interface MigrationFile {
+interface MigrationListItem {
+  version: number
+  name: string
+  path: string
+  applied: boolean
+}
+
+interface ListMigrationsResponse {
+  migrations: MigrationListItem[]
+}
+
+interface MigrationDetailResponse {
   version: number
   name: string
   path: string
   content: string
 }
 
-interface ListMigrationsResponse {
-  migrations: MigrationFile[]
+interface ApiContext {
+  siteId: string
+  token: string
+  basePath: string
 }
 
 const getLocalGitBranch = async (): Promise<string> => {
@@ -45,7 +58,7 @@ const resolveBranch = async (branchOption: string | true | undefined): Promise<s
   return branchOption
 }
 
-const fetchMigrations = async (command: BaseCommand, branch: string | undefined): Promise<MigrationFile[]> => {
+const getApiContext = (command: BaseCommand): ApiContext => {
   const siteId = command.siteId
   if (!siteId) {
     throw new Error('The project must be linked with netlify link before pulling migrations.')
@@ -56,18 +69,21 @@ const fetchMigrations = async (command: BaseCommand, branch: string | undefined)
     throw new Error('You must be logged in with netlify login to pull migrations.')
   }
 
-  const token = accessToken.replace('Bearer ', '')
-  const basePath = command.netlify.api.basePath
+  return {
+    siteId,
+    token: accessToken.replace('Bearer ', ''),
+    basePath: command.netlify.api.basePath,
+  }
+}
 
-  const url = new URL(`${basePath}/sites/${encodeURIComponent(siteId)}/database/migrations`)
+const fetchMigrations = async (ctx: ApiContext, branch: string | undefined): Promise<MigrationListItem[]> => {
+  const url = new URL(`${ctx.basePath}/sites/${encodeURIComponent(ctx.siteId)}/database/migrations`)
   if (branch) {
     url.searchParams.set('branch', branch)
   }
 
   const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: { Authorization: `Bearer ${ctx.token}` },
   })
 
   if (!response.ok) {
@@ -79,12 +95,34 @@ const fetchMigrations = async (command: BaseCommand, branch: string | undefined)
   return data.migrations
 }
 
+const fetchMigrationContent = async (ctx: ApiContext, name: string, branch: string | undefined): Promise<string> => {
+  const url = new URL(
+    `${ctx.basePath}/sites/${encodeURIComponent(ctx.siteId)}/database/migrations/${encodeURIComponent(name)}`,
+  )
+  if (branch) {
+    url.searchParams.set('branch', branch)
+  }
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${ctx.token}` },
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Failed to fetch content for migration "${name}" (${String(response.status)}): ${text}`)
+  }
+
+  const data = (await response.json()) as MigrationDetailResponse
+  return data.content
+}
+
 export const migrationPull = async (options: MigrationPullOptions, command: BaseCommand) => {
   const { force, json } = options
 
   const branch = (await resolveBranch(options.branch)) ?? process.env.NETLIFY_DB_BRANCH
   const source = branch ?? PRODUCTION_BRANCH
-  const migrations = await fetchMigrations(command, branch)
+  const ctx = getApiContext(command)
+  const migrations = await fetchMigrations(ctx, branch)
 
   if (migrations.length === 0) {
     if (json) {
@@ -96,6 +134,18 @@ export const migrationPull = async (options: MigrationPullOptions, command: Base
   }
 
   const migrationsDirectory = resolveMigrationsDirectory(command)
+  const canonicalMigrationsDir = resolve(migrationsDirectory)
+
+  const resolvedPaths = migrations.map((migration) => {
+    if (isAbsolute(migration.path) || migration.path.split(/[/\\]/).includes('..')) {
+      throw new Error(`Migration path "${migration.path}" contains invalid path segments.`)
+    }
+    const filePath = resolve(canonicalMigrationsDir, migration.path)
+    if (!filePath.startsWith(canonicalMigrationsDir)) {
+      throw new Error(`Migration path "${migration.path}" resolves outside the migrations directory.`)
+    }
+    return filePath
+  })
 
   if (!force) {
     const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
@@ -115,22 +165,13 @@ export const migrationPull = async (options: MigrationPullOptions, command: Base
     }
   }
 
-  const canonicalMigrationsDir = resolve(migrationsDirectory)
+  const contents = await Promise.all(migrations.map((migration) => fetchMigrationContent(ctx, migration.name, branch)))
 
   await rm(canonicalMigrationsDir, { recursive: true, force: true })
 
-  for (const migration of migrations) {
-    if (isAbsolute(migration.path) || migration.path.split(/[/\\]/).includes('..')) {
-      throw new Error(`Migration path "${migration.path}" contains invalid path segments.`)
-    }
-
-    const filePath = resolve(canonicalMigrationsDir, migration.path)
-    if (!filePath.startsWith(canonicalMigrationsDir)) {
-      throw new Error(`Migration path "${migration.path}" resolves outside the migrations directory.`)
-    }
-
+  for (const [index, filePath] of resolvedPaths.entries()) {
     await mkdir(dirname(filePath), { recursive: true })
-    await writeFile(filePath, migration.content)
+    await writeFile(filePath, contents[index])
   }
 
   if (json) {

--- a/src/commands/database/db-status.ts
+++ b/src/commands/database/db-status.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir } from 'fs/promises'
-import { join, relative } from 'path'
+import { join, relative, sep } from 'path'
 
 import { chalk, log, logJson, netlifyCommand } from '../../utils/command-helpers.js'
 import BaseCommand from '../base-command.js'
@@ -323,7 +323,8 @@ const renderPretty = (params: RenderParams) => {
 
   log('')
   const relativePath = relative(projectRoot, migrationsDirectory)
-  const displayPath = relativePath && !relativePath.startsWith('..') ? relativePath : migrationsDirectory
+  const isInsideProject = relativePath !== '' && !relativePath.startsWith('..')
+  const displayPath = (isInsideProject ? relativePath : migrationsDirectory).split(sep).join('/')
   log(`  ${STATUS_INFO} ${chalk.bold('Migrations directory')}`)
   log(chalk.gray(`${INDENT}Migration files in this directory are automatically applied when deploying to Netlify.`))
   log(`${INDENT}${displayPath}`)

--- a/src/commands/database/db-status.ts
+++ b/src/commands/database/db-status.ts
@@ -9,6 +9,7 @@ import {
   type MigrationFile,
   remoteAppliedMigrations,
 } from './util/applied-migrations.js'
+import { readApiErrorMessage } from './util/api-errors.js'
 import { connectToDatabase, detectExistingLocalConnectionString } from './util/db-connection.js'
 import { resolveMigrationsDirectory } from './util/migrations-path.js'
 import { fileExistsAsync } from '../../lib/fs.js'
@@ -176,8 +177,8 @@ const fetchBranchConnectionString = async (ctx: ServerContext, branchId: string)
   }
 
   if (!response.ok) {
-    const text = await response.text()
-    throw new Error(`Failed to fetch database branch "${branchId}" (${String(response.status)}): ${text}`)
+    const message = await readApiErrorMessage(response)
+    throw new Error(`Failed to fetch database branch "${branchId}" (${String(response.status)}): ${message}`)
   }
 
   const data = (await response.json()) as { connection_string?: string }

--- a/src/commands/database/db-status.ts
+++ b/src/commands/database/db-status.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir } from 'fs/promises'
-import { join } from 'path'
+import { join, relative } from 'path'
 
 import { chalk, log, logJson, netlifyCommand } from '../../utils/command-helpers.js'
 import BaseCommand from '../base-command.js'
@@ -48,7 +48,7 @@ const formatCommand = (suffix: string): string => chalk.cyanBright.bold(`${netli
 
 const logConnectCommands = () => {
   secondary(`Run ${formatCommand('database connect')} to start an interactive database client`)
-  secondary(`Run ${formatCommand('database connect --query "<SQL>"')} to run a one-shot query`)
+  secondary(`Run ${formatCommand(`database connect --query "SELECT 'SQL goes here'"`)} to run a one-shot query`)
 }
 
 const parseVersion = (name: string): number | null => {
@@ -213,11 +213,11 @@ const fetchSiteDatabase = async (ctx: ServerContext): Promise<{ connectionString
   return { connectionString: data.connection_string }
 }
 
-const renderList = (items: MigrationEntry[]): string => {
+const renderList = (items: MigrationEntry[], indent = '  '): string => {
   if (items.length === 0) {
-    return chalk.dim('  (none)')
+    return chalk.dim(`${indent}(none)`)
   }
-  return items.map((m) => `  • ${m.name}`).join('\n')
+  return items.map((m) => `${indent}• ${m.name}`).join('\n')
 }
 
 interface RenderParams {
@@ -228,7 +228,9 @@ interface RenderParams {
   showCredentials: boolean
   status: MigrationsStatus
   isLocal: boolean
+  hasUrlOverride: boolean
   migrationsDirectory: string
+  projectRoot: string
   adminUrl?: string
 }
 
@@ -237,7 +239,8 @@ interface RenderParams {
 const INDENT = '     '
 const STATUS_GOOD = '🟢'
 const STATUS_WARN = '🟡'
-const STATUS_PAUSED = '⏸️ '
+const STATUS_NONE = '⚪'
+const STATUS_INFO = 'ℹ️ '
 
 const primary = (emoji: string, text: string): void => {
   log(`  ${emoji} ${text}`)
@@ -255,7 +258,9 @@ const renderPretty = (params: RenderParams) => {
     showCredentials,
     status,
     isLocal,
+    hasUrlOverride,
     migrationsDirectory,
+    projectRoot,
     adminUrl,
   } = params
 
@@ -301,7 +306,7 @@ const renderPretty = (params: RenderParams) => {
       secondary(`To connect to the database directly, use the connection string: ${displayed}`)
     }
   } else if (isLocal) {
-    primary(STATUS_PAUSED, 'The local database is not running')
+    primary(STATUS_INFO, 'The local database is not running')
     secondary(
       `It starts automatically when you run ${formatCommand(
         'dev',
@@ -311,29 +316,16 @@ const renderPretty = (params: RenderParams) => {
   }
 
   log('')
-  log(`Migrations directory: ${chalk.bold(migrationsDirectory)}`)
+  log(chalk.bold('Migrations'))
+  log(chalk.gray('Database migrations managed by Netlify'))
+  log('')
 
   log('')
-  log(chalk.bold('Applied migrations'))
-  log(chalk.gray('Migrations that have been applied to the database branch'))
-  log('')
-  log(renderList(status.applied))
-  log('')
-  log(
-    chalk.gray(
-      'Note that these migrations cannot be removed or edited. To change anything, you should generate a new migration.',
-    ),
-  )
-
-  log('')
-  log(chalk.bold('Migrations not applied'))
-  log(chalk.gray("Migrations that exist locally that haven't yet been applied"))
-  log('')
-  log(renderList(status.pending))
-  if (isLocal && status.pending.length > 0 && status.outOfOrder.length === 0) {
-    log('')
-    log(chalk.gray(`Run ${formatCommand('database migrations apply')} to apply these to the local database.`))
-  }
+  const relativePath = relative(projectRoot, migrationsDirectory)
+  const displayPath = relativePath && !relativePath.startsWith('..') ? relativePath : migrationsDirectory
+  log(`  ${STATUS_INFO} ${chalk.bold('Migrations directory')}`)
+  log(chalk.gray(`${INDENT}Migration files in this directory are automatically applied when deploying to Netlify.`))
+  log(`${INDENT}${displayPath}`)
 
   if (status.missingOnDisk.length > 0 || status.outOfOrder.length > 0) {
     log('')
@@ -355,6 +347,37 @@ const renderPretty = (params: RenderParams) => {
           )} to delete these local-only migrations, then generate them again with a higher prefix.`,
         ),
       )
+    }
+  }
+
+  const appliedEmoji = status.applied.length > 0 ? STATUS_GOOD : STATUS_NONE
+  log('')
+  log(`  ${appliedEmoji} ${chalk.bold(`Applied migrations (${String(status.applied.length)})`)}`)
+  log(
+    chalk.gray(
+      `${INDENT}These migrations have been applied and cannot be edited or deleted. Any changes to the schema must involve a new migration.`,
+    ),
+  )
+  log(renderList(status.applied, INDENT))
+
+  log('')
+  const pendingEmoji = status.pending.length === 0 ? STATUS_GOOD : STATUS_WARN
+  log(`  ${pendingEmoji} ${chalk.bold(`Pending migrations (${String(status.pending.length)})`)}`)
+  log(
+    chalk.gray(
+      `${INDENT}These migrations are defined locally but haven't been applied, and you can change them or delete them.`,
+    ),
+  )
+  log(renderList(status.pending, INDENT))
+  if (status.pending.length > 0 && status.outOfOrder.length === 0) {
+    const canApplyLocally = isLocal && !hasUrlOverride
+    log('')
+    if (canApplyLocally) {
+      log(
+        chalk.gray(`${INDENT}Run ${formatCommand('database migrations apply')} to apply them to the local database.`),
+      )
+    } else {
+      log(chalk.gray(`${INDENT}Deploy these files to apply the migrations.`))
     }
   }
 }
@@ -459,7 +482,9 @@ export const statusDb = async (options: DatabaseStatusOptions, command: BaseComm
     showCredentials: options.showCredentials ?? false,
     status,
     isLocal,
+    hasUrlOverride: Boolean(envUrl),
     migrationsDirectory,
+    projectRoot: buildDir,
     adminUrl: siteInfo?.admin_url,
   })
 }

--- a/src/commands/database/db-status.ts
+++ b/src/commands/database/db-status.ts
@@ -373,9 +373,7 @@ const renderPretty = (params: RenderParams) => {
     const canApplyLocally = isLocal && !hasUrlOverride
     log('')
     if (canApplyLocally) {
-      log(
-        chalk.gray(`${INDENT}Run ${formatCommand('database migrations apply')} to apply them to the local database.`),
-      )
+      log(chalk.gray(`${INDENT}Run ${formatCommand('database migrations apply')} to apply them to the local database.`))
     } else {
       log(chalk.gray(`${INDENT}Deploy these files to apply the migrations.`))
     }

--- a/src/commands/database/util/api-errors.ts
+++ b/src/commands/database/util/api-errors.ts
@@ -1,0 +1,20 @@
+interface ApiErrorBody {
+  code?: number
+  message?: string
+}
+
+export const readApiErrorMessage = async (response: Response): Promise<string> => {
+  const text = await response.text()
+  if (!text) {
+    return ''
+  }
+  try {
+    const body = JSON.parse(text) as ApiErrorBody
+    if (typeof body.message === 'string' && body.message.trim()) {
+      return body.message
+    }
+  } catch {
+    // body is not JSON; fall through to raw text
+  }
+  return text
+}

--- a/src/commands/database/util/applied-migrations.ts
+++ b/src/commands/database/util/applied-migrations.ts
@@ -1,5 +1,6 @@
 import { type SQLExecutor } from '@netlify/dev'
 
+import { readApiErrorMessage } from './api-errors.js'
 import { MIGRATIONS_TABLE } from './constants.js'
 
 export interface MigrationFile {
@@ -53,8 +54,8 @@ export const remoteAppliedMigrations =
     })
 
     if (!response.ok) {
-      const text = await response.text()
-      throw new Error(`Failed to fetch applied migrations (${String(response.status)}): ${text}`)
+      const message = await readApiErrorMessage(response)
+      throw new Error(`Failed to fetch applied migrations (${String(response.status)}): ${message}`)
     }
 
     const data = (await response.json()) as ListMigrationsResponse

--- a/tests/unit/commands/database/db-migration-pull.test.ts
+++ b/tests/unit/commands/database/db-migration-pull.test.ts
@@ -50,7 +50,15 @@ import { resolve } from 'path'
 import inquirer from 'inquirer'
 import { migrationPull } from '../../../../src/commands/database/db-migration-pull.js'
 
-const sampleMigrations = [
+interface SampleMigration {
+  version: number
+  name: string
+  path: string
+  content: string
+  applied?: boolean
+}
+
+const sampleMigrations: SampleMigration[] = [
   {
     version: 1,
     name: '0001_create-users',
@@ -86,10 +94,31 @@ function createMockCommand(
   } as unknown as Parameters<typeof migrationPull>[1]
 }
 
-function mockFetchResponse(migrations: typeof sampleMigrations) {
-  mockFetch.mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ migrations }),
+function mockFetchResponse(migrations: SampleMigration[]) {
+  const listItems = migrations.map(({ content: _content, applied = false, ...rest }) => ({ ...rest, applied }))
+  mockFetch.mockImplementation((input: URL | string) => {
+    const url = input instanceof URL ? input : new URL(input)
+    const detailMatch = /\/database\/migrations\/([^/]+)$/.exec(url.pathname)
+    if (detailMatch) {
+      const name = decodeURIComponent(detailMatch[1])
+      const migration = migrations.find((m) => m.name === name)
+      if (!migration) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          text: () => Promise.resolve(`migration "${name}" not found`),
+        })
+      }
+      const { applied: _applied, ...detail } = migration
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(detail),
+      })
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ migrations: listItems }),
+    })
   })
 }
 
@@ -126,6 +155,64 @@ describe('migrationPull', () => {
     const calledUrl = mockFetch.mock.calls[0][0] as URL
     expect(calledUrl.toString()).toBe('https://api.netlify.com/api/v1/sites/site-123/database/migrations')
     expect(mockFetch.mock.calls[0][1]).toEqual({ headers: { Authorization: 'Bearer test-token' } })
+  })
+
+  test('fetches content for each migration from the detail endpoint', async () => {
+    mockFetchResponse(sampleMigrations)
+
+    await migrationPull({ force: true }, createMockCommand())
+
+    const detailCalls = mockFetch.mock.calls
+      .map((call) => call[0] as URL)
+      .filter((url) => /\/database\/migrations\/[^/]+$/.test(url.pathname))
+
+    expect(detailCalls).toHaveLength(2)
+    expect(detailCalls.map((u) => u.toString()).sort()).toEqual([
+      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0001_create-users',
+      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0002_add-posts',
+    ])
+    for (const call of mockFetch.mock.calls) {
+      expect(call[1]).toEqual({ headers: { Authorization: 'Bearer test-token' } })
+    }
+  })
+
+  test('forwards branch to both list and detail endpoints', async () => {
+    mockFetchResponse(sampleMigrations)
+
+    await migrationPull({ branch: 'staging', force: true }, createMockCommand())
+
+    for (const call of mockFetch.mock.calls) {
+      const url = call[0] as URL
+      expect(url.searchParams.get('branch')).toBe('staging')
+    }
+  })
+
+  test('throws with migration name when content fetch fails', async () => {
+    mockFetch.mockImplementation((input: URL | string) => {
+      const url = input instanceof URL ? input : new URL(input)
+      if (/\/database\/migrations\/[^/]+$/.test(url.pathname)) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve('internal error'),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            migrations: [
+              { version: 1, name: '0001_create-users', path: '0001_create-users/migration.sql', applied: false },
+            ],
+          }),
+      })
+    })
+
+    await expect(migrationPull({ force: true }, createMockCommand())).rejects.toThrow(
+      'Failed to fetch content for migration "0001_create-users" (500): internal error',
+    )
+    expect(mockRm).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
   test('logs message and exits when no migrations exist in production', async () => {

--- a/tests/unit/commands/database/db-migration-pull.test.ts
+++ b/tests/unit/commands/database/db-migration-pull.test.ts
@@ -321,6 +321,18 @@ describe('migrationPull', () => {
     )
   })
 
+  test('extracts the server `message` from a JSON error body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 423,
+      text: () => Promise.resolve(JSON.stringify({ code: 423, message: 'database is disabled' })),
+    })
+
+    await expect(migrationPull({ force: true }, createMockCommand())).rejects.toThrow(
+      'Failed to fetch migrations (423): database is disabled',
+    )
+  })
+
   test('rejects migration paths with directory traversal', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/tests/unit/commands/database/db-status.test.ts
+++ b/tests/unit/commands/database/db-status.test.ts
@@ -383,7 +383,7 @@ describe('statusDb', () => {
       expect(output).toContain('The local database is not running')
       expect(output).toContain('netlify dev')
       // Migration state is still rendered — connection string is the only thing suppressed.
-      expect(output).toContain('Applied migrations')
+      expect(output).toContain('Migrations')
       expect(output).toContain('• 0001_a')
       expect(output).toContain('• 0002_b')
     })
@@ -451,9 +451,9 @@ describe('statusDb', () => {
       await statusDb({}, createMockCommand())
 
       const output = logMessages.join('\n')
-      expect(output).toContain('Applied migrations')
+      expect(output).toContain('Applied')
       expect(output).toContain('• 0001_a')
-      expect(output).toContain('Migrations not applied')
+      expect(output).toContain('Pending')
       expect(output).toContain('• 0002_b')
     })
 
@@ -473,6 +473,18 @@ describe('statusDb', () => {
       await statusDb({}, createMockCommand())
 
       expect(logMessages.join('\n')).not.toContain('netlify database migrations apply')
+    })
+
+    test('shows the deploy hint instead of the apply-command hint when NETLIFY_DB_URL overrides the connection', async () => {
+      process.env.NETLIFY_DB_URL = 'postgres://override.example.com/db'
+      mockLocalAppliedRows([])
+      mockFS(migrationsTree(['0001_a']))
+
+      await statusDb({}, createMockCommand())
+
+      const output = logMessages.join('\n')
+      expect(output).not.toContain('netlify database migrations apply')
+      expect(output).toContain('Deploy these files to apply the migrations.')
     })
 
     test('shows --show-credentials hint when connection has credentials', async () => {
@@ -633,50 +645,61 @@ describe('statusDb', () => {
       )
     })
 
-    test('renders a subtitle under Applied migrations', async () => {
+    test('renders a subtitle under Migrations', async () => {
       await statusDb({}, createMockCommand())
 
-      expect(logMessages.join('\n')).toContain('Migrations that have been applied to the database branch')
+      expect(logMessages.join('\n')).toContain('Database migrations managed by Netlify')
     })
 
-    test('renders a subtitle under Migrations not applied', async () => {
+    test('renders a dedicated section for the migrations directory with a relative path', async () => {
       await statusDb({}, createMockCommand())
 
-      expect(logMessages.join('\n')).toContain("Migrations that exist locally that haven't yet been applied")
+      const output = logMessages.join('\n')
+      expect(output).toContain('Migrations directory')
+      expect(output).toContain('netlify/database/migrations')
     })
 
-    test('renders a dedicated line for the migrations directory', async () => {
-      await statusDb({}, createMockCommand())
-
-      expect(logMessages.join('\n')).toContain('Migrations directory: /project/netlify/database/migrations')
-    })
-
-    test('migrations directory line honours netlify.toml db.migrations.path override', async () => {
+    test('falls back to the absolute path when the directory is outside the project root', async () => {
       await statusDb({}, createMockCommand({ migrationsPath: '/custom/migrations/dir' }))
 
-      expect(logMessages.join('\n')).toContain('Migrations directory: /custom/migrations/dir')
+      expect(logMessages.join('\n')).toContain('/custom/migrations/dir')
     })
 
-    test('always renders the immutability note below the Applied migrations list', async () => {
+    test('renders the immutability note above the Applied Migrations list', async () => {
       mockLocalAppliedRows(['0001_a'])
       mockFS(migrationsTree(['0001_a']))
 
       await statusDb({}, createMockCommand())
 
       const output = logMessages.join('\n')
-      // Note appears after the bullet list.
       const bulletIndex = output.indexOf('• 0001_a')
-      const noteIndex = output.indexOf('Note that these migrations cannot be removed or edited')
-      expect(bulletIndex).toBeGreaterThanOrEqual(0)
-      expect(noteIndex).toBeGreaterThan(bulletIndex)
-      expect(output).toContain('you should generate a new migration')
+      const noteIndex = output.indexOf('These migrations have been applied and cannot be edited or deleted')
+      expect(bulletIndex).toBeGreaterThan(0)
+      expect(noteIndex).toBeGreaterThan(0)
+      expect(noteIndex).toBeLessThan(bulletIndex)
+      expect(output).toContain('Any changes to the schema must involve a new migration')
     })
 
-    test('renders the immutability note regardless of NETLIFY_AGENT_RUNNER_ID', async () => {
-      // env var intentionally unset in beforeEach
+    test('renders the immutability note even when there are no applied migrations', async () => {
       await statusDb({}, createMockCommand())
 
-      expect(logMessages.join('\n')).toContain('Note that these migrations cannot be removed or edited')
+      expect(logMessages.join('\n')).toContain('These migrations have been applied and cannot be edited or deleted')
+    })
+
+    test('renders a subtitle under Pending Migrations', async () => {
+      await statusDb({}, createMockCommand())
+
+      expect(logMessages.join('\n')).toContain(
+        "These migrations are defined locally but haven't been applied, and you can change them or delete them.",
+      )
+    })
+
+    test('renders a note under the migrations directory line', async () => {
+      await statusDb({}, createMockCommand())
+
+      expect(logMessages.join('\n')).toContain(
+        'Migration files in this directory are automatically applied when deploying to Netlify.',
+      )
     })
   })
 
@@ -788,7 +811,7 @@ describe('statusDb', () => {
       })
     })
 
-    test('does not show the apply-command hint for remote', async () => {
+    test('shows the deploy hint instead of the apply-command hint for remote', async () => {
       setupFetchRouter({
         siteDatabase: { connection_string: PROD_CONN },
         branch: { 'feature-x': { connection_string: BRANCH_CONN } },
@@ -798,7 +821,9 @@ describe('statusDb', () => {
 
       await statusDb({ branch: 'feature-x' }, createMockCommand())
 
-      expect(logMessages.join('\n')).not.toContain('netlify database migrations apply')
+      const output = logMessages.join('\n')
+      expect(output).not.toContain('netlify database migrations apply')
+      expect(output).toContain('Deploy these files to apply the migrations.')
     })
 
     test('falls back to NETLIFY_DB_BRANCH env var when --branch is not passed', async () => {

--- a/tests/unit/commands/database/util/api-errors.test.ts
+++ b/tests/unit/commands/database/util/api-errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+
+import { readApiErrorMessage } from '../../../../../src/commands/database/util/api-errors.js'
+
+const makeResponse = (text: string): Response => ({ text: () => Promise.resolve(text) } as unknown as Response)
+
+describe('readApiErrorMessage', () => {
+  test('extracts the `message` field from a JSON error body', async () => {
+    const response = makeResponse(JSON.stringify({ code: 404, message: 'database not found' }))
+    expect(await readApiErrorMessage(response)).toBe('database not found')
+  })
+
+  test('falls back to the raw body when it is not JSON', async () => {
+    const response = makeResponse('plain text error')
+    expect(await readApiErrorMessage(response)).toBe('plain text error')
+  })
+
+  test('falls back to the raw body when JSON has no `message` field', async () => {
+    const response = makeResponse(JSON.stringify({ code: 500 }))
+    expect(await readApiErrorMessage(response)).toBe(JSON.stringify({ code: 500 }))
+  })
+
+  test('falls back to the raw body when `message` is blank', async () => {
+    const body = JSON.stringify({ code: 500, message: '   ' })
+    const response = makeResponse(body)
+    expect(await readApiErrorMessage(response)).toBe(body)
+  })
+
+  test('returns empty string when body is empty', async () => {
+    const response = makeResponse('')
+    expect(await readApiErrorMessage(response)).toBe('')
+  })
+})


### PR DESCRIPTION
## https://github.com/netlify/cli/pull/8200/changes/fd77a178ce52866150cb4a1521fe54475b830539

Reworks the human-friendly output of `netlify database status ` into a single _Migrations_ section (replacing the previous separate "Applied migrations" and "Migrations not applied" sections).

Also fixed the apply-guidance: the `netlify database migrations apply` hint only appears when truly targeting the local dev DB, and switches to "Deploy these files to apply the migrations." when using a remote database.

The `--json` output is now affected.

## https://github.com/netlify/cli/pull/8200/changes/60c162d180476afdce4c4bb3cf39a47696d55e7f

Fixed `netlify database migrations pull` to match the server's new split API. The list endpoint (`/database/migrations`) is now metadata-only and a new per-migration endpoint (`/database/migrations/{name}`) returns the SQL content, so the command now makes a list call followed by parallel content fetches. 

## https://github.com/netlify/cli/pull/8200/changes/9bb834f67c9112247b453289f590e98c1c6d182c

Added a shared `readApiErrorMessage` helper used by every CLI call site that hits `/database/*`, which extracts the server's message field from JSON error bodies so users see clean messages instead of raw JSON.