### PR TITLE
fix: await function template downloads in functions-create

### DIFF
--- a/src/commands/functions/functions-create.ts
+++ b/src/commands/functions/functions-create.ts
@@ -4,6 +4,7 @@ import { mkdir, readdir, unlink } from 'fs/promises'
 import { createRequire } from 'module'
 import path, { dirname, join, relative } from 'path'
 import process from 'process'
+import { pipeline } from 'stream/promises'
 import { fileURLToPath, pathToFileURL } from 'url'
 
 import { OptionValues } from 'commander'
@@ -409,10 +410,13 @@ const downloadFromURL = async function (command, options, argumentName, function
     folderContents.map(async ({ download_url: downloadUrl, name }) => {
       try {
         const res = await fetch(downloadUrl)
+        if (!res.ok || !res.body) {
+          throw new Error(`HTTP ${res.status.toString()}: ${res.statusText}`)
+        }
         const fileName = path.basename(name)
         const finalName = path.basename(fileName, '.js') === functionName ? `${nameToUse}.js` : fileName
         const dest = fs.createWriteStream(path.join(fnFolder, finalName))
-        res.body?.pipe(dest)
+        await pipeline(res.body, dest)
       } catch (error_) {
         throw new Error(`Error while retrieving ${downloadUrl} ${error_}`)
       }


### PR DESCRIPTION
Two bugs in `downloadFromURL` (`src/commands/functions/functions-create.ts`), both on the `netlify functions:create --url` path.

**Template downloads were never awaited.** Files were written with `res.body?.pipe(dest)` — no `await`, so `Promise.all` resolved before any write had finished. The `cp.exec('npm i', ...)` that immediately follows could therefore run against a partially-written function directory. `await pipeline(res.body, dest)` closes the race.

**A failed download was written to disk as the template.** There was no `res.ok` check, so a 404 or 500 from GitHub had its error-page body piped into the function file and the command reported success. That's now an explicit throw, which the surrounding `catch` turns into the existing `Error while retrieving ${downloadUrl}` message.

```diff
 const res = await fetch(downloadUrl)
+if (!res.ok || !res.body) {
+  throw new Error(`HTTP ${res.status.toString()}: ${res.statusText}`)
+}
 const fileName = path.basename(name)
 const finalName = path.basename(fileName, '.js') === functionName ? `${nameToUse}.js` : fileName
 const dest = fs.createWriteStream(path.join(fnFolder, finalName))
-res.body?.pipe(dest)
+await pipeline(res.body, dest)
```

The `node-fetch` import is unchanged — node-fetch v3's `res.body` is a Node `Readable` typed `NodeJS.ReadableStream | null`, which satisfies `PipelineSource`, so this is purely the bug fix.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run test:unit` — 499/500, matching the baseline on unmodified `main` exactly (the `generate-autocompletion` snapshot failure is pre-existing; I reproduced it on `main` at `97fd77d3c`)

No `package-lock.json` change.

---

Split out of #8453, which bundled this with unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)