### PR TITLE
test: retain process.env when overriding NETLIFY vars

### DIFF
--- a/tests/integration/commands/build/build-program.test.ts
+++ b/tests/integration/commands/build/build-program.test.ts
@@ -71,7 +71,7 @@ describe('command/build', () => {
       // eslint-disable-next-line no-restricted-properties
       process.cwd = () => builder.directory
       await withMockApi(routes, async ({ apiUrl }) => {
-        process.env = getEnvironmentVariables({ apiUrl })
+        process.env = { ...originalEnv, ...getEnvironmentVariables({ apiUrl }) }
 
         await builder.withNetlifyToml({ config: {} }).withStateFile({ siteId: siteInfo.id }).build()
 


### PR DESCRIPTION
The previous code was nuking the entire `process.env` which meant some built-in tools like `os.tmpdir()` would be `undefined` on Windows (as it depends on `env.TEMP` or some such thing existing).

We should be able to safely extend the existing env instead of overwriting it.

I suspect this will fix:
https://github.com/netlify/cli/actions/runs/31727425876/job/94549735809#step:10:286

Since that error happens when joining an `undefined` tmpdir.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻. This ensures we
      can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
