### PR TITLE
fix: user sending the wrong command is not an error

### DIFF
--- a/site/netlify/functions/error-reporting.ts
+++ b/site/netlify/functions/error-reporting.ts
@@ -15,6 +15,7 @@ const USER_INPUT_ERROR_MESSAGE_PATTERNS: string[] = [
   'could not retrieve project',
   "You don't appear to be in a folder that is linked to a project",
   'EADDRINUSE: address already in use',
+  'for a list of available commands',
 ]
 
 const isUserInputError = (message: unknown): boolean =>

--- a/src/commands/main.ts
+++ b/src/commands/main.ts
@@ -210,7 +210,8 @@ const mainCommand = async function (options, command) {
     log()
     command.outputHelp({ error: true })
     log()
-    return logAndThrowError(`Run ${NETLIFY_CYAN(`${command.name()} help`)} for a list of available commands.`)
+    logError(`Run ${NETLIFY_CYAN(`${command.name()} help`)} for a list of available commands.`)
+    exit(1)
   }
 
   const applySuggestion = await new Promise((resolve) => {
@@ -235,7 +236,8 @@ const mainCommand = async function (options, command) {
   log()
 
   if (!applySuggestion) {
-    return logAndThrowError(`Run ${NETLIFY_CYAN(`${command.name()} help`)} for a list of available commands.`)
+    logError(`Run ${NETLIFY_CYAN(`${command.name()} help`)} for a list of available commands.`)
+    exit(1)
   }
 
   await execa(process.argv[0], [process.argv[1], suggestion], { stdio: 'inherit' })


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Right now we throw an error if the user is using a wrong command on the CLI. Not only does this give a lot of noise in our monitoring, it is also not necessary.

This changes the logic to only log and exit, and also to filter out these kind of messages from the error logging (for old versions still doing this)
---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
