### PR TITLE
debug: probe fastify-static 9.1.1 test failures (do not merge)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@fastify/static": "9.0.0",
+        "@fastify/static": "9.1.1",
         "@netlify/ai": "0.4.1",
         "@netlify/api": "14.0.18",
         "@netlify/blobs": "10.7.0",
@@ -1491,7 +1491,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.0.0",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.1.tgz",
+      "integrity": "sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==",
       "funding": [
         {
           "type": "github",
@@ -1534,7 +1536,9 @@
       }
     },
     "node_modules/@fastify/static/node_modules/content-disposition": {
-      "version": "1.0.1",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1545,34 +1549,38 @@
       }
     },
     "node_modules/@fastify/static/node_modules/glob": {
-      "version": "13.0.0",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@fastify/static/node_modules/lru-cache": {
-      "version": "11.2.5",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@fastify/static/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1582,14 +1590,16 @@
       }
     },
     "node_modules/@fastify/static/node_modules/path-scurry": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -15038,8 +15048,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typecheck:watch": "tsc --watch"
   },
   "dependencies": {
-    "@fastify/static": "9.0.0",
+    "@fastify/static": "9.1.1",
     "@netlify/ai": "0.4.1",
     "@netlify/api": "14.0.18",
     "@netlify/blobs": "10.7.0",

--- a/src/lib/edge-functions/proxy.ts
+++ b/src/lib/edge-functions/proxy.ts
@@ -175,6 +175,8 @@ export const initializeProxy = async ({
 
     const url = new URL(req.url!, `http://${LOCAL_HOST}:${mainPort}`)
     const { functionNames, invocationMetadata } = registry.matchURLPath(url.pathname, req.method!, req.headers)
+    // eslint-disable-next-line no-console
+    console.error(`[EF-PROBE] ${req.method} ${req.url} matched=${JSON.stringify(functionNames)}`)
 
     if (functionNames.length === 0) {
       return

--- a/src/utils/static-server.ts
+++ b/src/utils/static-server.ts
@@ -13,6 +13,8 @@ import { log, NETLIFYDEVLOG } from './command-helpers.js'
 export const startStaticServer = async ({ settings }) => {
   const server = Fastify()
   const rootPath = path.resolve(settings.dist)
+  // eslint-disable-next-line no-console
+  console.error(`[STATIC-PROBE] starting; root=${rootPath}`)
   server.register(fastifyStatic, {
     root: rootPath,
     etag: false,
@@ -25,6 +27,8 @@ export const startStaticServer = async ({ settings }) => {
   })
 
   server.addHook('onRequest', (req, reply, done) => {
+    // eslint-disable-next-line no-console
+    console.error(`[STATIC-PROBE] ${req.method} ${req.url}`)
     reply.header('age', '0')
     reply.header('cache-control', 'public, max-age=0, must-revalidate')
     const validMethods = ['GET', 'HEAD']


### PR DESCRIPTION
## Purpose

Throwaway branch off [#8165](https://github.com/netlify/cli/pull/8165) to investigate why integration tests fail with `@fastify/static` 9.0.0 → 9.1.1. **Do not merge.**

## What this adds

Three `console.error` probes that bubble through `devServer.output` into vitest's failure log:

- `[EF-PROBE] <method> <url> matched=<functionNames>` — at `src/lib/edge-functions/proxy.ts` after `registry.matchURLPath`. Tells us whether requests reached the EF proxy and what the registry returned.
- `[STATIC-PROBE] starting; root=<path>` — at `src/utils/static-server.ts` boot.
- `[STATIC-PROBE] <method> <url>` — on every static-server request.

## How to read the output

| `[EF-PROBE]` for `/ordertest`? | `matched=` | Diagnosis |
|---|---|---|
| missing | — | request bypassed EF proxy entirely |
| present | `[]` | EF registry hadn't finished loading (race exposed by faster 9.1.1 boot) |
| present | full chain | EF matched but origin response leaked through |
| present | partial chain | registry partially loaded |

Looking at the ubuntu Integration shard 3/4 logs for `tests/integration/commands/dev/edge-functions.test.ts > should run edge functions in correct order`.

## Cleanup

Delete this branch once we have an answer; revert / never merge.