### PR TITLE
fix: surface zip stderr and exit code in source-zip upload errors

### DIFF
--- a/src/utils/deploy/upload-source-zip.ts
+++ b/src/utils/deploy/upload-source-zip.ts
@@ -121,7 +121,13 @@ export const uploadSourceZip = async ({
     try {
       zipPath = await createSourceZip({ sourceDir, filename, statusCb })
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error)
+      const execError = error as { message?: string; stderr?: string | Buffer; code?: number | string }
+      const stderr = execError.stderr ? String(execError.stderr).trim() : ''
+      const detail = [stderr, execError.code != null ? `exit code ${String(execError.code)}` : '']
+        .filter(Boolean)
+        .join('; ')
+      const baseMsg = error instanceof Error ? error.message : String(error)
+      const errorMsg = detail ? `${baseMsg} (${detail})` : baseMsg
       statusCb({
         type: 'source-zip-upload',
         msg: `Failed to create source zip: ${errorMsg}`,

--- a/tests/unit/utils/deploy/upload-source-zip.test.ts
+++ b/tests/unit/utils/deploy/upload-source-zip.test.ts
@@ -282,6 +282,54 @@ describe('uploadSourceZip', () => {
     expect(mockCommandHelpers.warn).toHaveBeenCalledWith('Failed to create source zip: zip command failed')
   })
 
+  test('surfaces zip stderr and exit code in the error message', async () => {
+    const mockOs = await import('os')
+    vi.mocked(mockOs.platform).mockReturnValue('darwin')
+
+    const { uploadSourceZip } = await import('../../../../src/utils/deploy/upload-source-zip.js')
+
+    const mockChildProcess = await import('child_process')
+    const mockCommandHelpers = await import('../../../../src/utils/command-helpers.js')
+    const mockTempFile = await import('../../../../src/utils/temporary-file.js')
+
+    // util.promisify(execFile) rejects with an error carrying `stderr` and `code`.
+    const zipError = Object.assign(new Error('Command failed: zip -r /tmp/x.zip .'), {
+      stderr: 'zip error: Nothing to do! (/tmp/x.zip)',
+      code: 12,
+    })
+    vi.mocked(mockChildProcess.execFile).mockImplementation((_command, _args, _options, callback) => {
+      if (callback) {
+        callback(zipError, '', '')
+      }
+      return {} as ChildProcess
+    })
+
+    vi.mocked(mockCommandHelpers.warn).mockImplementation(() => {})
+    vi.mocked(mockTempFile.temporaryDirectory).mockReturnValue('/tmp/test-temp-dir')
+
+    const mockStatusCb = vi.fn()
+
+    await expect(
+      uploadSourceZip({
+        sourceDir: '/test/source',
+        uploadUrl: 'https://s3.example.com/upload-url',
+        filename: 'test-source.zip',
+        statusCb: mockStatusCb,
+      }),
+    ).rejects.toThrow('Command failed: zip -r /tmp/x.zip .')
+
+    const expectedMsg =
+      'Failed to create source zip: Command failed: zip -r /tmp/x.zip . (zip error: Nothing to do! (/tmp/x.zip); exit code 12)'
+    expect(mockCommandHelpers.warn).toHaveBeenCalledWith(expectedMsg)
+    expect(mockStatusCb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'source-zip-upload',
+        phase: 'error',
+        msg: expectedMsg,
+      }),
+    )
+  })
+
   test('cleans up zip file even when upload fails', async () => {
     // Ensure OS platform mock returns non-Windows
     const mockOs = await import('os')


### PR DESCRIPTION
## Summary

`netlify deploy --upload-source-zip` shells out to `zip` to build the source snapshot (`createSourceZip` in `src/utils/deploy/upload-source-zip.ts`). On a nonzero exit, `execFile`'s `error.message` is only the generic `Command failed: zip -r …` — the actual reason and exit code live on `error.stderr` / `error.code`, which were discarded. So the failure dead-ends at `Command failed: zip -r …` with no recoverable cause.

## Change

Include `zip`'s `stderr` and exit code in the reported error, e.g.:

```
Failed to create source zip: Command failed: zip -r … (zip error: Nothing to do! (…); exit code 12)
```

instead of the dead-end `Failed to create source zip: Command failed: zip -r …`.

Behavior is otherwise unchanged — the original error is still thrown, so callers and retry logic are unaffected; only the logged/`warn`ed message (and the `source-zip-upload` error status) is enriched.

## Test

Adds a unit test that mirrors how `util.promisify(execFile)` rejects (error carrying `stderr` + `code`) and asserts both are surfaced in the message. Existing tests unchanged and green.

## Why

Fleet telemetry shows this `zip` step failing on a large, steady volume of source-zip uploads with no recoverable reason in the logs. This is intentionally scoped to **make the failure visible** so the underlying cause can be pinpointed with data rather than guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)