### PR TITLE
fix: resolve package.json from the function's directory in detectZisiBuilder

### DIFF
--- a/src/lib/functions/runtimes/js/builders/zisi.ts
+++ b/src/lib/functions/runtimes/js/builders/zisi.ts
@@ -186,8 +186,7 @@ export default async function detectZisiBuilder({
 }) {
   const functionsConfig = netlifyConfigToZisiConfig({ config, projectRoot })
 
-  // @ts-expect-error(serhalp) -- We seem to be incorrectly using this function, but it seems to work... Investigate.
-  const packageJson = await readPackageUp(func.mainFile)
+  const packageJson = await readPackageUp({ cwd: path.dirname(func.mainFile) })
   const hasTypeModule = packageJson?.packageJson.type === 'module'
 
   const featureFlags: FeatureFlags = {}


### PR DESCRIPTION
## Summary

Fixes #8423.

`detectZisiBuilder` passed `func.mainFile` (a string) to `readPackageUp`, but `read-package-up` expects an options object (`{ cwd }`). The string was silently ignored and the `package.json` lookup fell back to `process.cwd()` — the pre-existing `@ts-expect-error` TODO on that line ("We seem to be incorrectly using this function, but it seems to work... Investigate.") was flagging exactly this.

When `netlify dev` runs with `--cwd <project>` from a directory outside the project (the CLI honors `--cwd` for config resolution but never `process.chdir()`s), no `package.json` is found, `hasTypeModule` is incorrectly `false`, and the `{"type":"commonjs"}` marker is never written into the functions-serve directories. In a project whose root `package.json` has `"type": "module"`, every zisi/esbuild CJS function bundle is then parsed as ESM and every function invocation 500s with `ReferenceError: module is not defined in ES module scope`.

This resolves the lookup from the function's own directory instead, which is exactly what `@netlify/functions-dev` already does in its equivalent code path (`readPackageUp({ cwd: path.dirname(func.mainFile) })`), and lets the `@ts-expect-error` be dropped.

## Testing

- `npm run typecheck` passes (the `@ts-expect-error` removal confirms the call now matches the library's types).
- Manually verified against a real project (root `package.json` with `"type": "module"`, v1 `.ts` function, `node_bundler = "esbuild"`): running `netlify dev --cwd <repo>` from an outside directory previously 500'd every function with `module is not defined in ES module scope`; with this change the `{"type":"commonjs"}` marker is written into each `.netlify/functions-serve/<name>/` directory and all functions respond normally. Running from inside the repo is unaffected.

There are currently no unit tests covering `detectZisiBuilder` — happy to add one if you can point me at the preferred harness for this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
