### PR TITLE
chore: clear tsbuildinfo in clean script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `npm run build` - Compiles TypeScript using `tsc --project tsconfig.build.json`
 - `npm run dev` - Runs TypeScript compiler in watch mode
-- `npm run clean` - Removes the `dist/` directory
+- `npm run clean` - Removes the `dist/` directory and the TypeScript incremental build info files
 
 ### Testing
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "type": "module",
   "scripts": {
     "build": "node ./node_modules/typescript-native/bin/tsc --project tsconfig.build.json",
-    "clean": "rm -rf dist/",
+    "clean": "rm -rf dist/ tsconfig.build.tsbuildinfo tsconfig.tsbuildinfo",
     "dev": "node ./node_modules/typescript-native/bin/tsc --project tsconfig.build.json --watch",
     "docs": "npm run --prefix=site build",
     "format": "oxfmt --write",


### PR DESCRIPTION
`npm run clean` removes `dist/` but leaves `tsconfig.build.tsbuildinfo` behind. `tsc --incremental` decides what to emit from that file alone, not from what's actually on disk — so the next `npm run build` sees an up-to-date cache and emits **nothing**. No `dist/`, no error, no output.

Reproduced on `main` today:

```
npm run build   # dist has 1097 files
npm run clean   # dist gone, tsconfig.build.tsbuildinfo still there
npm run build   # dist has 0 files
```

With this change the second build repopulates `dist/` normally (verified: 1068 → clean → 1068).

`tsconfig.tsbuildinfo` (from the typecheck-only project) is included for the same reason.

Also updates the now-stale `npm run clean` line in `CLAUDE.md`.

`chore:` rather than `fix:` — dev-only script, nothing user-visible.

---

Split out of #8453, which bundled this with unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)