### PR TITLE
fix: stop shipping source maps in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:integration": "vitest run --retry=3 tests/integration/",
     "test:unit": "vitest run tests/unit/",
     "postinstall": "node ./scripts/postinstall.js",
+    "prepack": "node ./scripts/strip-source-maps.js",
     "typecheck": "node ./node_modules/typescript-native/bin/tsc",
     "typecheck:watch": "node ./node_modules/typescript-native/bin/tsc --watch"
   },

--- a/scripts/strip-source-maps.js
+++ b/scripts/strip-source-maps.js
@@ -1,0 +1,92 @@
+/*
+ * This script runs at pack time (`prepack`), before the tarball is assembled.
+ *
+ * We build with `sourceMap` and `declarationMap` enabled so that local development against `dist/`
+ * has working maps. Those maps are useless to end users, though: they reference `../src/*.ts`, and
+ * `src` is not in the package's `files` list, so every map in a published install points at a file
+ * that isn't there. They accounted for roughly half of the published package, so we strip them
+ * here rather than shipping dead weight.
+ *
+ * This is idempotent — `npm publish` is invoked more than once per release (see
+ * `.github/workflows/release-please.yml`), and the second run should be a no-op.
+ */
+
+import { readdir, rm, readFile, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DIST_DIR = path.join(__dirname, '..', 'dist')
+// `tsc --incremental` decides what to emit from this file alone, not from what's on disk. Stripping
+// maps out from under it would otherwise leave a subsequent local build convinced it has nothing to
+// do, silently yielding a `dist/` with no maps (or, after `npm run clean`, no `dist/` at all).
+const BUILD_INFO_FILE = path.join(__dirname, '..', 'tsconfig.build.tsbuildinfo')
+
+// Matches the trailing `//# sourceMappingURL=...` annotation left behind once the map is gone.
+const SOURCE_MAPPING_URL_RE = /^\/\/# sourceMappingURL=.*$\n?/gm
+
+const walk = async (dir) => {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name)
+      return entry.isDirectory() ? walk(entryPath) : [entryPath]
+    }),
+  )
+  return files.flat()
+}
+
+const stripSourceMaps = async () => {
+  const files = await walk(DIST_DIR)
+
+  if (files.length === 0) {
+    console.error('strip-source-maps: no dist/ output found, nothing to do')
+    return
+  }
+
+  const maps = files.filter((file) => file.endsWith('.map'))
+  const annotated = files.filter((file) => file.endsWith('.js') || file.endsWith('.d.ts'))
+
+  // Collect sizes first and sum at the end: `total += await size(file)` would read `total` before
+  // awaiting and clobber every concurrent update.
+  const bytesRemoved = (
+    await Promise.all(
+      maps.map(async (file) => {
+        const { size } = await stat(file)
+        await rm(file)
+        return size
+      }),
+    )
+  ).reduce((total, size) => total + size, 0)
+
+  let annotationsRemoved = 0
+  await Promise.all(
+    annotated.map(async (file) => {
+      const contents = await readFile(file, 'utf8')
+      const stripped = contents.replace(SOURCE_MAPPING_URL_RE, '')
+      if (stripped !== contents) {
+        annotationsRemoved += 1
+        await writeFile(file, stripped)
+      }
+    }),
+  )
+
+  await rm(BUILD_INFO_FILE, { force: true })
+
+  console.error(
+    `strip-source-maps: removed ${maps.length.toString()} map file(s) (${(bytesRemoved / 1024 / 1024).toFixed(
+      2,
+    )} MB) and ${annotationsRemoved.toString()} sourceMappingURL annotation(s)`,
+  )
+}
+
+await stripSourceMaps()


### PR DESCRIPTION
We ship 534 `.map` files — **534 of the package's 1128 files** — and none of them can work. Every map references `../src/*.ts`, `src` isn't in `files`, and none carry `sourcesContent`. So in an installed copy, every map points at a path that doesn't exist. Nobody has ever gotten a resolved stack frame out of them.

`sourceMap`/`declarationMap` stay **on** for local development; a `prepack` script strips maps and their `//# sourceMappingURL=` annotations from `dist/` before the tarball is assembled.

| | before | after | |
|---|---|---|---|
| tarball | 480 KB | **296 KB** | −38% |
| unpacked | 2.06 MB | **1.14 MB** | −45% |
| files | 1128 | **595** | −47% |

### Why the script also deletes `tsconfig.build.tsbuildinfo`

`tsc --incremental` decides what to emit from that file alone, not from what's on disk. Stripping maps out from under it would otherwise leave a subsequent local build convinced it has nothing to do, silently yielding a `dist/` with no maps. Deleting it forces the next local build to emit in full.

### Idempotency

`.github/workflows/release-please.yml` invokes `npm publish` more than once per release, so `prepack` runs more than once. The second run is a no-op, as is a run with no `dist/` present.

## Verification

- `npm run clean && npm run build` → 1068 files, 534 maps
- `npm pack` → **595 files, 296 KB, 0 `.map` entries in the tarball, 0 `sourceMappingURL` annotations left**
- `npm run prepack` a second time → `removed 0 map file(s)` — clean no-op
- `npm run prepack` with no `dist/` → `no dist/ output found, nothing to do`
- `npm run build` again → 1068 files, 534 maps back. Round trip holds; local debugging is unaffected.
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run test:unit` — 499/500, matching the baseline on unmodified `main` exactly (the `generate-autocompletion` snapshot failure is pre-existing; I reproduced it on `main` at `97fd77d3c`)

No `package-lock.json` change.

---

Split out of #8453, which bundled this with unrelated work. The wider `node_modules` footprint research (~361 MB installed, ~1040 packages, and where the rest of it lives) is in that PR's description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)