### PR TITLE
feat(agents): add pr and commit commands (4/8)

### DIFF
--- a/docs/commands/agents.md
+++ b/docs/commands/agents.md
@@ -27,10 +27,12 @@ netlify agents
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
+| [`agents:commit`](/commands/agents#agentscommit) | Commit an agent run’s changes directly to a branch  |
 | [`agents:create`](/commands/agents#agentscreate) | Create and start a new agent run on your site  |
 | [`agents:diff`](/commands/agents#agentsdiff) | Print the code changes produced by an agent run  |
 | [`agents:list`](/commands/agents#agentslist) | List agent runs for the current site  |
 | [`agents:open`](/commands/agents#agentsopen) | Open the agent run preview, dashboard, or pull request in a browser  |
+| [`agents:pr`](/commands/agents#agentspr) | Open a pull request for an agent run  |
 | [`agents:show`](/commands/agents#agentsshow) | Show details of a specific agent run  |
 | [`agents:stop`](/commands/agents#agentsstop) | Stop a running agent run  |
 
@@ -43,6 +45,36 @@ netlify agents:list --status running
 netlify agents:show 60c7c3b3e7b4a0001f5e4b3a --watch
 netlify agents:diff 60c7c3b3e7b4a0001f5e4b3a
 netlify agents:open 60c7c3b3e7b4a0001f5e4b3a
+```
+
+---
+## `agents:commit`
+
+Commit an agent run’s changes directly to a branch
+
+**Usage**
+
+```bash
+netlify agents:commit
+```
+
+**Arguments**
+
+- id - agent run ID
+
+**Flags**
+
+- `branch` (*string*) - target branch to commit to
+- `filter` (*string*) - For monorepos, specify the name of the application to run the command in
+- `json` (*boolean*) - output result as JSON
+- `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+- `project` (*string*) - project ID or name (if not in a linked directory)
+
+**Examples**
+
+```bash
+netlify agents:commit 60c7c3b3e7b4a0001f5e4b3a --branch staging
 ```
 
 ---
@@ -191,6 +223,35 @@ netlify agents:open
 netlify agents:open 60c7c3b3e7b4a0001f5e4b3a
 netlify agents:open 60c7c3b3e7b4a0001f5e4b3a dashboard
 netlify agents:open 60c7c3b3e7b4a0001f5e4b3a pr
+```
+
+---
+## `agents:pr`
+
+Open a pull request for an agent run
+
+**Usage**
+
+```bash
+netlify agents:pr
+```
+
+**Arguments**
+
+- id - agent run ID
+
+**Flags**
+
+- `filter` (*string*) - For monorepos, specify the name of the application to run the command in
+- `json` (*boolean*) - output result as JSON
+- `project` (*string*) - project ID or name (if not in a linked directory)
+- `debug` (*boolean*) - Print debugging information
+- `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
+
+**Examples**
+
+```bash
+netlify agents:pr 60c7c3b3e7b4a0001f5e4b3a
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,12 @@ Manage Netlify AI agent runs
 
 | Subcommand | description  |
 |:--------------------------- |:-----|
+| [`agents:commit`](/commands/agents#agentscommit) | Commit an agent run’s changes directly to a branch  |
 | [`agents:create`](/commands/agents#agentscreate) | Create and start a new agent run on your site  |
 | [`agents:diff`](/commands/agents#agentsdiff) | Print the code changes produced by an agent run  |
 | [`agents:list`](/commands/agents#agentslist) | List agent runs for the current site  |
 | [`agents:open`](/commands/agents#agentsopen) | Open the agent run preview, dashboard, or pull request in a browser  |
+| [`agents:pr`](/commands/agents#agentspr) | Open a pull request for an agent run  |
 | [`agents:show`](/commands/agents#agentsshow) | Show details of a specific agent run  |
 | [`agents:stop`](/commands/agents#agentsstop) | Stop a running agent run  |
 

--- a/src/commands/agents/agents-commit.ts
+++ b/src/commands/agents/agents-commit.ts
@@ -1,0 +1,104 @@
+import type { OptionValues } from 'commander'
+import inquirer from 'inquirer'
+
+import { chalk, log, logAndThrowError, logJson } from '../../utils/command-helpers.js'
+import { startSpinner, stopSpinner } from '../../lib/spinner.js'
+import type BaseCommand from '../base-command.js'
+import { createAgentsApi } from './api.js'
+import type { AgentRunner } from './types.js'
+
+interface AgentCommitOptions extends OptionValues {
+  branch?: string
+  json?: boolean
+}
+
+const pickDefaultBranch = (runner: AgentRunner): { branch: string; reason: string } | null => {
+  const prState = runner.pr_state
+  const hasOpenPr = runner.pr_url && (prState === 'open' || prState === 'draft')
+  if (hasOpenPr && runner.pr_branch) {
+    return { branch: runner.pr_branch, reason: 'updating the existing pull request' }
+  }
+  if (runner.branch) {
+    return { branch: runner.branch, reason: "committing to this agent run's branch" }
+  }
+  return null
+}
+
+export const agentsCommit = async (id: string, options: AgentCommitOptions, command: BaseCommand) => {
+  if (!id) return logAndThrowError('Agent run ID is required')
+  await command.authenticate()
+  const { siteInfo } = command.netlify
+  if (!siteInfo.build_settings?.repo_url) {
+    return logAndThrowError(
+      'This project is not connected to a git repository. Commits are only available for git-backed projects.',
+    )
+  }
+  const api = createAgentsApi(command.netlify)
+
+  let targetBranch = options.branch?.trim()
+
+  if (!targetBranch) {
+    const lookupSpinner = startSpinner({ text: 'Looking up agent run...' })
+    let runner: AgentRunner
+    try {
+      runner = await api.getAgentRunner(id)
+      stopSpinner({ spinner: lookupSpinner })
+    } catch (error_) {
+      stopSpinner({ spinner: lookupSpinner, error: true })
+      const error = error_ as Error & { status?: number }
+      if (error.status === 404) return logAndThrowError(`Agent run not found: ${id}`)
+      return logAndThrowError(`Failed to fetch agent run: ${error.message}`)
+    }
+
+    const suggestion = pickDefaultBranch(runner)
+    if (!suggestion) {
+      return logAndThrowError('Could not determine a target branch. Pass --branch <name>.')
+    }
+
+    if (options.json || !process.stdin.isTTY) {
+      targetBranch = suggestion.branch
+    } else {
+      log(chalk.dim(`Default: ${suggestion.branch} (${suggestion.reason})`))
+      const { branchInput } = await inquirer.prompt<{ branchInput: string }>([
+        {
+          type: 'input',
+          name: 'branchInput',
+          message: 'Which branch should the agent commit to?',
+          default: suggestion.branch,
+          validate: (input: string) => (input.trim().length > 0 ? true : 'Branch name is required'),
+        },
+      ])
+      targetBranch = branchInput.trim()
+    }
+  }
+
+  const spinner = startSpinner({ text: `Committing to ${targetBranch}...` })
+  try {
+    const runner = await api.agentRunnerCommitToBranch(id, targetBranch)
+    stopSpinner({ spinner })
+
+    if (options.json) {
+      logJson(runner)
+      return runner
+    }
+
+    if (runner.merge_commit_error) {
+      log(`${chalk.red('✗')} Commit failed: ${runner.merge_commit_error}`)
+      return runner
+    }
+
+    if (runner.merge_commit_is_being_created) {
+      log(chalk.yellow('A commit is being created. Try again in a moment.'))
+      return runner
+    }
+
+    log(`${chalk.green('✓')} Committed to ${chalk.cyan(targetBranch)}`)
+    log()
+    if (runner.merge_commit_sha) log(`  SHA: ${chalk.cyan(runner.merge_commit_sha)}`)
+    return runner
+  } catch (error_) {
+    stopSpinner({ spinner, error: true })
+    const error = error_ as Error
+    return logAndThrowError(`Failed to commit: ${error.message}`)
+  }
+}

--- a/src/commands/agents/agents-pr.ts
+++ b/src/commands/agents/agents-pr.ts
@@ -1,0 +1,55 @@
+import type { OptionValues } from 'commander'
+
+import { chalk, log, logAndThrowError, logJson } from '../../utils/command-helpers.js'
+import { startSpinner, stopSpinner } from '../../lib/spinner.js'
+import type BaseCommand from '../base-command.js'
+import { createAgentsApi } from './api.js'
+
+interface AgentPrOptions extends OptionValues {
+  json?: boolean
+}
+
+export const agentsPullRequest = async (id: string, options: AgentPrOptions, command: BaseCommand) => {
+  if (!id) return logAndThrowError('Agent run ID is required')
+  await command.authenticate()
+  const { siteInfo } = command.netlify
+  if (!siteInfo.build_settings?.repo_url) {
+    return logAndThrowError(
+      'This project is not connected to a git repository. Pull requests are only available for git-backed projects.',
+    )
+  }
+  const api = createAgentsApi(command.netlify)
+
+  const spinner = startSpinner({ text: 'Creating pull request...' })
+  try {
+    const runner = await api.agentRunnerPullRequest(id)
+    stopSpinner({ spinner })
+
+    if (options.json) {
+      logJson(runner)
+      return runner
+    }
+
+    if (runner.pr_error) {
+      log(`${chalk.red('✗')} Pull request failed: ${runner.pr_error}`)
+      return runner
+    }
+
+    if (runner.pr_is_being_created) {
+      log(chalk.yellow('A pull request is being created. Try again in a moment.'))
+      return runner
+    }
+
+    log(`${chalk.green('✓')} Pull request created!`)
+    log()
+    if (runner.pr_url) log(`  URL: ${chalk.blue(runner.pr_url)}`)
+    if (runner.pr_branch) log(`  Branch: ${chalk.cyan(runner.pr_branch)}`)
+    if (runner.pr_state) log(`  State: ${chalk.cyan(runner.pr_state)}`)
+    return runner
+  } catch (error_) {
+    stopSpinner({ spinner, error: true })
+    const error = error_ as Error & { status?: number }
+    if (error.status === 404) return logAndThrowError(`Agent run not found: ${id}`)
+    return logAndThrowError(`Failed to create pull request: ${error.message}`)
+  }
+}

--- a/src/commands/agents/agents.ts
+++ b/src/commands/agents/agents.ts
@@ -140,6 +140,33 @@ export const createAgentsCommand = (program: BaseCommand) => {
       await agentsDiff(id, options, command)
     })
 
+  program
+    .command('agents:pr')
+    .argument('<id>', 'agent run ID')
+    .description('Open a pull request for an agent run')
+    .option('--json', 'output result as JSON')
+    .option('--project <project>', 'project ID or name (if not in a linked directory)')
+    .hook('preAction', requiresSiteInfoWithProject)
+    .addExamples(['netlify agents:pr 60c7c3b3e7b4a0001f5e4b3a'])
+    .action(async (id: string, options: OptionValues, command: BaseCommand) => {
+      const { agentsPullRequest } = await import('./agents-pr.js')
+      await agentsPullRequest(id, options, command)
+    })
+
+  program
+    .command('agents:commit')
+    .argument('<id>', 'agent run ID')
+    .description('Commit an agent run’s changes directly to a branch')
+    .option('-b, --branch <branch>', 'target branch to commit to')
+    .option('--json', 'output result as JSON')
+    .option('--project <project>', 'project ID or name (if not in a linked directory)')
+    .hook('preAction', requiresSiteInfoWithProject)
+    .addExamples(['netlify agents:commit 60c7c3b3e7b4a0001f5e4b3a --branch staging'])
+    .action(async (id: string, options: OptionValues, command: BaseCommand) => {
+      const { agentsCommit } = await import('./agents-commit.js')
+      await agentsCommit(id, options, command)
+    })
+
   const name = chalk.greenBright('`agents`')
 
   return program

--- a/tests/integration/commands/agents/agents-commit.test.ts
+++ b/tests/integration/commands/agents/agents-commit.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { callCli } from '../../utils/call-cli.js'
+import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
+import { withSiteBuilder } from '../../utils/site-builder.js'
+import { mockSiteInfo, mockAgentRunner } from './fixtures.js'
+
+vi.mock('../../../../src/lib/spinner.js', () => ({
+  startSpinner: vi.fn(() => ({ text: 'test' })),
+  stopSpinner: vi.fn(),
+}))
+
+describe('agents:commit command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const baseRoutes = [
+    { path: 'sites/site_id', response: mockSiteInfo },
+    { path: 'sites/site_id/service-instances', response: [] },
+    { path: 'user', response: { name: 'test user' } },
+    { path: 'accounts', response: [{ slug: 'test-account' }] },
+  ]
+
+  test('should commit to a branch', async (t) => {
+    const runnerWithCommit = { ...mockAgentRunner, merge_commit_sha: 'abc1234' }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: runnerWithCommit,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl, requests }) => {
+        const cliResponse = (await callCli(
+          ['agents:commit', 'test_id', '--branch', 'staging'],
+          getCLIOptions({ apiUrl, builder }),
+        )) as string
+
+        expect(cliResponse).toContain('Committed to')
+        expect(cliResponse).toContain('staging')
+        expect(cliResponse).toContain('SHA: abc1234')
+
+        const commitRequest = requests.find((r) => r.path.endsWith('/commit') && r.method === 'POST')
+        expect(commitRequest).toBeDefined()
+        expect(commitRequest?.body).toEqual({ target_branch: 'staging' })
+      })
+    })
+  })
+
+  test('should report merge_commit_error when commit fails on the server', async (t) => {
+    const runnerWithError = { ...mockAgentRunner, merge_commit_error: 'merge conflict' }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: runnerWithError,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(
+          ['agents:commit', 'test_id', '--branch', 'staging'],
+          getCLIOptions({ apiUrl, builder }),
+        )) as string
+
+        expect(cliResponse).toContain('Commit failed: merge conflict')
+      })
+    })
+  })
+
+  test('should report an in-progress commit creation', async (t) => {
+    const runnerInProgress = { ...mockAgentRunner, merge_commit_is_being_created: true }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: runnerInProgress,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(
+          ['agents:commit', 'test_id', '--branch', 'staging'],
+          getCLIOptions({ apiUrl, builder }),
+        )) as string
+
+        expect(cliResponse).toContain('A commit is being created')
+        expect(cliResponse).not.toContain('Committed to')
+      })
+    })
+  })
+
+  test('should return JSON when --json flag is used', async (t) => {
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: { ...mockAgentRunner, merge_commit_sha: 'abc1234' },
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(
+          ['agents:commit', 'test_id', '--branch', 'staging', '--json'],
+          getCLIOptions({ apiUrl, builder }),
+          true,
+        )) as typeof mockAgentRunner & { merge_commit_sha: string }
+
+        expect(cliResponse.merge_commit_sha).toBe('abc1234')
+      })
+    })
+  })
+
+  test('should handle API errors', async (t) => {
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        status: 500,
+        response: { error: 'Internal error' },
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        await expect(
+          callCli(['agents:commit', 'test_id', '--branch', 'staging'], getCLIOptions({ apiUrl, builder })),
+        ).rejects.toThrow('Failed to commit: Internal error')
+      })
+    })
+  })
+
+  test('should default to runner.branch when --branch is omitted', async (t) => {
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id',
+        method: 'GET' as const,
+        response: { ...mockAgentRunner, branch: 'feature-x' },
+      },
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: { ...mockAgentRunner, merge_commit_sha: 'abc' },
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl, requests }) => {
+        await callCli(['agents:commit', 'test_id', '--json'], getCLIOptions({ apiUrl, builder }))
+        const commitRequest = requests.find((r) => r.path.endsWith('/commit') && r.method === 'POST')
+        expect(commitRequest?.body).toEqual({ target_branch: 'feature-x' })
+      })
+    })
+  })
+
+  test('should default to runner.pr_branch when an open PR exists', async (t) => {
+    const runnerWithPr = {
+      ...mockAgentRunner,
+      branch: 'feature-x',
+      pr_branch: 'pr-branch',
+      pr_url: 'https://github.com/x/y/pull/1',
+      pr_state: 'open',
+    }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id',
+        method: 'GET' as const,
+        response: runnerWithPr,
+      },
+      {
+        path: 'agent_runners/test_id/commit',
+        method: 'POST' as const,
+        response: { ...runnerWithPr, merge_commit_sha: 'abc' },
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl, requests }) => {
+        await callCli(['agents:commit', 'test_id', '--json'], getCLIOptions({ apiUrl, builder }))
+        const commitRequest = requests.find((r) => r.path.endsWith('/commit') && r.method === 'POST')
+        expect(commitRequest?.body).toEqual({ target_branch: 'pr-branch' })
+      })
+    })
+  })
+
+  test('should require agent ID argument', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(baseRoutes, async ({ apiUrl }) => {
+        await expect(callCli(['agents:commit'], getCLIOptions({ apiUrl, builder }))).rejects.toThrow(
+          'missing required argument',
+        )
+      })
+    })
+  })
+})

--- a/tests/integration/commands/agents/agents-pr.test.ts
+++ b/tests/integration/commands/agents/agents-pr.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { callCli } from '../../utils/call-cli.js'
+import { getCLIOptions, withMockApi } from '../../utils/mock-api.js'
+import { withSiteBuilder } from '../../utils/site-builder.js'
+import { mockSiteInfo, mockAgentRunner } from './fixtures.js'
+
+vi.mock('../../../../src/lib/spinner.js', () => ({
+  startSpinner: vi.fn(() => ({ text: 'test' })),
+  stopSpinner: vi.fn(),
+}))
+
+describe('agents:pr command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const baseRoutes = [
+    { path: 'sites/site_id', response: mockSiteInfo },
+    { path: 'sites/site_id/service-instances', response: [] },
+    { path: 'user', response: { name: 'test user' } },
+    { path: 'accounts', response: [{ slug: 'test-account' }] },
+  ]
+
+  test('should create a pull request', async (t) => {
+    const runnerWithPr = {
+      ...mockAgentRunner,
+      pr_url: 'https://github.com/owner/repo/pull/42',
+      pr_branch: 'agent/abc',
+      pr_state: 'open',
+    }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/pull_request',
+        method: 'POST' as const,
+        response: runnerWithPr,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(['agents:pr', 'test_id'], getCLIOptions({ apiUrl, builder }))) as string
+
+        expect(cliResponse).toContain('Pull request created!')
+        expect(cliResponse).toContain('https://github.com/owner/repo/pull/42')
+        expect(cliResponse).toContain('Branch: agent/abc')
+        expect(cliResponse).toContain('State: open')
+      })
+    })
+  })
+
+  test('should report pr_error returned by the API', async (t) => {
+    const runnerWithError = { ...mockAgentRunner, pr_error: 'no diff to base on' }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/pull_request',
+        method: 'POST' as const,
+        response: runnerWithError,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(['agents:pr', 'test_id'], getCLIOptions({ apiUrl, builder }))) as string
+
+        expect(cliResponse).toContain('Pull request failed: no diff to base on')
+      })
+    })
+  })
+
+  test('should report an in-progress pull request creation', async (t) => {
+    const runnerInProgress = { ...mockAgentRunner, pr_is_being_created: true }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/pull_request',
+        method: 'POST' as const,
+        response: runnerInProgress,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(['agents:pr', 'test_id'], getCLIOptions({ apiUrl, builder }))) as string
+
+        expect(cliResponse).toContain('A pull request is being created')
+        expect(cliResponse).not.toContain('Pull request created!')
+      })
+    })
+  })
+
+  test('should return JSON when --json flag is used', async (t) => {
+    const runnerWithPr = { ...mockAgentRunner, pr_url: 'https://github.com/owner/repo/pull/42' }
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/pull_request',
+        method: 'POST' as const,
+        response: runnerWithPr,
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        const cliResponse = (await callCli(
+          ['agents:pr', 'test_id', '--json'],
+          getCLIOptions({ apiUrl, builder }),
+          true,
+        )) as typeof mockAgentRunner & { pr_url: string }
+
+        expect(cliResponse.pr_url).toBe('https://github.com/owner/repo/pull/42')
+      })
+    })
+  })
+
+  test('should handle API errors', async (t) => {
+    const routes = [
+      ...baseRoutes,
+      {
+        path: 'agent_runners/test_id/pull_request',
+        method: 'POST' as const,
+        status: 500,
+        response: { error: 'something went wrong' },
+      },
+    ]
+
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(routes, async ({ apiUrl }) => {
+        await expect(callCli(['agents:pr', 'test_id'], getCLIOptions({ apiUrl, builder }))).rejects.toThrow(
+          'Failed to create pull request: something went wrong',
+        )
+      })
+    })
+  })
+
+  test('should require agent ID argument', async (t) => {
+    await withSiteBuilder(t, async (builder) => {
+      await builder.build()
+
+      await withMockApi(baseRoutes, async ({ apiUrl }) => {
+        await expect(callCli(['agents:pr'], getCLIOptions({ apiUrl, builder }))).rejects.toThrow(
+          'missing required argument',
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
#### Summary

Linear: https://linear.app/netlify/issue/EX-2195

Part 4 of the agents CLI revamp split. Adds two commands that push a run's work out through git.

- `agents:pr` opens a pull request for the run's branch. Refuses on projects without a git remote.
- `agents:commit` commits the run's changes, defaulting to `runner.branch` (or `runner.pr_branch` when a PR is already open). Git-backed projects only.

```
$ netlify agents:pr <id>
✓ Pull request created!
  URL: https://github.com/x/y/pull/1
  Branch: agent-readme-comment-f5a2
  State: Open

$ netlify agents:commit <id>
Default: agent-branch-x (committing to this agent run's branch)
✓ Committed to agent-branch-x
  SHA: abc1234
```

Stacked on the diff/open PR.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you`re fixing a typo or something that`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅
