### PR TITLE
fix: infinite loop on error

### DIFF
--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -73,36 +73,60 @@ export const CI_FORCED_COMMANDS = {
   'sites:delete': { options: '-f, --force', description: 'Delete without prompting (useful for CI).' },
 }
 
+const SYSTEM_INFO_TIMEOUT = 5_000
+
+let isHandlingUncaughtException = false
+
 process.on('uncaughtException', async (err: AddressInUseError | Error) => {
-  if ('code' in err && err.code === 'EADDRINUSE') {
-    logError(
-      `${chalk.red(`Port ${err.port} is already in use`)}\n\n` +
-        `Your serverless functions might be initializing a server\n` +
-        `to listen on specific port without properly closing it.\n\n` +
-        `This behavior is generally not advised\n` +
-        `To resolve this issue, try the following:\n` +
-        `1. If you NEED your serverless function to listen on a specific port,\n` +
-        `use a randomly assigned port as we do not officially support this.\n` +
-        `2. Review your serverless functions for lingering server connections, close them\n` +
-        `3. Check if any other applications are using port ${err.port}\n`,
-    )
-  } else {
-    logError(
-      `${chalk.red(
-        'Netlify CLI has terminated unexpectedly.',
-      )}\n\nPlease report this problem with reproduction steps at ${chalk.underline(
-        'https://ntl.fyi/cli-error',
-      )} including the error details below.\n`,
-    )
-
-    const systemInfo = await getSystemInfo()
-
-    console.log(chalk.dim(err.stack || err))
-    console.log(chalk.dim(systemInfo))
-    reportError(err, { severity: 'error' })
+  if (isHandlingUncaughtException) {
+    process.exit(1)
   }
+  isHandlingUncaughtException = true
 
-  process.exit(1)
+  try {
+    if ('code' in err && err.code === 'EADDRINUSE') {
+      logError(
+        `${chalk.red(`Port ${err.port} is already in use`)}\n\n` +
+          `Your serverless functions might be initializing a server\n` +
+          `to listen on specific port without properly closing it.\n\n` +
+          `This behavior is generally not advised\n` +
+          `To resolve this issue, try the following:\n` +
+          `1. If you NEED your serverless function to listen on a specific port,\n` +
+          `use a randomly assigned port as we do not officially support this.\n` +
+          `2. Review your serverless functions for lingering server connections, close them\n` +
+          `3. Check if any other applications are using port ${err.port}\n`,
+      )
+    } else {
+      logError(
+        `${chalk.red(
+          'Netlify CLI has terminated unexpectedly.',
+        )}\n\nPlease report this problem with reproduction steps at ${chalk.underline(
+          'https://ntl.fyi/cli-error',
+        )} including the error details below.\n`,
+      )
+
+      // print the error regardless of systemInfo
+      console.log(chalk.dim(err.stack || err))
+
+      // systemInfo sometimes could get stuck resulting in exit() never called
+      // we now prevent that by bailing early so the CLI quits in time
+      const systemInfo = await Promise.race([
+        getSystemInfo().catch(() => ''),
+        new Promise<string>((resolve) =>
+          setTimeout(() => {
+            resolve('')
+          }, SYSTEM_INFO_TIMEOUT),
+        ),
+      ])
+
+      if (systemInfo) {
+        console.log(chalk.dim(systemInfo))
+      }
+      reportError(err, { severity: 'error' })
+    }
+  } finally {
+    process.exit(1)
+  }
 })
 
 const pkg = await getCLIPackageJson()

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -105,11 +105,8 @@ process.on('uncaughtException', async (err: AddressInUseError | Error) => {
         )} including the error details below.\n`,
       )
 
-      // print the error regardless of systemInfo
       console.log(chalk.dim(err.stack || err))
 
-      // systemInfo sometimes could get stuck resulting in exit() never called
-      // we now prevent that by bailing early so the CLI quits in time
       const systemInfo = await Promise.race([
         getSystemInfo().catch(() => ''),
         new Promise<string>((resolve) =>


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Next iteration of: https://github.com/netlify/cli/pull/8268. This PR should fix the original issue of the CLI ending in a loop. It should exit as soon as the error is triggered.