### PR TITLE
fix(database): pull migrations from an explicit branch

### DIFF
--- a/src/commands/database/db-migration-pull.ts
+++ b/src/commands/database/db-migration-pull.ts
@@ -77,11 +77,9 @@ const getApiContext = (command: BaseCommand): ApiContext => {
   }
 }
 
-const fetchMigrations = async (ctx: ApiContext, branch: string | undefined): Promise<MigrationListItem[]> => {
+const fetchMigrations = async (ctx: ApiContext, branch: string): Promise<MigrationListItem[]> => {
   const url = new URL(`${ctx.basePath}/sites/${encodeURIComponent(ctx.siteId)}/database/migrations`)
-  if (branch) {
-    url.searchParams.set('branch', branch)
-  }
+  url.searchParams.set('branch', branch)
 
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${ctx.token}` },
@@ -96,13 +94,11 @@ const fetchMigrations = async (ctx: ApiContext, branch: string | undefined): Pro
   return data.migrations
 }
 
-const fetchMigrationContent = async (ctx: ApiContext, name: string, branch: string | undefined): Promise<string> => {
+const fetchMigrationContent = async (ctx: ApiContext, name: string, branch: string): Promise<string> => {
   const url = new URL(
     `${ctx.basePath}/sites/${encodeURIComponent(ctx.siteId)}/database/migrations/${encodeURIComponent(name)}`,
   )
-  if (branch) {
-    url.searchParams.set('branch', branch)
-  }
+  url.searchParams.set('branch', branch)
 
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${ctx.token}` },
@@ -120,16 +116,19 @@ const fetchMigrationContent = async (ctx: ApiContext, name: string, branch: stri
 export const migrationPull = async (options: MigrationPullOptions, command: BaseCommand) => {
   const { force, json } = options
 
-  const branch = (await resolveBranch(options.branch)) ?? process.env.NETLIFY_DB_BRANCH
-  const source = branch ?? PRODUCTION_BRANCH
+  // Always resolve to an explicit branch. Leaving it undefined makes the detail
+  // endpoint fall back to the published deploy, which 404s for a migration that
+  // was applied and later deleted from the repo — the files this command exists
+  // to restore. It also made the request disagree with the branch reported below.
+  const branch = (await resolveBranch(options.branch)) ?? process.env.NETLIFY_DB_BRANCH ?? PRODUCTION_BRANCH
   const ctx = getApiContext(command)
   const migrations = await fetchMigrations(ctx, branch)
 
   if (migrations.length === 0) {
     if (json) {
-      logJson({ migrations_pulled: 0, branch: source })
+      logJson({ migrations_pulled: 0, branch })
     } else {
-      log(`No migrations found for ${source}.`)
+      log(`No migrations found for ${branch}.`)
     }
     return
   }
@@ -155,7 +154,7 @@ export const migrationPull = async (options: MigrationPullOptions, command: Base
         name: 'confirmed',
         message: `This will overwrite all local migrations in ${migrationsDirectory} with ${String(
           migrations.length,
-        )} migration${migrations.length === 1 ? '' : 's'} from ${source}. Continue?`,
+        )} migration${migrations.length === 1 ? '' : 's'} from ${branch}. Continue?`,
         default: false,
       },
     ])
@@ -178,11 +177,11 @@ export const migrationPull = async (options: MigrationPullOptions, command: Base
   if (json) {
     logJson({
       migrations_pulled: migrations.length,
-      branch: source,
+      branch,
       migrations: migrations.map((m) => m.name),
     })
   } else {
-    log(`Pulled ${String(migrations.length)} migration${migrations.length === 1 ? '' : 's'} from ${source}:`)
+    log(`Pulled ${String(migrations.length)} migration${migrations.length === 1 ? '' : 's'} from ${branch}:`)
     for (const migration of migrations) {
       log(`  - ${migration.name}`)
     }

--- a/tests/unit/commands/database/db-migration-pull.test.ts
+++ b/tests/unit/commands/database/db-migration-pull.test.ts
@@ -153,7 +153,9 @@ describe('migrationPull', () => {
     await migrationPull({}, createMockCommand())
 
     const calledUrl = mockFetch.mock.calls[0][0] as URL
-    expect(calledUrl.toString()).toBe('https://api.netlify.com/api/v1/sites/site-123/database/migrations')
+    expect(calledUrl.toString()).toBe(
+      'https://api.netlify.com/api/v1/sites/site-123/database/migrations?branch=production',
+    )
     expect(mockFetch.mock.calls[0][1]).toEqual({ headers: { Authorization: 'Bearer test-token' } })
   })
 
@@ -168,12 +170,26 @@ describe('migrationPull', () => {
 
     expect(detailCalls).toHaveLength(2)
     expect(detailCalls.map((u) => u.toString()).sort()).toEqual([
-      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0001_create-users',
-      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0002_add-posts',
+      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0001_create-users?branch=production',
+      'https://api.netlify.com/api/v1/sites/site-123/database/migrations/0002_add-posts?branch=production',
     ])
     for (const call of mockFetch.mock.calls) {
       expect(call[1]).toEqual({ headers: { Authorization: 'Bearer test-token' } })
     }
+  })
+
+  test('requests the production branch it reports pulling from when none is given', async () => {
+    // Sending no branch makes the detail endpoint resolve against the published
+    // deploy, which 404s for a migration that was applied and later deleted from
+    // the repo — exactly the files this command exists to restore.
+    mockFetchResponse(sampleMigrations)
+
+    await migrationPull({ force: true }, createMockCommand())
+
+    const branches = mockFetch.mock.calls.map((call) => (call[0] as URL).searchParams.get('branch'))
+    expect(branches.length).toBeGreaterThan(0)
+    expect([...new Set(branches)]).toEqual(['production'])
+    expect(logMessages.join('\n')).toContain('from production')
   })
 
   test('forwards branch to both list and detail endpoints', async () => {
@@ -393,13 +409,13 @@ describe('migrationPull', () => {
       expect(calledUrl.searchParams.get('branch')).toBe('feature/my-branch')
     })
 
-    test('does not send branch query parameter when --branch is not used', async () => {
+    test('sends the production branch explicitly when --branch is not used', async () => {
       mockFetchResponse(sampleMigrations)
 
       await migrationPull({ force: true }, createMockCommand())
 
       const calledUrl = mockFetch.mock.calls[0][0] as URL
-      expect(calledUrl.searchParams.has('branch')).toBe(false)
+      expect(calledUrl.searchParams.get('branch')).toBe('production')
     })
 
     test('uses branch name in log messages', async () => {


### PR DESCRIPTION
#### Summary

`netlify db migrations pull` left the branch undefined unless --branch was passed, so neither request carried a branch query parameter. The list endpoint defaults to production server-side and returned the full set, but the detail endpoint fell back to the site's published deploy, whose manifest no longer lists a migration that was applied and later deleted from the repo. The command therefore failed with a 404 on exactly the files it exists to restore, while reporting "production" as the source it had pulled from.

Resolve the branch to production when neither --branch nor NETLIFY_DB_BRANCH is set, and always send it. The fetch helpers now take a required branch so the parameter cannot silently go missing again. This also makes the reported source match the branch actually requested.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we
      can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
