### PR TITLE
fix(deps): move local-functions-proxy to optionalDependencies for --omit=optional support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@netlify/edge-functions-bootstrap": "^3.2.0",
     "@netlify/headers-parser": "^10.1.1",
     "@netlify/images": "^1.3.12",
-    "@netlify/local-functions-proxy": "^2.0.3",
     "@netlify/redirect-parser": "^16.1.0",
     "@netlify/zip-it-and-ship-it": "^15.3.3",
     "@octokit/rest": "^22.0.0",
@@ -214,6 +213,9 @@
     "typescript-native": "npm:typescript@~7.0.2",
     "verdaccio": "^6.3.2",
     "vitest": "^3.2.4"
+  },
+  "optionalDependencies": {
+    "@netlify/local-functions-proxy": "^2.0.3"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/src/lib/functions/local-proxy.ts
+++ b/src/lib/functions/local-proxy.ts
@@ -1,8 +1,20 @@
 import { stdout } from 'process'
-
-import { getBinaryPath as getFunctionsProxyPath } from '@netlify/local-functions-proxy'
-
 import execa from '../../utils/execa.js'
+
+let getFunctionsProxyPath: (() => Promise<string | null>) | null = null
+
+async function loadFunctionsProxy() {
+  if (getFunctionsProxyPath === null) {
+    try {
+      const mod = await import('@netlify/local-functions-proxy')
+      getFunctionsProxyPath = mod.getBinaryPath
+    } catch {
+      // Package not installed (e.g., when using --omit=optional)
+      getFunctionsProxyPath = () => Promise.resolve(null)
+    }
+  }
+  return getFunctionsProxyPath
+}
 
 export const runFunctionsProxy = async ({
   binaryPath,
@@ -19,7 +31,8 @@ export const runFunctionsProxy = async ({
   name: string
   timeout: number
 }) => {
-  const functionsProxyPath = await getFunctionsProxyPath()
+  const getBinaryPath = await loadFunctionsProxy()
+  const functionsProxyPath = await getBinaryPath()
   const requestData = {
     resource: '',
     ...event,
@@ -33,11 +46,9 @@ export const runFunctionsProxy = async ({
       requestTimeEpoch: 0,
     },
   }
-
   if (functionsProxyPath === null) {
     throw new Error('Host machine does not support local functions proxy server')
   }
-
   const parameters = [
     '--event',
     JSON.stringify(requestData),
@@ -51,8 +62,6 @@ export const runFunctionsProxy = async ({
     `${timeout.toString()}s`,
   ]
   const proxyProcess = execa(functionsProxyPath, parameters)
-
   proxyProcess.stderr?.pipe(stdout)
-
   return proxyProcess
 }


### PR DESCRIPTION
## Problem

`netlify-cli@26.2.0` installs the `@netlify/local-functions-proxy-linux-x64@1.1.1` platform binary even when npm is invoked with `--omit=optional`. This happens because the dependency is in regular `dependencies` rather than `optionalDependencies`, so npm does not respect the `--omit=optional` flag for it.

The bundled Go binary has flagged security vulnerabilities including:
- CVE-2023-24538
- CVE-2023-24540
- CVE-2024-24790
- CVE-2025-68121

## Solution

1. **Moved `@netlify/local-functions-proxy` from `dependencies` to `optionalDependencies`** in `package.json`. This ensures that `npm install --omit=optional` will skip the platform-specific binary packages.

2. **Changed the import in `src/lib/functions/local-proxy.ts` from a static import to a dynamic import** with error handling. When the package is not installed (e.g., with `--omit=optional`), the CLI still works but local functions proxy is unavailable — a clear error is thrown when the user tries to use local functions.

## Testing

- TypeScript compiles cleanly (`npm run build` passes)
- ESLint clean
- Prettier/oxfmt formatted
- The CLI still works without local functions proxy when the package is not installed

Fixes #8342