### PR TITLE
fix: trim whitespace in redirect from and to addresses

### DIFF
--- a/src/utils/redirects.ts
+++ b/src/utils/redirects.ts
@@ -36,6 +36,11 @@ const getErrorMessage = function ({ message }) {
 //  - `from` is called `origin`
 //  - `query` is called `params`
 //  - `conditions.role|country|language` are capitalized
+// Leading and trailing whitespace in `from` and `to` is trimmed so that typos
+// such as `to = " https://example.com"` do not silently break redirects
+// (see https://github.com/netlify/cli/issues/4707).
+const trimValue = (value) => (typeof value === 'string' ? value.trim() : value)
+
 const normalizeRedirect = function ({
   // @ts-expect-error TS(7031) FIXME: Binding element 'country' implicitly has an 'any' ... Remove this comment to see the full error message
   conditions: { country, language, role, ...conditions },
@@ -45,11 +50,15 @@ const normalizeRedirect = function ({
   query,
   // @ts-expect-error TS(7031) FIXME: Binding element 'signed' implicitly has an 'any' t... Remove this comment to see the full error message
   signed,
+  // @ts-expect-error TS(7031) FIXME: Binding element 'to' implicitly has an 'any type...
+  to,
   ...redirect
 }) {
   return {
     ...redirect,
-    origin: from,
+    origin: trimValue(from),
+    path: trimValue(from),
+    to: trimValue(to),
     params: query,
     conditions: {
       ...conditions,

--- a/tests/unit/utils/redirects.test.ts
+++ b/tests/unit/utils/redirects.test.ts
@@ -230,3 +230,29 @@ test('should parse redirect rules from _redirects file and netlify.toml', async 
     expect(redirects).toEqual(expected)
   })
 })
+
+test('should trim leading and trailing whitespace from redirect `from` and `to`', async (t) => {
+  await withSiteBuilder(t, async (builder) => {
+    await builder
+      .withNetlifyToml({
+        config: {
+          redirects: [
+            {
+              from: ' /leading-space ',
+              status: 200,
+              to: ' https://www.netlify.com ',
+            },
+          ],
+        },
+      })
+      .build()
+
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ configPath: string; }' is not ... Remove this comment to see the full error message
+    const redirects = await parseRedirects({ configPath: `${builder.directory}/netlify.toml` })
+    expect(redirects[0]).toMatchObject({
+      origin: '/leading-space',
+      path: '/leading-space',
+      to: 'https://www.netlify.com',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Redirects silently failed to match when a leading or trailing space was present in the `from` or `to` address, for example:

```toml
[[redirects]]
  from = "/test"
  to = " https://www.netlify.com"
  status = 200
```

This is a common typo that is very hard to spot. This PR trims whitespace from `from` (which becomes both `origin` and `path` after normalization) and `to` in the redirect normalizer, so such typos no longer break redirects silently.

## Changes

- `src/utils/redirects.ts`: added a `trimValue` helper and applied it to `origin`, `path` and `to` in `normalizeRedirect`
- `tests/unit/utils/redirects.test.ts`: added a regression test covering a whitespace-padded `from` and `to`

## Verification

`npx vitest run tests/unit/utils/redirects.test.ts` - all 4 tests pass, including the new regression test.

Fixes #4707