### PR TITLE
fix(edge-functions): point the bootstrap fallback at server.ts

### DIFF
--- a/src/lib/edge-functions/bootstrap.ts
+++ b/src/lib/edge-functions/bootstrap.ts
@@ -4,7 +4,7 @@ import { getURL } from '@netlify/edge-functions-bootstrap/version'
 
 import { warn } from '../../utils/command-helpers.js'
 
-export const FALLBACK_BOOTSTRAP_URL = 'https://edge.netlify.com/bootstrap/index-combined.ts'
+export const FALLBACK_BOOTSTRAP_URL = 'https://edge.netlify.com/bootstrap/server.ts'
 
 export const getBootstrapURL = async () => {
   if (env.NETLIFY_EDGE_BOOTSTRAP) {

--- a/tests/unit/lib/edge-functions/bootstrap.test.ts
+++ b/tests/unit/lib/edge-functions/bootstrap.test.ts
@@ -29,4 +29,13 @@ describe('`getBootstrapURL()`', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toMatch(/^application\/typescript/)
   })
+
+  test('Falls back to a publicly accessible URL', { retry: 3 }, async () => {
+    // The fallback is what serves edge functions when the version lookup fails,
+    // so a typo in it stays invisible until that happens in the wild.
+    const res = await fetch(FALLBACK_BOOTSTRAP_URL)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/^application\/typescript/)
+  })
 })


### PR DESCRIPTION
`index-combined.ts` was a four-line re-export barrel in front of the bootstrap's `server.ts`, and it is being retired - `server.ts` exports the same function and patches globals on import, so it is a drop-in for local dev