### PR TITLE
fix: don't use inquirer for non-interactive variant of "database migrations new" command

### DIFF
--- a/docs/commands/database.md
+++ b/docs/commands/database.md
@@ -201,7 +201,7 @@ netlify database migrations new
 - `description` (*string*) - Purpose of the migration (used to generate the file name)
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `json` (*boolean*) - Output result as JSON
-- `scheme` (*sequential | timestamp*) - Numbering scheme for migration prefixes
+- `scheme` (*timestamp | sequential*) - Numbering scheme for migration prefixes
 - `debug` (*boolean*) - Print debugging information
 - `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 

--- a/src/commands/database/database.ts
+++ b/src/commands/database/database.ts
@@ -96,8 +96,8 @@ export const createDatabaseCommand = (program: BaseCommand) => {
     .option('-d, --description <description>', 'Purpose of the migration (used to generate the file name)')
     .addOption(
       new Option('-s, --scheme <scheme>', 'Numbering scheme for migration prefixes').choices([
-        'sequential',
         'timestamp',
+        'sequential',
       ]),
     )
     .option('--json', 'Output result as JSON')

--- a/src/commands/database/db-migration-new.ts
+++ b/src/commands/database/db-migration-new.ts
@@ -117,8 +117,8 @@ export const migrationNew = async (options: MigrationNewOptions, command: BaseCo
           name: 'scheme',
           message: 'Numbering scheme:',
           choices: [
-            { name: 'Timestamp (20260312143000)', value: 'timestamp' },
-            { name: 'Sequential (0001, 0002, ...)', value: 'sequential' },
+            { name: 'Timestamp (e.g. 20260312143000) [Recommended]', value: 'timestamp' },
+            { name: 'Sequential (e.g. 0001, 0002, ...)', value: 'sequential' },
           ],
           default: defaultScheme,
         },

--- a/src/commands/database/db-migration-new.ts
+++ b/src/commands/database/db-migration-new.ts
@@ -7,6 +7,7 @@ import { log, logJson } from '../../utils/command-helpers.js'
 import BaseCommand from '../base-command.js'
 import { resolveMigrationsDirectory } from './util/migrations-path.js'
 import { utcTimestampPrefix } from './util/timestamp.js'
+import { isInteractive } from '../../utils/scripted-commands.js'
 
 export type NumberingScheme = 'sequential' | 'timestamp'
 
@@ -89,31 +90,43 @@ export const migrationNew = async (options: MigrationNewOptions, command: BaseCo
   let scheme = options.scheme
 
   if (!description) {
-    const answers = await inquirer.prompt<{ description: string }>([
-      {
-        type: 'input',
-        name: 'description',
-        message: 'What is the purpose of this migration?',
-        validate: (input: string) => (input.trim().length > 0 ? true : 'Description cannot be empty'),
-      },
-    ])
-    description = answers.description
+    if (isInteractive()) {
+      const answers = await inquirer.prompt<{ description: string }>([
+        {
+          type: 'input',
+          name: 'description',
+          message: 'What is the purpose of this migration?',
+          validate: (input: string) => (input.trim().length > 0 ? true : 'Description cannot be empty'),
+        },
+      ])
+      description = answers.description
+    } else {
+      throw new Error(
+        `--description <description> argument is required when not running interactively. Provide a description of the migration (e.g. --description "add users table").`,
+      )
+    }
   }
 
   if (!scheme) {
-    const answers = await inquirer.prompt<{ scheme: NumberingScheme }>([
-      {
-        type: 'list',
-        name: 'scheme',
-        message: 'Numbering scheme:',
-        choices: [
-          { name: 'Sequential (0001, 0002, ...)', value: 'sequential' },
-          { name: 'Timestamp (20260312143000)', value: 'timestamp' },
-        ],
-        ...(detectedScheme && { default: detectedScheme }),
-      },
-    ])
-    scheme = answers.scheme
+    const defaultScheme = detectedScheme ?? 'timestamp'
+
+    if (isInteractive()) {
+      const answers = await inquirer.prompt<{ scheme: NumberingScheme }>([
+        {
+          type: 'list',
+          name: 'scheme',
+          message: 'Numbering scheme:',
+          choices: [
+            { name: 'Timestamp (20260312143000)', value: 'timestamp' },
+            { name: 'Sequential (0001, 0002, ...)', value: 'sequential' },
+          ],
+          default: defaultScheme,
+        },
+      ])
+      scheme = answers.scheme
+    } else {
+      scheme = defaultScheme
+    }
   }
 
   const slug = generateSlug(description)

--- a/tests/unit/commands/database/db-migration-new.test.ts
+++ b/tests/unit/commands/database/db-migration-new.test.ts
@@ -248,18 +248,14 @@ describe('migrationNew', () => {
     await migrationNew({ description: 'add comments' }, createMockCommand())
 
     expect(inquirer.prompt).not.toHaveBeenCalled()
-    expect(mockMkdir).toHaveBeenCalledWith(
-      join('/project/netlify/database/migrations', '0003_add-comments'),
-      { recursive: true },
-    )
+    expect(mockMkdir).toHaveBeenCalledWith(join('/project/netlify/database/migrations', '0003_add-comments'), {
+      recursive: true,
+    })
   })
 
   test('detects timestamp scheme in non-interactive mode when timestamp migrations exist', async () => {
     vi.mocked(isInteractive).mockReturnValue(false)
-    mockReaddir.mockResolvedValue([
-      dirEntry('20260312143000_create-users'),
-      dirEntry('20260312150000_add-posts'),
-    ])
+    mockReaddir.mockResolvedValue([dirEntry('20260312143000_create-users'), dirEntry('20260312150000_add-posts')])
 
     await migrationNew({ description: 'add comments' }, createMockCommand())
 

--- a/tests/unit/commands/database/db-migration-new.test.ts
+++ b/tests/unit/commands/database/db-migration-new.test.ts
@@ -26,6 +26,10 @@ vi.mock('inquirer', () => ({
   default: { prompt: vi.fn() },
 }))
 
+vi.mock('../../../../src/utils/scripted-commands.js', () => ({
+  isInteractive: vi.fn(),
+}))
+
 vi.mock('../../../../src/utils/command-helpers.js', async () => ({
   ...(await vi.importActual('../../../../src/utils/command-helpers.js')),
   log: (...args: string[]) => {
@@ -46,6 +50,7 @@ import {
   generateNextPrefix,
 } from '../../../../src/commands/database/db-migration-new.js'
 import { resolveMigrationsDirectory } from '../../../../src/commands/database/util/migrations-path.js'
+import { isInteractive } from '../../../../src/utils/scripted-commands.js'
 
 function createMockCommand(overrides: { migrationsPath?: string | undefined } = {}) {
   const { migrationsPath = '/project/netlify/database/migrations' } = overrides
@@ -195,6 +200,7 @@ describe('migrationNew', () => {
   })
 
   test('prompts for description when not provided', async () => {
+    vi.mocked(isInteractive).mockReturnValue(true)
     vi.mocked(inquirer.prompt)
       .mockResolvedValueOnce({ description: 'create users table' })
       .mockResolvedValueOnce({ scheme: 'sequential' })
@@ -205,7 +211,16 @@ describe('migrationNew', () => {
     expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('create-users-table'), expect.any(Object))
   })
 
+  test('throws when description is missing in non-interactive mode', async () => {
+    vi.mocked(isInteractive).mockReturnValue(false)
+
+    await expect(migrationNew({}, createMockCommand())).rejects.toThrow(
+      '--description <description> argument is required when not running interactively',
+    )
+  })
+
   test('prompts for scheme with detected default when not provided', async () => {
+    vi.mocked(isInteractive).mockReturnValue(true)
     mockReaddir.mockResolvedValue([dirEntry('0001_create-users'), dirEntry('0002_add-posts')])
     vi.mocked(inquirer.prompt).mockResolvedValueOnce({ scheme: 'sequential' })
 
@@ -213,6 +228,45 @@ describe('migrationNew', () => {
 
     const promptCall = vi.mocked(inquirer.prompt).mock.calls[0][0] as { default?: string }[]
     expect(promptCall[0].default).toBe('sequential')
+  })
+
+  test('defaults to timestamp scheme in non-interactive mode when no migrations exist', async () => {
+    vi.mocked(isInteractive).mockReturnValue(false)
+
+    await migrationNew({ description: 'add posts table' }, createMockCommand())
+
+    expect(inquirer.prompt).not.toHaveBeenCalled()
+    const mkdirCall = mockMkdir.mock.calls[0][0] as string
+    const folderName = mkdirCall.split(/[/\\]/).pop() ?? ''
+    expect(folderName).toMatch(/^\d{14}_add-posts-table$/)
+  })
+
+  test('detects sequential scheme in non-interactive mode when sequential migrations exist', async () => {
+    vi.mocked(isInteractive).mockReturnValue(false)
+    mockReaddir.mockResolvedValue([dirEntry('0001_create-users'), dirEntry('0002_add-posts')])
+
+    await migrationNew({ description: 'add comments' }, createMockCommand())
+
+    expect(inquirer.prompt).not.toHaveBeenCalled()
+    expect(mockMkdir).toHaveBeenCalledWith(
+      join('/project/netlify/database/migrations', '0003_add-comments'),
+      { recursive: true },
+    )
+  })
+
+  test('detects timestamp scheme in non-interactive mode when timestamp migrations exist', async () => {
+    vi.mocked(isInteractive).mockReturnValue(false)
+    mockReaddir.mockResolvedValue([
+      dirEntry('20260312143000_create-users'),
+      dirEntry('20260312150000_add-posts'),
+    ])
+
+    await migrationNew({ description: 'add comments' }, createMockCommand())
+
+    expect(inquirer.prompt).not.toHaveBeenCalled()
+    const mkdirCall = mockMkdir.mock.calls[0][0] as string
+    const folderName = mkdirCall.split(/[/\\]/).pop() ?? ''
+    expect(folderName).toMatch(/^\d{14}_add-comments$/)
   })
 
   test('uses timestamp scheme when specified', async () => {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Main goal here is to avoid using `inquirer` in non-interactive mode.

I did smuggle in here preference to using `timestamp` numbering schema over sequential as it is less problematic when working on parallel changes. We still will honor sequential and default to it if this is a scheme already used by a project. This part is optimistic and can walk it back if deemed undesirable.

Currently non-interactive works only when both `--scheme` and `--description` is provided:
```bash
> netlify database migrations new --description "test" --scheme timestamp  < /dev/null
Created migration: 20260504084016_test
  /Users/misiek/test/pgs-test-init/netlify/database/migrations/20260504084016_test/migration.sql
```

But if they are not - there is non-helpful error happening:
```bash
> netlify database migrations new --description "test" < /dev/null
? Numbering scheme: (Use arrow keys)
❯ Sequential (0001, 0002, ...) 
  Timestamp (20260312143000) Warning: Detected unsettled top-level await at file:///Users/misiek/.nvm/versions/node/v24.0.0/lib/node_modules/netlify-cli/bin/run.js:87
  await main()
  ^

> netlify database migrations new --scheme timestamp < /dev/null
? What is the purpose of this migration? Warning: Detected unsettled top-level await at file:///Users/misiek/.nvm/versions/node/v24.0.0/lib/node_modules/netlify-cli/bin/run.js:87
  await main()
```

With changes in this PR:
- we get more meaningful error for missing `--description`:
```bash
> ntl_local database migrations new --scheme timestamp < /dev/null
 ›   Error: --description <description> argument is required when not running interactively. Provide a description of the migration (e.g. --description "add users table").
```
- we default to a scheme that is already used in a project (or default to timestamp if no migrations exist yet)
```bash
# if no migrations or timestamps used before
> ntl_local database migrations new --description "test"  < /dev/null
Created migration: 20260504084320_test
  /Users/misiek/test/pgs-test-init/netlify/database/migrations/20260504084320_test/migration.sql

# if sequential migrations used before
> ntl_local database migrations new --description "test2"  < /dev/null
Created migration: 0002_test2
  /Users/misiek/test/pgs-test-init/netlify/database/migrations/0002_test2/migration.sql
```

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
