### PR TITLE
fix(logs): auto-select the latest finished deploy, including failures

### DIFF
--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -18,6 +18,7 @@ import { LOG_LEVELS_LIST, CLI_LOG_LEVEL_CHOICES_STRING } from './log-levels.js'
 import {
   fetchDeployHistoricalLogs,
   findCurrentBuildingDeploy,
+  findLatestFinishedDeploy,
   findLatestReadyDeploy,
   streamDeploy,
 } from './sources/deploy.js'
@@ -218,7 +219,9 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
     }
 
     if (!deployId) {
-      const latestId = await findLatestReadyDeploy(client, siteId)
+      const latestId = sources.includes('deploy')
+        ? await findLatestFinishedDeploy(client, siteId)
+        : await findLatestReadyDeploy(client, siteId)
       if (latestId) {
         deployId = latestId
       }

--- a/src/commands/logs/sources/deploy.ts
+++ b/src/commands/logs/sources/deploy.ts
@@ -167,3 +167,11 @@ export const findLatestReadyDeploy = async (client: NetlifyAPI, siteId: string):
   const deploys = (await client.listSiteDeploys({ siteId, state: 'ready', per_page: 1 })) as { id: string }[]
   return deploys.length > 0 ? deploys[0].id : undefined
 }
+
+const FINISHED_DEPLOY_STATES = new Set(['ready', 'error', 'cancelled'])
+
+export const findLatestFinishedDeploy = async (client: NetlifyAPI, siteId: string): Promise<string | undefined> => {
+  const deploys = (await client.listSiteDeploys({ siteId, per_page: 10 })) as { id: string; state: string }[]
+  const finished = deploys.find((deploy) => FINISHED_DEPLOY_STATES.has(deploy.state))
+  return finished?.id
+}

--- a/tests/unit/commands/logs/deploy.test.ts
+++ b/tests/unit/commands/logs/deploy.test.ts
@@ -30,7 +30,8 @@ vi.mock('../../../../src/utils/websockets/index.js', () => ({
   getWebSocket: (url: string) => getWebSocketMock(url),
 }))
 
-const { fetchDeployHistoricalLogs, streamDeploy } = await import('../../../../src/commands/logs/sources/deploy.js')
+const { fetchDeployHistoricalLogs, findLatestFinishedDeploy, findLatestReadyDeploy, streamDeploy } =
+  await import('../../../../src/commands/logs/sources/deploy.js')
 
 const FROM = Date.parse('2026-01-01T00:00:00.000Z')
 const TO = Date.parse('2026-01-01T00:10:00.000Z')
@@ -204,6 +205,56 @@ describe('fetchDeployHistoricalLogs', () => {
     ws.emit('error', new Error('connection refused'))
 
     await expect(promise).rejects.toThrow('connection refused')
+  })
+})
+
+describe('deploy selection', () => {
+  it('findLatestFinishedDeploy returns the newest finished deploy, including failed ones', async () => {
+    const listSiteDeploys = vi.fn().mockResolvedValue([{ id: 'failed-deploy', state: 'error' }])
+    const client = { listSiteDeploys } as never
+
+    const id = await findLatestFinishedDeploy(client, 'site-1')
+
+    expect(id).toBe('failed-deploy')
+    expect(listSiteDeploys).toHaveBeenCalledWith({ siteId: 'site-1', per_page: 10 })
+  })
+
+  it('findLatestFinishedDeploy skips in-progress builds', async () => {
+    const listSiteDeploys = vi.fn().mockResolvedValue([
+      { id: 'building-deploy', state: 'building' },
+      { id: 'enqueued-deploy', state: 'enqueued' },
+      { id: 'ready-deploy', state: 'ready' },
+    ])
+    const client = { listSiteDeploys } as never
+
+    expect(await findLatestFinishedDeploy(client, 'site-1')).toBe('ready-deploy')
+  })
+
+  it('findLatestFinishedDeploy treats cancelled deploys as finished', async () => {
+    const listSiteDeploys = vi.fn().mockResolvedValue([
+      { id: 'building-deploy', state: 'building' },
+      { id: 'cancelled-deploy', state: 'cancelled' },
+    ])
+    const client = { listSiteDeploys } as never
+
+    expect(await findLatestFinishedDeploy(client, 'site-1')).toBe('cancelled-deploy')
+  })
+
+  it('findLatestReadyDeploy filters to ready deploys only', async () => {
+    const listSiteDeploys = vi.fn().mockResolvedValue([{ id: 'ready-deploy', state: 'ready' }])
+    const client = { listSiteDeploys } as never
+
+    const id = await findLatestReadyDeploy(client, 'site-1')
+
+    expect(id).toBe('ready-deploy')
+    expect(listSiteDeploys).toHaveBeenCalledWith({ siteId: 'site-1', state: 'ready', per_page: 1 })
+  })
+
+  it('returns undefined when there are no finished deploys', async () => {
+    const client = {
+      listSiteDeploys: vi.fn().mockResolvedValue([{ id: 'building-deploy', state: 'building' }]),
+    } as never
+    expect(await findLatestFinishedDeploy(client, 'site-1')).toBeUndefined()
   })
 })
 

--- a/tests/unit/commands/logs/logs.test.ts
+++ b/tests/unit/commands/logs/logs.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fetchDeployHistoricalLogsMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>()
+const findLatestFinishedDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
+const findLatestReadyDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
+
+vi.mock('../../../../src/commands/logs/sources/deploy.js', () => ({
+  fetchDeployHistoricalLogs: (...args: unknown[]) => fetchDeployHistoricalLogsMock(...args),
+  findCurrentBuildingDeploy: vi.fn(),
+  findLatestFinishedDeploy: (...args: unknown[]) => findLatestFinishedDeployMock(...args),
+  findLatestReadyDeploy: (...args: unknown[]) => findLatestReadyDeployMock(...args),
+  isDeployFinished: () => Promise.resolve(false),
+  streamDeploy: vi.fn(),
+}))
+
+vi.mock('../../../../src/commands/logs/sources/edge-functions.js', () => ({
+  fetchEdgeFunctionHistoricalLogs: () => Promise.resolve([]),
+  streamEdgeFunctions: vi.fn(),
+}))
+
+const { logsCommand } = await import('../../../../src/commands/logs/logs.js')
+
+const makeCommand = () =>
+  ({
+    netlify: {
+      api: { accessToken: 'token-1' },
+      site: { id: 'site-1' },
+      siteInfo: {},
+    },
+  }) as never
+
+beforeEach(() => {
+  fetchDeployHistoricalLogsMock.mockReset().mockResolvedValue([])
+  findLatestFinishedDeployMock.mockReset().mockResolvedValue('finished-deploy')
+  findLatestReadyDeployMock.mockReset().mockResolvedValue('ready-deploy')
+})
+
+describe('logsCommand deploy auto-selection', () => {
+  it('auto-selects the latest finished deploy for --source deploy', async () => {
+    await logsCommand({ source: ['deploy'], since: '1h' }, makeCommand())
+
+    expect(findLatestFinishedDeployMock).toHaveBeenCalledOnce()
+    expect(findLatestReadyDeployMock).not.toHaveBeenCalled()
+    expect(fetchDeployHistoricalLogsMock.mock.calls[0]?.[0]).toMatchObject({ deployId: 'finished-deploy' })
+  })
+
+  it('auto-selects the latest ready deploy for non-deploy sources', async () => {
+    await logsCommand({ source: ['edge-functions'], since: '1h' }, makeCommand())
+
+    expect(findLatestReadyDeployMock).toHaveBeenCalledOnce()
+    expect(findLatestFinishedDeployMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch deploy logs when there is no finished deploy', async () => {
+    findLatestFinishedDeployMock.mockResolvedValue(undefined)
+
+    await logsCommand({ source: ['deploy'], since: '1h' }, makeCommand())
+
+    expect(findLatestFinishedDeployMock).toHaveBeenCalledOnce()
+    expect(fetchDeployHistoricalLogsMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Stacked on #8476. Part of splitting #8452 into atomic PRs.

`netlify logs --source deploy` auto-selected the latest **`ready`** deploy, so failed builds were silently skipped. 

It now selects the latest **finished** deploy — `ready`, `error`, or `cancelled` — and skips in-progress builds (which have no final log yet).

## Command

`netlify logs --source deploy --since 30d` where the latest build was failed:

<img width="1069" height="37" alt="image" src="https://github.com/user-attachments/assets/75ec4798-1fc0-4970-9b50-3b3507acf995" />
...
<img width="1791" height="460" alt="image" src="https://github.com/user-attachments/assets/82625ef3-9b1f-4414-b63a-a3ef09bfb901" />

