### PR TITLE
feat: forward agent runner ids on deploy creation

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -40,6 +40,7 @@ import {
 } from '../../utils/command-helpers.js'
 import { DEFAULT_CONCURRENT_HASH, DEFAULT_DEPLOY_TIMEOUT } from '../../utils/deploy/constants.js'
 import { type DeployEvent, deploySite } from '../../utils/deploy/deploy-site.js'
+import { getDeploySourceFields } from '../../utils/deploy/deploy-source.js'
 import { uploadSourceZip } from '../../utils/deploy/upload-source-zip.js'
 import { getEnvelopeEnv } from '../../utils/env/index.js'
 import { mergeDeployEnvVars } from '../../utils/env/deploy-env-vars.js'
@@ -600,7 +601,7 @@ const runDeploy = async ({
         draft,
         branch: alias,
         include_upload_url: options.uploadSourceZip,
-        deploy_source: process.env.NETLIFY_DEPLOY_SOURCE || 'cli',
+        ...getDeploySourceFields(),
       }
 
       const createDeployResponse = await api.createSiteDeploy({ siteId, title, body: createDeployBody })
@@ -1390,7 +1391,7 @@ export const deploy = async (options: DeployOptionValues, command: BaseCommand) 
       draft,
       branch: alias,
       include_upload_url: options.uploadSourceZip,
-      deploy_source: process.env.NETLIFY_DEPLOY_SOURCE || 'cli',
+      ...getDeploySourceFields(),
     }
 
     // TODO: Type this properly in `@netlify/api`.

--- a/src/utils/deploy/deploy-source.ts
+++ b/src/utils/deploy/deploy-source.ts
@@ -1,0 +1,16 @@
+export interface DeploySourceFields {
+  deploy_source: string
+  agent_runner_id?: string
+  agent_runner_session_id?: string
+}
+
+export const getDeploySourceFields = (): DeploySourceFields => {
+  const agentRunnerId = process.env.NETLIFY_AGENT_RUNNER_ID
+  const agentRunnerSessionId = process.env.NETLIFY_AGENT_RUNNER_SESSION_ID
+
+  return {
+    deploy_source: process.env.NETLIFY_DEPLOY_SOURCE || 'cli',
+    ...(agentRunnerId ? { agent_runner_id: agentRunnerId } : {}),
+    ...(agentRunnerSessionId ? { agent_runner_session_id: agentRunnerSessionId } : {}),
+  }
+}

--- a/tests/integration/commands/deploy/deploy-api-routes.ts
+++ b/tests/integration/commands/deploy/deploy-api-routes.ts
@@ -53,6 +53,8 @@ interface CreateDeployBody {
   branch?: string
   environment?: DeployEnvironmentVariable[]
   deploy_source?: string
+  agent_runner_id?: string
+  agent_runner_session_id?: string
 }
 
 export interface DeployRouteState {

--- a/tests/integration/commands/deploy/deploy.test.ts
+++ b/tests/integration/commands/deploy/deploy.test.ts
@@ -1535,6 +1535,80 @@ describe.concurrent('deploy command', () => {
     })
   })
 
+  test('should forward agent runner ids from the environment in create deploy request', async (t) => {
+    await withMockDeploy(async (mockApi) => {
+      await withSiteBuilder(t, async (builder) => {
+        builder.withContentFile({
+          path: 'public/index.html',
+          content: '<h1>test</h1>',
+        })
+
+        await builder.build()
+
+        await callCli(
+          ['deploy', '--json', '--no-build', '--dir', 'public'],
+          getCLIOptions({
+            apiUrl: mockApi.apiUrl,
+            builder,
+            env: {
+              NETLIFY_DEPLOY_SOURCE: 'agent_runner',
+              NETLIFY_AGENT_RUNNER_ID: 'runner-123',
+              NETLIFY_AGENT_RUNNER_SESSION_ID: 'session-456',
+            },
+          }),
+        ).then(parseDeploy)
+
+        const createDeployRequest = mockApi.requests.find(
+          (req) => req.method === 'POST' && req.path === '/api/v1/sites/site_id/deploys',
+        )
+        expect(createDeployRequest).toBeDefined()
+        expect(createDeployRequest!.body as Record<string, unknown>).toMatchObject({
+          deploy_source: 'agent_runner',
+          agent_runner_id: 'runner-123',
+          agent_runner_session_id: 'session-456',
+        })
+      })
+    })
+  })
+
+  test('should forward agent runner ids in create deploy request when building', async (t) => {
+    await withMockDeploy(async (mockApi) => {
+      await withSiteBuilder(t, async (builder) => {
+        builder
+          .withContentFile({
+            path: 'public/index.html',
+            content: '<h1>test</h1>',
+          })
+          .withNetlifyToml({ config: { build: { publish: 'public' } } })
+
+        await builder.build()
+
+        await callCli(
+          ['deploy', '--json'],
+          getCLIOptions({
+            apiUrl: mockApi.apiUrl,
+            builder,
+            env: {
+              NETLIFY_DEPLOY_SOURCE: 'agent_runner',
+              NETLIFY_AGENT_RUNNER_ID: 'runner-123',
+              NETLIFY_AGENT_RUNNER_SESSION_ID: 'session-456',
+            },
+          }),
+        ).then(parseDeploy)
+
+        const createDeployRequest = mockApi.requests.find(
+          (req) => req.method === 'POST' && req.path === '/api/v1/sites/site_id/deploys',
+        )
+        expect(createDeployRequest).toBeDefined()
+        expect(createDeployRequest!.body as Record<string, unknown>).toMatchObject({
+          deploy_source: 'agent_runner',
+          agent_runner_id: 'runner-123',
+          agent_runner_session_id: 'session-456',
+        })
+      })
+    })
+  })
+
   test('should include build_version in deploy body', async (t) => {
     await withMockDeploy(async (mockApi, deployState) => {
       await withSiteBuilder(t, async (builder) => {

--- a/tests/unit/utils/deploy/deploy-source.test.ts
+++ b/tests/unit/utils/deploy/deploy-source.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import { getDeploySourceFields } from '../../../../src/utils/deploy/deploy-source.js'
+
+beforeEach(() => {
+  vi.stubEnv('NETLIFY_DEPLOY_SOURCE', undefined)
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_ID', undefined)
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_SESSION_ID', undefined)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+test('defaults the deploy source to `cli`', () => {
+  expect(getDeploySourceFields()).toEqual({ deploy_source: 'cli' })
+})
+
+test('honors NETLIFY_DEPLOY_SOURCE', () => {
+  vi.stubEnv('NETLIFY_DEPLOY_SOURCE', 'agent_runner')
+
+  expect(getDeploySourceFields()).toEqual({ deploy_source: 'agent_runner' })
+})
+
+test('forwards the agent runner ids', () => {
+  vi.stubEnv('NETLIFY_DEPLOY_SOURCE', 'agent_runner')
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_ID', 'runner-123')
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_SESSION_ID', 'session-456')
+
+  expect(getDeploySourceFields()).toEqual({
+    deploy_source: 'agent_runner',
+    agent_runner_id: 'runner-123',
+    agent_runner_session_id: 'session-456',
+  })
+})
+
+test('omits the session id when only the runner id is set', () => {
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_ID', 'runner-123')
+
+  expect(getDeploySourceFields()).toEqual({ deploy_source: 'cli', agent_runner_id: 'runner-123' })
+})
+
+test('omits empty agent runner ids', () => {
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_ID', '')
+  vi.stubEnv('NETLIFY_AGENT_RUNNER_SESSION_ID', '')
+
+  expect(getDeploySourceFields()).toEqual({ deploy_source: 'cli' })
+})


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

Second part of [PAW-210](https://linear.app/netlify/issue/PAW-210/better-track-preview-state-for-agent-runners) — the `netlify-cli` slice of the [recommended approach](https://linear.app/netlify/issue/PAW-210/better-track-preview-state-for-agent-runners#comment-2d67b45f). Follows netlify/agent-runner-orchestrator#1125.

Today the runner↔deploy link is made at deploy *completion*, so an agent runner just stays `running` through the whole build and bitballoon can't distinguish "the agent is thinking" from "the agent is done, the preview is building". The fix is to link at deploy *creation* instead, which means the runner ids have to reach the `createSiteDeploy` request.

The orchestrator now sets `NETLIFY_AGENT_RUNNER_ID` and `NETLIFY_AGENT_RUNNER_SESSION_ID` in the CLI's env next to the existing `NETLIFY_DEPLOY_SOURCE`. This PR forwards them through as fields on the create-deploy body. One-field passthrough; no change to the deploy flow.

#### What changed

- **`src/utils/deploy/deploy-source.ts`** (new) — `getDeploySourceFields()` returns `deploy_source` plus `agent_runner_id` / `agent_runner_session_id`. Each id is omitted when unset rather than sent as `undefined`.
- **`src/commands/deploy/deploy.ts`** — both `createSiteDeploy` call sites spread that helper in place of the duplicated `deploy_source` line:
  - `runDeploy` (~L604), which creates the deploy on the `--no-build` path
  - `deploy` (~L1394), which creates it up front when building

#### Reviewer notes

- **Both create paths are covered, and they're the only ones.** Those two call sites were the only places the CLI sent `deploy_source`. `--trigger` goes through `createSiteBuild` (a git-based build trigger) and anonymous/drop deploys never sent a deploy source, so neither is in scope.
- **Deploy retries need nothing here.** The orchestrator's retry path re-invokes the CLI, so the env is re-read on each `createSiteDeploy`.
- **The session id is included as well as the runner id.** The orchestrator sets both, and the bitballoon slice needs the session to point at the deploy (`session.deploy_id`). Happy to trim to just `agent_runner_id` if you'd rather the CLI carried only the one field.
- **Unrecognised ids:** as flagged on the orchestrator PR, `bin-local.ts` generates `local-<hex>` ids for local runs, so bitballoon's create path should ignore an id it doesn't recognise rather than erroring.
- **Test results:** new unit tests 5/5; full unit suite 477/477 across 66 files (the 5 reported "errors" are unhandled telemetry rejections from `geo-location`/`exec-fetcher` hitting a 500 on a binary download — pre-existing and environmental). Full deploy integration suite 55/55, including two new tests covering both create paths. `typecheck`, `lint` and `format:check` all clean.

#### Still to come on PAW-210

- `bitballoon`: accept the params in `Api::V1::DeploysController#create`, link at creation in `Deploy.create_with_site!`, and add the derived `preview_state` to the agent runner snapshot serializer.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/cli/issues/new/choose) before writing your code 🧑‍💻 — tracked in PAW-210.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝 — n/a, these are internal env vars set by the orchestrator and aren't part of the documented CLI surface (`NETLIFY_DEPLOY_SOURCE` isn't documented either).
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![a very serious puffin](https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Puffin_%28Fratercula_arctica%29_%2814%29.jpg/440px-Puffin_%28Fratercula_arctica%29_%2814%29.jpg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
