### PR TITLE
fix(logs): fetch historical deploy logs over websocket

### DIFF
--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -225,8 +225,6 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
     }
   }
 
-  const apiBase = client.basePath
-
   const sinceValue = (options.since as string | undefined) ?? DEFAULT_SINCE
   const untilValue = options.until as string | undefined
 
@@ -234,7 +232,6 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
     await runHistoricalMode({
       sources,
       client,
-      apiBase,
       siteId,
       accessToken: client.accessToken,
       deployId,
@@ -269,7 +266,6 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
 const runHistoricalMode = async ({
   sources,
   client,
-  apiBase,
   siteId,
   accessToken,
   deployId,
@@ -283,7 +279,6 @@ const runHistoricalMode = async ({
 }: {
   sources: Source[]
   client: NetlifyAPI
-  apiBase: string
   siteId: string
   accessToken: string | null | undefined
   deployId?: string
@@ -299,7 +294,7 @@ const runHistoricalMode = async ({
 
   if (sources.includes('deploy') && deployId) {
     const deployEntries = await fetchDeployHistoricalLogs({
-      apiBase,
+      siteId,
       accessToken,
       deployId,
       from,

--- a/src/commands/logs/sources/deploy.ts
+++ b/src/commands/logs/sources/deploy.ts
@@ -1,11 +1,10 @@
 import type { NetlifyAPI } from '@netlify/api'
 
 import { getWebSocket } from '../../../utils/websockets/index.js'
-import { debugFetch } from '../log-api.js'
 import type { LogEntry } from '../log-api.js'
 
-interface DeployLogLine {
-  ts: string
+interface DeployLogMessage {
+  ts?: string | number
   log?: string
   message?: string
   level?: string
@@ -13,50 +12,110 @@ interface DeployLogLine {
   type?: string
 }
 
+const DEPLOY_LOG_REPLAY_TIMEOUT_MS = 30_000
+
+const parseDeployLogTimestamp = (message: DeployLogMessage): number | undefined => {
+  if (!message.ts) {
+    return undefined
+  }
+  const ts = new Date(message.ts).getTime()
+  return Number.isNaN(ts) ? undefined : ts
+}
+
+const toLogEntry = (message: DeployLogMessage, ts: number): LogEntry => ({
+  source: 'deploy',
+  name: 'deploy',
+  ts,
+  level: message.level ?? 'INFO',
+  message: message.log ?? message.message ?? '',
+  section: message.section,
+})
+
+const isEndOfBuild = (message: DeployLogMessage): boolean => message.type === 'report' && message.section === 'building'
+
+const parseDeployLogMessage = (data: string): DeployLogMessage | null => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(data)
+  } catch {
+    return null
+  }
+  return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : null
+}
+
 export const fetchDeployHistoricalLogs = async ({
-  apiBase,
+  siteId,
   accessToken,
   deployId,
   from,
   to,
 }: {
-  apiBase: string
+  siteId: string
   accessToken: string | null | undefined
   deployId: string
   from: number
   to: number
 }): Promise<LogEntry[]> => {
-  const response = await debugFetch(`${apiBase}/api/v1/deploys/${encodeURIComponent(deployId)}/log`, {
-    headers: {
-      Authorization: `Bearer ${accessToken ?? ''}`,
-    },
+  const collected: { entry: LogEntry; hasTimestamp: boolean }[] = []
+  const ws = getWebSocket('wss://socketeer.services.netlify.com/build/logs')
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    const finish = (error?: Error) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      ws.close()
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+    const timeout = setTimeout(() => {
+      finish()
+    }, DEPLOY_LOG_REPLAY_TIMEOUT_MS)
+
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          deploy_id: deployId,
+          site_id: siteId,
+          access_token: accessToken,
+        }),
+      )
+    })
+
+    ws.on('message', (data: string) => {
+      const message = parseDeployLogMessage(data)
+      if (!message) {
+        return
+      }
+      if (isEndOfBuild(message)) {
+        finish()
+        return
+      }
+      const parsedTs = parseDeployLogTimestamp(message)
+      collected.push({
+        entry: toLogEntry(message, parsedTs ?? Date.now()),
+        hasTimestamp: parsedTs !== undefined,
+      })
+    })
+
+    ws.on('close', () => {
+      finish()
+    })
+    ws.on('error', (error: Error) => {
+      finish(error)
+    })
   })
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch deploy logs: ${response.status.toString()} ${response.statusText}`)
-  }
-
-  const logData = (await response.json()) as DeployLogLine[]
-  if (!Array.isArray(logData)) {
-    return []
-  }
-
-  return logData
-    .map((line): LogEntry | null => {
-      const ts = new Date(line.ts).getTime()
-      if (Number.isNaN(ts) || ts < from || ts > to) {
-        return null
-      }
-      return {
-        source: 'deploy',
-        name: 'deploy',
-        ts,
-        level: line.level ?? 'INFO',
-        message: line.log ?? line.message ?? '',
-        section: line.section,
-      }
-    })
-    .filter((entry): entry is LogEntry => entry !== null)
+  return collected
+    .filter(({ entry, hasTimestamp }) => !hasTimestamp || (entry.ts >= from && entry.ts <= to))
+    .map(({ entry }) => entry)
+    .sort((a, b) => a.ts - b.ts)
 }
 
 export const streamDeploy = (
@@ -79,24 +138,13 @@ export const streamDeploy = (
   })
 
   ws.on('message', (data: string) => {
-    const logData = JSON.parse(data) as {
-      message: string
-      section?: string
-      type?: string
-      level?: string
-      ts?: string
+    const message = parseDeployLogMessage(data)
+    if (!message) {
+      return
     }
+    onEntry(toLogEntry(message, parseDeployLogTimestamp(message) ?? Date.now()))
 
-    onEntry({
-      source: 'deploy',
-      name: 'deploy',
-      ts: logData.ts ? new Date(logData.ts).getTime() : Date.now(),
-      level: logData.level ?? 'INFO',
-      message: logData.message,
-      section: logData.section,
-    })
-
-    if (logData.type === 'report' && logData.section === 'building') {
+    if (isEndOfBuild(message)) {
       ws.close()
     }
   })

--- a/tests/unit/commands/logs/deploy.test.ts
+++ b/tests/unit/commands/logs/deploy.test.ts
@@ -1,0 +1,227 @@
+import { EventEmitter } from 'node:events'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeWebSocket extends EventEmitter {
+  sent: string[] = []
+  closed = false
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    this.emit('close')
+  }
+}
+
+const sockets: FakeWebSocket[] = []
+const getWebSocketMock = vi.fn((_url: string) => {
+  const ws = new FakeWebSocket()
+  sockets.push(ws)
+  return ws
+})
+
+vi.mock('../../../../src/utils/websockets/index.js', () => ({
+  getWebSocket: (url: string) => getWebSocketMock(url),
+}))
+
+const { fetchDeployHistoricalLogs, streamDeploy } = await import('../../../../src/commands/logs/sources/deploy.js')
+
+const FROM = Date.parse('2026-01-01T00:00:00.000Z')
+const TO = Date.parse('2026-01-01T00:10:00.000Z')
+
+const drive = (ws: FakeWebSocket, messages: unknown[]) => {
+  ws.emit('open')
+  for (const message of messages) {
+    ws.emit('message', JSON.stringify(message))
+  }
+}
+
+beforeEach(() => {
+  sockets.length = 0
+  getWebSocketMock.mockClear()
+})
+
+describe('fetchDeployHistoricalLogs', () => {
+  it('connects to socketeer and sends the deploy handshake', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    const [ws] = sockets
+    drive(ws, [{ type: 'report', section: 'building' }])
+    await promise
+
+    expect(getWebSocketMock).toHaveBeenCalledWith('wss://socketeer.services.netlify.com/build/logs')
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      deploy_id: 'deploy-1',
+      site_id: 'site-1',
+      access_token: 'token-1',
+    })
+  })
+
+  it('replays stored build logs as sorted deploy entries', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    drive(sockets[0], [
+      { ts: '2026-01-01T00:05:00.000Z', log: 'second', level: 'INFO', section: 'building' },
+      { ts: '2026-01-01T00:02:00.000Z', message: 'first', level: 'WARNING', section: 'initializing' },
+      { type: 'report', section: 'building' },
+    ])
+    const entries = await promise
+
+    expect(entries.map((entry) => entry.message)).toEqual(['first', 'second'])
+    expect(entries[0]).toMatchObject({ source: 'deploy', name: 'deploy', level: 'WARNING', section: 'initializing' })
+  })
+
+  it('drops timestamped lines outside the requested window but keeps untimestamped build lines', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    drive(sockets[0], [
+      { ts: '2025-06-01T00:00:00.000Z', log: 'too old' },
+      { ts: '2026-01-01T00:05:00.000Z', log: 'in range' },
+      { log: 'no timestamp' },
+      { type: 'report', section: 'building' },
+    ])
+    const entries = await promise
+
+    const messages = entries.map((entry) => entry.message)
+    expect(messages).toContain('in range')
+    expect(messages).toContain('no timestamp')
+    expect(messages).not.toContain('too old')
+  })
+
+  it('parses numeric epoch-millisecond timestamps', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    drive(sockets[0], [
+      { ts: Date.parse('2026-01-01T00:05:00.000Z'), log: 'numeric ts' },
+      { type: 'report', section: 'building' },
+    ])
+    const entries = await promise
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ message: 'numeric ts', ts: Date.parse('2026-01-01T00:05:00.000Z') })
+  })
+
+  it('ignores malformed messages without throwing', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    const [ws] = sockets
+    ws.emit('open')
+    ws.emit('message', 'not-json')
+    ws.emit('message', JSON.stringify({ ts: '2026-01-01T00:05:00.000Z', log: 'valid' }))
+    ws.emit('message', JSON.stringify({ type: 'report', section: 'building' }))
+    const entries = await promise
+
+    expect(entries.map((entry) => entry.message)).toEqual(['valid'])
+  })
+
+  it('skips null and non-object frames without throwing', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    drive(sockets[0], [
+      null,
+      42,
+      'a string',
+      ['an', 'array'],
+      { ts: '2026-01-01T00:05:00.000Z', log: 'valid' },
+      { type: 'report', section: 'building' },
+    ])
+    const entries = await promise
+
+    expect(entries.map((entry) => entry.message)).toEqual(['valid'])
+  })
+
+  it('resolves when the socket closes without a terminal report', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    const [ws] = sockets
+    ws.emit('open')
+    ws.emit('message', JSON.stringify({ ts: '2026-01-01T00:05:00.000Z', log: 'partial' }))
+    ws.close()
+    const entries = await promise
+
+    expect(entries.map((entry) => entry.message)).toEqual(['partial'])
+  })
+
+  it('rejects the replay promise on socket error', async () => {
+    const promise = fetchDeployHistoricalLogs({
+      siteId: 'site-1',
+      accessToken: 'token-1',
+      deployId: 'deploy-1',
+      from: FROM,
+      to: TO,
+    })
+
+    const [ws] = sockets
+    ws.emit('open')
+    ws.emit('error', new Error('connection refused'))
+
+    await expect(promise).rejects.toThrow('connection refused')
+  })
+})
+
+describe('streamDeploy', () => {
+  it('streams entries and closes on the terminal build report', () => {
+    const onEntry = vi.fn()
+    const onClose = vi.fn()
+
+    streamDeploy('site-1', 'deploy-1', 'token-1', onEntry, onClose)
+    const [ws] = sockets
+
+    ws.emit('open')
+    ws.emit('message', JSON.stringify({ ts: '2026-01-01T00:05:00.000Z', message: 'live line', level: 'INFO' }))
+    expect(onEntry).toHaveBeenCalledWith(expect.objectContaining({ source: 'deploy', message: 'live line' }))
+    expect(ws.closed).toBe(false)
+
+    ws.emit('message', JSON.stringify({ type: 'report', section: 'building' }))
+    expect(ws.closed).toBe(true)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
#### Summary

## The bug

404 on `netlify logs --source deploy` 

The above command requested `${apiBase}/api/v1/deploys/:id/log`, which both double-prefixed `/api/v1` and hit a REST endpoint that does not exist.

### The fix

Replay stored build logs over the socketeer websocket using the same transport the `--follow` path and the deploy UI use.

#### Command

Run against `netlify-react-ui` on this branch:

`netlify logs --source deploy --since 30d`

#### Output example

<img width="1271" height="39" alt="image" src="https://github.com/user-attachments/assets/bbaac409-e592-4e5a-841d-7cfe33560c62" />
<img width="1216" height="1105" alt="image" src="https://github.com/user-attachments/assets/cbed2ea7-592a-4e77-92ea-4a07cacdc561" />


Supersedes #8421.
