### PR TITLE
ci: use `pnpm/action-setup` on Windows for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,13 +92,7 @@ jobs:
           cache: npm
           check-latest: true
 
-      # Let corepack manage npm, pnpm, and yarn versions on Windows.
-      - name: Enable corepack (Windows)
-        if: matrix.os == 'windows-2025'
-        run: corepack enable
-
-      - name: Setup pnpm (non-Windows)
-        if: matrix.os != 'windows-2025'
+      - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10


### PR DESCRIPTION
#### Summary

Corepack on Windows wasn't properly respecting the npm_config_registry environment variable when running pnpm commands, causing E2E tests to fail with "No matching version found for netlify-cli@testing" because pnpm was fetching from npmjs.org instead of the local Verdaccio server.

The e2e tests for pnpm were implicitly using whatever happened to be the latest pnpm. pnpm@11 was recently released and broke some assumption somewhere.

This removes the weird Windows exception.