### PR TITLE
fix(database): render every statement of a multi-statement query

### DIFF
--- a/src/commands/database/db-connect.ts
+++ b/src/commands/database/db-connect.ts
@@ -4,7 +4,7 @@ import { log, logJson } from '../../utils/command-helpers.js'
 import BaseCommand from '../base-command.js'
 import { connectRawClient } from './util/db-connection.js'
 import { executeMetaCommand } from './util/meta-commands.js'
-import { formatQueryResult } from './util/psql-formatter.js'
+import { formatQueryResult, formatStatementResults, lastRowSet } from './util/psql-formatter.js'
 
 export interface ConnectOptions {
   query?: string
@@ -44,9 +44,9 @@ export const connect = async (options: ConnectOptions, command: BaseCommand): Pr
     try {
       const result = await client.query<Record<string, unknown>>(options.query)
       if (options.json) {
-        logJson(result.rows)
+        logJson(lastRowSet(result))
       } else {
-        log(formatQueryResult(result.fields, result.rows, result.rowCount, result.command))
+        log(formatStatementResults(result))
       }
     } finally {
       await cleanup()
@@ -126,7 +126,7 @@ export const connect = async (options: ConnectOptions, command: BaseCommand): Pr
       void (async () => {
         try {
           const result = await client.query<Record<string, unknown>>(sql)
-          log(formatQueryResult(result.fields, result.rows, result.rowCount, result.command))
+          log(formatStatementResults(result))
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           log(`ERROR:  ${message}`)

--- a/src/commands/database/util/psql-formatter.ts
+++ b/src/commands/database/util/psql-formatter.ts
@@ -1,4 +1,6 @@
-import type { FieldDef } from 'pg'
+import type { FieldDef, QueryResult } from 'pg'
+
+type StatementResult = QueryResult<Record<string, unknown>>
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined) {
@@ -63,3 +65,19 @@ export const formatQueryResult = (
 
   return lines.join('\n')
 }
+
+// pg resolves a simple query to one `Result` per statement when the SQL holds
+// more than one statement, and to a bare `Result` when it holds exactly one.
+const toStatementResults = (result: StatementResult | StatementResult[]): StatementResult[] =>
+  Array.isArray(result) ? result : [result]
+
+export const formatStatementResults = (result: StatementResult | StatementResult[]): string =>
+  toStatementResults(result)
+    .map(({ fields, rows, rowCount, command }) => formatQueryResult(fields, rows, rowCount, command))
+    .join('\n')
+
+// Rows to emit for `--json`: those of the last statement that returned a row
+// set, so a scripted `BEGIN; SELECT ...; COMMIT;` yields the SELECT's rows
+// rather than COMMIT's empty one. Always an array, whatever the statement count.
+export const lastRowSet = (result: StatementResult | StatementResult[]): Record<string, unknown>[] =>
+  toStatementResults(result).findLast(({ fields }) => fields.length > 0)?.rows ?? []

--- a/tests/unit/commands/database/db-connect.test.ts
+++ b/tests/unit/commands/database/db-connect.test.ts
@@ -33,13 +33,19 @@ vi.mock('../../../../src/utils/command-helpers.js', async () => ({
 
 import { connect } from '../../../../src/commands/database/db-connect.js'
 
-const makeField = (name: string): FieldDef =>
-  ({ name, tableID: 0, columnID: 0, dataTypeID: 23, dataTypeSize: 4, dataTypeModifier: -1, format: 'text' })
+const makeField = (name: string): FieldDef => ({
+  name,
+  tableID: 0,
+  columnID: 0,
+  dataTypeID: 23,
+  dataTypeSize: 4,
+  dataTypeModifier: -1,
+  format: 'text',
+})
 
 const makeResult = (
   overrides: Partial<QueryResult<Record<string, unknown>>> & { command: string },
-): QueryResult<Record<string, unknown>> =>
-  ({ fields: [], rows: [], rowCount: null, oid: 0, ...overrides })
+): QueryResult<Record<string, unknown>> => ({ fields: [], rows: [], rowCount: null, oid: 0, ...overrides })
 
 // pg resolves a multi-statement simple query to one result per statement.
 const TRANSACTION_RESULTS = [

--- a/tests/unit/commands/database/db-connect.test.ts
+++ b/tests/unit/commands/database/db-connect.test.ts
@@ -1,0 +1,99 @@
+import type { FieldDef, QueryResult } from 'pg'
+
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { mockQuery, mockCleanup, logMessages, jsonMessages } = vi.hoisted(() => {
+  const mockQuery = vi.fn()
+  const mockCleanup = vi.fn().mockResolvedValue(undefined)
+  const logMessages: string[] = []
+  const jsonMessages: unknown[] = []
+  return { mockQuery, mockCleanup, logMessages, jsonMessages }
+})
+
+vi.mock('../../../../src/commands/database/util/db-connection.js', () => ({
+  connectRawClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      client: { query: (...args: unknown[]) => mockQuery(...args) },
+      connectionString: 'postgres://user:pw@localhost:5432/postgres',
+      cleanup: mockCleanup,
+    }),
+  ),
+}))
+
+vi.mock('../../../../src/utils/command-helpers.js', async () => ({
+  ...(await vi.importActual('../../../../src/utils/command-helpers.js')),
+  log: (...args: string[]) => {
+    logMessages.push(args.join(' '))
+  },
+  logJson: (message: unknown) => {
+    jsonMessages.push(message)
+  },
+}))
+
+import { connect } from '../../../../src/commands/database/db-connect.js'
+
+const makeField = (name: string): FieldDef =>
+  ({ name, tableID: 0, columnID: 0, dataTypeID: 23, dataTypeSize: 4, dataTypeModifier: -1, format: 'text' })
+
+const makeResult = (
+  overrides: Partial<QueryResult<Record<string, unknown>>> & { command: string },
+): QueryResult<Record<string, unknown>> =>
+  ({ fields: [], rows: [], rowCount: null, oid: 0, ...overrides })
+
+// pg resolves a multi-statement simple query to one result per statement.
+const TRANSACTION_RESULTS = [
+  makeResult({ command: 'BEGIN' }),
+  makeResult({ command: 'SELECT', fields: [makeField('value')], rows: [{ value: 1 }], rowCount: 1 }),
+  makeResult({ command: 'COMMIT' }),
+]
+
+const createMockCommand = () =>
+  ({
+    project: { root: '/project', baseDirectory: undefined },
+    netlify: { site: { root: '/project' }, config: {} },
+  }) as unknown as Parameters<typeof connect>[1]
+
+const TRANSACTION_QUERY = 'BEGIN; SELECT 1 AS value; COMMIT;'
+
+describe('connect --query', () => {
+  beforeEach(() => {
+    logMessages.length = 0
+    jsonMessages.length = 0
+    vi.clearAllMocks()
+    mockCleanup.mockResolvedValue(undefined)
+  })
+
+  test('renders every statement of a transaction instead of throwing', async () => {
+    mockQuery.mockResolvedValue(TRANSACTION_RESULTS)
+
+    await connect({ query: TRANSACTION_QUERY }, createMockCommand())
+
+    expect(logMessages.join('\n')).toContain(['BEGIN', ' value ', '-------', ' 1     ', '(1 row)', 'COMMIT'].join('\n'))
+    expect(mockCleanup).toHaveBeenCalledOnce()
+  })
+
+  test('outputs the rows of the transaction as JSON with --json', async () => {
+    mockQuery.mockResolvedValue(TRANSACTION_RESULTS)
+
+    await connect({ query: TRANSACTION_QUERY, json: true }, createMockCommand())
+
+    expect(jsonMessages).toEqual([[{ value: 1 }]])
+  })
+
+  test('renders a single-statement query', async () => {
+    mockQuery.mockResolvedValue(TRANSACTION_RESULTS[1])
+
+    await connect({ query: 'SELECT 1 AS value;' }, createMockCommand())
+
+    expect(logMessages.join('\n')).toContain([' value ', '-------', ' 1     ', '(1 row)'].join('\n'))
+  })
+
+  test('redacts credentials from the logged connection string', async () => {
+    mockQuery.mockResolvedValue(TRANSACTION_RESULTS[1])
+
+    await connect({ query: 'SELECT 1 AS value;' }, createMockCommand())
+
+    expect(logMessages[0]).toBe('Connected to postgres://localhost:5432/postgres')
+  })
+})

--- a/tests/unit/commands/database/util/psql-formatter.test.ts
+++ b/tests/unit/commands/database/util/psql-formatter.test.ts
@@ -8,19 +8,25 @@ import {
   lastRowSet,
 } from '../../../../../src/commands/database/util/psql-formatter.js'
 
-const makeField = (name: string): FieldDef =>
-  ({ name, tableID: 0, columnID: 0, dataTypeID: 23, dataTypeSize: 4, dataTypeModifier: -1, format: 'text' })
+const makeField = (name: string): FieldDef => ({
+  name,
+  tableID: 0,
+  columnID: 0,
+  dataTypeID: 23,
+  dataTypeSize: 4,
+  dataTypeModifier: -1,
+  format: 'text',
+})
 
 const makeResult = (
   overrides: Partial<QueryResult<Record<string, unknown>>> & { command: string },
-): QueryResult<Record<string, unknown>> =>
-  ({
-    fields: [],
-    rows: [],
-    rowCount: null,
-    oid: 0,
-    ...overrides,
-  })
+): QueryResult<Record<string, unknown>> => ({
+  fields: [],
+  rows: [],
+  rowCount: null,
+  oid: 0,
+  ...overrides,
+})
 
 const BEGIN = makeResult({ command: 'BEGIN' })
 const COMMIT = makeResult({ command: 'COMMIT' })

--- a/tests/unit/commands/database/util/psql-formatter.test.ts
+++ b/tests/unit/commands/database/util/psql-formatter.test.ts
@@ -1,0 +1,78 @@
+import type { FieldDef, QueryResult } from 'pg'
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  formatQueryResult,
+  formatStatementResults,
+  lastRowSet,
+} from '../../../../../src/commands/database/util/psql-formatter.js'
+
+const makeField = (name: string): FieldDef =>
+  ({ name, tableID: 0, columnID: 0, dataTypeID: 23, dataTypeSize: 4, dataTypeModifier: -1, format: 'text' })
+
+const makeResult = (
+  overrides: Partial<QueryResult<Record<string, unknown>>> & { command: string },
+): QueryResult<Record<string, unknown>> =>
+  ({
+    fields: [],
+    rows: [],
+    rowCount: null,
+    oid: 0,
+    ...overrides,
+  })
+
+const BEGIN = makeResult({ command: 'BEGIN' })
+const COMMIT = makeResult({ command: 'COMMIT' })
+const SELECT_ONE = makeResult({
+  command: 'SELECT',
+  fields: [makeField('value')],
+  rows: [{ value: 1 }],
+  rowCount: 1,
+})
+const INSERT_TWO = makeResult({ command: 'INSERT', rowCount: 2 })
+
+const SELECT_ONE_BLOCK = [' value ', '-------', ' 1     ', '(1 row)'].join('\n')
+
+describe('formatStatementResults', () => {
+  test('formats a bare result from a single-statement query', () => {
+    expect(formatStatementResults(SELECT_ONE)).toBe(SELECT_ONE_BLOCK)
+  })
+
+  test('formats one block per statement for a multi-statement transaction', () => {
+    expect(formatStatementResults([BEGIN, SELECT_ONE, COMMIT])).toBe(`BEGIN\n${SELECT_ONE_BLOCK}\nCOMMIT`)
+  })
+
+  test('formats a multi-statement query whose final statement returns no rows', () => {
+    expect(formatStatementResults([BEGIN, INSERT_TWO, COMMIT])).toBe('BEGIN\nINSERT 0 2\nCOMMIT')
+  })
+
+  test('formats an empty result list as an empty string', () => {
+    expect(formatStatementResults([])).toBe('')
+  })
+})
+
+describe('lastRowSet', () => {
+  test('returns the rows of a single-statement query', () => {
+    expect(lastRowSet(SELECT_ONE)).toEqual([{ value: 1 }])
+  })
+
+  test('returns the rows of the last row-returning statement, ignoring the trailing COMMIT', () => {
+    expect(lastRowSet([BEGIN, SELECT_ONE, COMMIT])).toEqual([{ value: 1 }])
+  })
+
+  test('returns the last row set when several statements return rows', () => {
+    const other = makeResult({ command: 'SELECT', fields: [makeField('other')], rows: [{ other: 2 }], rowCount: 1 })
+    expect(lastRowSet([SELECT_ONE, other])).toEqual([{ other: 2 }])
+  })
+
+  test('returns an empty array when no statement returned a row set', () => {
+    expect(lastRowSet([BEGIN, INSERT_TWO, COMMIT])).toEqual([])
+  })
+})
+
+describe('formatQueryResult', () => {
+  test('reports the command tag for a statement with no row set', () => {
+    expect(formatQueryResult([], [], null, 'COMMIT')).toBe('COMMIT')
+  })
+})


### PR DESCRIPTION
`netlify database connect --query` exited with code 1 on any multi-statement query, failing with `TypeError: Cannot read properties of undefined (reading 'length')`. The statements had already run and committed by then, so callers saw a false failure and could retry writes that were already applied.

Repro: `netlify database connect --query "BEGIN; SELECT 1 AS value; COMMIT;"`

Cause: pg returns one result per statement for multi-statement SQL, but a bare result for a single statement. Only the single-statement shape was handled. `COMMIT` isn't special — any query with two or more statements hits this.

Now each statement renders as its own psql-style block, and `--json` emits the rows of the last statement that returned a row set. The interactive REPL hit the same bug and is fixed too.

Fixes RUN-3229
