### PR TITLE
fix: don't crash the CLI when the upstream dev server dies mid-response

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -556,6 +556,15 @@ const initializeProxy = async function ({
     }
 
     if (res instanceof http.ServerResponse) {
+      if (res.headersSent || res.writableEnded) {
+        // The upstream died mid-response: headers are already on the wire, so
+        // `writeHead` below would throw ERR_HTTP_HEADERS_SENT out of this event
+        // handler and terminate the whole CLI (see #5917). The response is
+        // unsalvageable — drop the socket and keep the dev server alive so
+        // requests after the upstream comes back succeed.
+        res.destroy()
+        return
+      }
       res.writeHead(500, {
         'Content-Type': 'text/plain',
       })


### PR DESCRIPTION
## Summary

Fixes the crash class tracked in #5917 (also #7060, #5676): when the framework dev server that `netlify dev` proxies to dies **mid-response**, the proxy's error handler calls `res.writeHead(500, …)` on a response whose headers are already on the wire. `ERR_HTTP_HEADERS_SENT` is thrown out of an event handler, and the whole CLI terminates:

```
Error: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:354:11)
    at ProxyServer.<anonymous> (src/utils/proxy.ts:559:11)
    at ClientRequest.proxyError (http-proxy/lib/http-proxy/passes/web-incoming.js:165:18)
⬥ Netlify CLI has terminated unexpectedly.
```

One condition fixes it: if `res.headersSent || res.writableEnded`, the response is unsalvageable — destroy the socket and return, instead of throwing. The one in-flight request was doomed either way; the CLI survives, and requests after the upstream recovers succeed.

## Deterministic reproduction

This crash has historically been hard to pin ("sometimes when I save a file", #5917). Next.js provides a deterministic trigger: its dev server **restarts itself** when the V8 heap passes 80% of its limit (`next/dist/server/lib/start-server.js` → `process.exit(RESTART_EXIT_CODE)`), expecting its supervisor to bring it back — which it does, in ~3s. Any request mid-flight through netlify-cli's proxy at that moment hits this handler with headers already sent.

Repro: `netlify dev` wrapping a large Next 16 app, drive sustained browser traffic (we used a ~480-test Playwright suite) until Next logs `Server is approaching the used memory threshold, restarting...`. Unpatched: the CLI died on this line in 2 of 2 runs at that moment. Patched (same workload, same default heap): 2 restarts occurred, CLI survived both, zero `ERR_CONNECTION_REFUSED` in the suite — 457/486 tests passed vs. a cascade of 289 spurious failures when the CLI dies.

## Notes

- `writableEnded` is included alongside `headersSent` because `res.end()` after end also errors; ended implies headers sent for HTTP/1, so this is belt-and-braces.
- The Socket (upgrade) path is unchanged.
- Scoped deliberately to the error handler — the crash site with three linked issues — rather than guarding all `writeHead` call sites.
