### PR TITLE
fix: bump @fastify/static to 9.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@fastify/static": "9.1.1",
+        "@fastify/static": "^9.1.3",
         "@netlify/ai": "0.4.1",
         "@netlify/api": "14.0.18",
         "@netlify/blobs": "10.7.0",
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.1.tgz",
-      "integrity": "sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typecheck:watch": "tsc --watch"
   },
   "dependencies": {
-    "@fastify/static": "9.1.1",
+    "@fastify/static": "^9.1.3",
     "@netlify/ai": "0.4.1",
     "@netlify/api": "14.0.18",
     "@netlify/blobs": "10.7.0",


### PR DESCRIPTION
#### Summary

- upgrade `@fastify/static` to latest release to fix vulnerability
- changed semver request to use a caret