### PR TITLE
chore: add context7.json to claim ownership

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/netlify/cli",
+  "public_key": "pk_o1kJHj61VuNZdp8u5vsq0"
+}


### PR DESCRIPTION
Adds a `context7.json` to the repo root so we can claim ownership of this project on Context7.

Once this is merged, ownership can be managed at https://context7.com/netlify/cli/admin

Linear: AX-44