### PR TITLE
fix: reorder systemInfo logging after error stack

### DIFF
--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -95,9 +95,8 @@ process.on('uncaughtException', async (err: AddressInUseError | Error) => {
       )} including the error details below.\n`,
     )
 
-    const systemInfo = await getSystemInfo()
-
     console.log(chalk.dim(err.stack || err))
+    const systemInfo = await getSystemInfo()
     console.log(chalk.dim(systemInfo))
     reportError(err, { severity: 'error' })
   }


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

For cases like these: https://answers.netlify.com/t/157384/

The CLI was quitting without any error message - most likely because the systemInfo() async call didn't finish (in time). With this change, we'd at least always see the error message which could lead to some debugging other than everyone being lost on what the actual error is.
