### PR TITLE
test: fix edge functions watch-ignore path assertions on Windows

### DIFF
--- a/.github/test-matrix.yml
+++ b/.github/test-matrix.yml
@@ -15,6 +15,13 @@ node_install_overrides:
 # Used by: unit-tests.yml, integration-tests.yml, e2e-tests.yml
 extra_oses_on_release: ['macOS-latest', 'windows-2025']
 
+# Operating systems added to EVERY PR's matrix (primary Node version only), on
+# top of the always-on Linux coverage. Kept minimal — each entry runs on every
+# PR. Overlap with `extra_oses_on_release` is deduplicated by the consuming
+# workflow. Do NOT include ubuntu here.
+# Used by: unit-tests.yml
+extra_oses_always: ['macOS-latest', 'windows-2025']
+
 # The "primary" Node.js version. Two uses:
 #   1. Paired with each of `extra_oses_on_release` in the full matrix.
 #   2. The pinned version for all single-version workflows.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,11 +38,15 @@ jobs:
         run: |
           node_versions=$(yq eval '.node_versions | join(" ")' .github/test-matrix.yml)
           extra_oses=$(yq eval '.extra_oses_on_release | join(" ")' .github/test-matrix.yml)
+          always_oses=$(yq eval '.extra_oses_always | join(" ")' .github/test-matrix.yml)
           primary=$(yq eval '.primary_node_version' .github/test-matrix.yml)
 
           OS_NODE=()
           for node in $node_versions; do
             OS_NODE+=("ubuntu-latest:$node")
+          done
+          for os in $always_oses; do
+            OS_NODE+=("$os:$primary")
           done
           if [[ "$HEAD_REF" == release-please--* ]]; then
             for os in $extra_oses; do
@@ -50,8 +54,11 @@ jobs:
             done
           fi
 
+          declare -A seen
           entries=()
           for combo in "${OS_NODE[@]}"; do
+            [[ -n "${seen[$combo]:-}" ]] && continue
+            seen[$combo]=1
             os="${combo%:*}"
             node="${combo##*:}"
             entries+=("{\"os\":\"$os\",\"node-version\":\"$node\"}")

--- a/tests/unit/lib/edge-functions/watch-ignore.test.ts
+++ b/tests/unit/lib/edge-functions/watch-ignore.test.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'fs'
-import { join } from 'path'
+import { join, resolve } from 'path'
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -208,19 +208,19 @@ describe('constructor path resolution', () => {
 
   test('resolves a relative publishDir against projectDir', () => {
     const registry = new EdgeFunctionsRegistryImpl(makeOptions({ publishDir: '_site' }))
-    expect((registry as unknown as RegistryPrivateState).publishDir).toBe('/project/_site')
+    expect((registry as unknown as RegistryPrivateState).publishDir).toBe(resolve('/project', '_site'))
   })
 
   test('keeps an absolute publishDir unchanged', () => {
     const registry = new EdgeFunctionsRegistryImpl(makeOptions({ publishDir: '/other/_site' }))
-    expect((registry as unknown as RegistryPrivateState).publishDir).toBe('/other/_site')
+    expect((registry as unknown as RegistryPrivateState).publishDir).toBe(resolve('/project', '/other/_site'))
   })
 
   test('resolves relative watchIgnore paths against projectDir', () => {
     const registry = new EdgeFunctionsRegistryImpl(makeOptions({ watchIgnore: ['src/posts', 'content'] }))
     expect((registry as unknown as RegistryPrivateState).watchIgnore).toEqual([
-      '/project/src/posts',
-      '/project/content',
+      resolve('/project', 'src/posts'),
+      resolve('/project', 'content'),
     ])
   })
 
@@ -228,14 +228,17 @@ describe('constructor path resolution', () => {
     const registry = new EdgeFunctionsRegistryImpl(
       makeOptions({ watchIgnore: ['/absolute/src/posts', '/other/content'] }),
     )
-    expect((registry as unknown as RegistryPrivateState).watchIgnore).toEqual(['/absolute/src/posts', '/other/content'])
+    expect((registry as unknown as RegistryPrivateState).watchIgnore).toEqual([
+      resolve('/project', '/absolute/src/posts'),
+      resolve('/project', '/other/content'),
+    ])
   })
 
   test('handles a mix of relative and absolute watchIgnore paths', () => {
     const registry = new EdgeFunctionsRegistryImpl(makeOptions({ watchIgnore: ['src/posts', '/absolute/content'] }))
     expect((registry as unknown as RegistryPrivateState).watchIgnore).toEqual([
-      '/project/src/posts',
-      '/absolute/content',
+      resolve('/project', 'src/posts'),
+      resolve('/project', '/absolute/content'),
     ])
   })
 })


### PR DESCRIPTION
## Summary

Two related changes:

1. **Fix the failing Windows unit tests.** 5 tests in `tests/unit/lib/edge-functions/watch-ignore.test.ts` hardcoded POSIX-style expected paths (e.g. `/project/_site`, `/absolute/src/posts`). The `EdgeFunctionsRegistryImpl` constructor normalizes `publishDir`/`watchIgnore` with `path.resolve(projectDir, …)` (`src/lib/edge-functions/registry.ts:179-180`), which on Windows produces drive-prefixed, backslash paths (`D:\project\_site`), so the assertions could only pass on macOS/Linux:

   ```
   AssertionError: expected 'D:\project\_site' to be '/project/_site'
   AssertionError: expected [ 'D:\project\src\posts', …(1) ] to deeply equal [ '/project/src/posts', …(1) ]
   ```

   Fixed by computing the expected values with the same `resolve('/project', …)` call the implementation uses, so the assertions hold on every platform while still verifying the meaningful behavior (inputs resolved relative to `projectDir`).

2. **Run unit tests on macOS and Windows for every PR.** Since #8199, macOS/Windows test jobs only run on `release-please--*` PRs and the nightly schedule — which is exactly why this regression wasn't caught until it surfaced on the release PR (#8290). This adds a `macOS-latest` and a `windows-2025` job at the primary Node version to every PR's **unit test** matrix, via a new `extra_oses_always` key in `.github/test-matrix.yml`, deduplicated against the release-only OS set so release PRs don't get duplicate jobs. Integration and E2E matrices are unchanged (they remain release/schedule-gated).

## Context

The broken tests were introduced in #8271 (`feat: add watch-ignore flag`), so this failure already exists on `main` — it's not specific to the release PR (#8290) that surfaced it. Once this merges, #8290 goes green on re-run.

## Verification

- `npm exec vitest -- run tests/unit/lib/edge-functions/watch-ignore.test.ts` → 14 passed locally.
- Simulated the updated matrix computation: regular PRs now include `macOS-latest / 24` and `windows-2025 / 24` on top of the always-on Linux coverage; `release-please--*` PRs include each exactly once (deduped).
- With change (2) in place, this PR's own CI now runs the macOS and Windows unit jobs and validates the fix directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)