### PR TITLE
feat(logs): add --deploy-id flag to target a specific deploy

### DIFF
--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -17,7 +17,7 @@ netlify logs
 
 **Flags**
 
-- `deploy-id` (*string*) - Show logs for a specific deploy by ID, including failed builds
+- `deploy-id` (*string*) - Show logs for a specific deploy by ID, including failed builds. Can be used with all sources.
 - `edge-function` (*string*) - Filter to specific edge functions by name or path
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `follow` (*boolean*) - Stream logs in real time instead of showing historical logs
@@ -27,7 +27,7 @@ netlify logs
 - `since` (*string*) - Start of the historical log window. Accepts a duration (e.g. 10m, 1h, 24h) or an ISO 8601 timestamp. Defaults to 10m
 - `source` (*functions | edge-functions | deploy*) - Log sources to include. Defaults to functions and edge-functions
 - `until` (*string*) - End of the historical log window. Accepts a duration or an ISO 8601 timestamp (defaults to now)
-- `url` (*string*) - Show logs for the deploy behind the given URL. Supports deploy permalinks and branch subdomains
+- `url` (*string*) - Show logs for the deploy behind the given URL. Supports deploy permalinks and branch subdomains. Can be used with all sources.
 - `debug` (*boolean*) - Print debugging information
 - `auth` (*string*) - Netlify auth token - can be used to run this command without logging in
 
@@ -37,6 +37,7 @@ netlify logs
 netlify logs
 netlify logs --since 1h
 netlify logs --source deploy --deploy-id <deploy-id> --since 7d
+netlify logs --source functions --deploy-id <deploy-id>
 netlify logs --source functions --function checkout --since 24h
 netlify logs --source edge-functions --since 30m
 netlify logs --source deploy --source functions --since 1h

--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -17,6 +17,7 @@ netlify logs
 
 **Flags**
 
+- `deploy-id` (*string*) - Show logs for a specific deploy by ID, including failed builds
 - `edge-function` (*string*) - Filter to specific edge functions by name or path
 - `filter` (*string*) - For monorepos, specify the name of the application to run the command in
 - `follow` (*boolean*) - Stream logs in real time instead of showing historical logs
@@ -35,6 +36,7 @@ netlify logs
 ```bash
 netlify logs
 netlify logs --since 1h
+netlify logs --source deploy --deploy-id <deploy-id> --since 7d
 netlify logs --source functions --function checkout --since 24h
 netlify logs --source edge-functions --since 30m
 netlify logs --source deploy --source functions --since 1h

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -126,7 +126,7 @@ export const createLogsCommand = (program: BaseCommand) => {
     .addOption(
       new Option(
         '-u, --url <url>',
-        'Show logs for the deploy behind the given URL. Supports deploy permalinks and branch subdomains',
+        'Show logs for the deploy behind the given URL. Supports deploy permalinks and branch subdomains. Can be used with all sources.',
       ),
     )
     .addOption(

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -130,12 +130,16 @@ export const createLogsCommand = (program: BaseCommand) => {
       ),
     )
     .addOption(
+      new Option('-d, --deploy-id <deploy-id>', 'Show logs for a specific deploy by ID, including failed builds'),
+    )
+    .addOption(
       new Option('-l, --level <levels...>', `Log levels to include. Choices are:${CLI_LOG_LEVEL_CHOICES_STRING}`),
     )
     .addOption(new Option('--json', 'Output logs as JSON Lines'))
     .addExamples([
       'netlify logs',
       'netlify logs --since 1h',
+      'netlify logs --source deploy --deploy-id <deploy-id> --since 7d',
       'netlify logs --source functions --function checkout --since 24h',
       'netlify logs --source edge-functions --since 30m',
       'netlify logs --source deploy --source functions --since 1h',

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -130,7 +130,10 @@ export const createLogsCommand = (program: BaseCommand) => {
       ),
     )
     .addOption(
-      new Option('-d, --deploy-id <deploy-id>', 'Show logs for a specific deploy by ID, including failed builds. Can be used with all sources.'),
+      new Option(
+        '-d, --deploy-id <deploy-id>',
+        'Show logs for a specific deploy by ID, including failed builds. Can be used with all sources.',
+      ),
     )
     .addOption(
       new Option('-l, --level <levels...>', `Log levels to include. Choices are:${CLI_LOG_LEVEL_CHOICES_STRING}`),

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -140,6 +140,7 @@ export const createLogsCommand = (program: BaseCommand) => {
       'netlify logs',
       'netlify logs --since 1h',
       'netlify logs --source deploy --deploy-id <deploy-id> --since 7d',
+      'netlify logs --source functions --deploy-id <deploy-id>',
       'netlify logs --source functions --function checkout --since 24h',
       'netlify logs --source edge-functions --since 30m',
       'netlify logs --source deploy --source functions --since 1h',

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -130,7 +130,7 @@ export const createLogsCommand = (program: BaseCommand) => {
       ),
     )
     .addOption(
-      new Option('-d, --deploy-id <deploy-id>', 'Show logs for a specific deploy by ID, including failed builds'),
+      new Option('-d, --deploy-id <deploy-id>', 'Show logs for a specific deploy by ID, including failed builds. Can be used with all sources.'),
     )
     .addOption(
       new Option('-l, --level <levels...>', `Log levels to include. Choices are:${CLI_LOG_LEVEL_CHOICES_STRING}`),

--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -6,6 +6,7 @@ import type BaseCommand from '../base-command.js'
 
 import {
   createColorAssigner,
+  DEPLOY_ID_RE,
   formatJsonLine,
   formatLogLine,
   parseTimeValue,
@@ -168,7 +169,16 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
   }
 
   let deployId: string | undefined
-  if (options.url) {
+  if (options.deployId) {
+    const explicitDeployId = (options.deployId as string).trim()
+    if (!DEPLOY_ID_RE.test(explicitDeployId)) {
+      return logAndThrowError(`Invalid --deploy-id value: ${explicitDeployId}. Expected a deploy ID.`)
+    }
+    if (options.url) {
+      return logAndThrowError('--deploy-id cannot be used together with --url.')
+    }
+    deployId = explicitDeployId
+  } else if (options.url) {
     try {
       deployId = await resolveDeployIdFromUrl(options.url as string, client, siteId, siteInfo)
     } catch (error) {

--- a/tests/unit/commands/logs/logs.test.ts
+++ b/tests/unit/commands/logs/logs.test.ts
@@ -72,7 +72,10 @@ describe('logsCommand --deploy-id', () => {
 
   it('rejects --deploy-id combined with --url', async () => {
     await expect(
-      logsCommand({ source: ['deploy'], deployId: A_VALID_DEPLOY_ID, url: 'https://example.netlify.app' }, makeCommand()),
+      logsCommand(
+        { source: ['deploy'], deployId: A_VALID_DEPLOY_ID, url: 'https://example.netlify.app' },
+        makeCommand(),
+      ),
     ).rejects.toThrow('--deploy-id cannot be used together with --url.')
   })
 

--- a/tests/unit/commands/logs/logs.test.ts
+++ b/tests/unit/commands/logs/logs.test.ts
@@ -20,6 +20,8 @@ vi.mock('../../../../src/commands/logs/sources/edge-functions.js', () => ({
 
 const { logsCommand } = await import('../../../../src/commands/logs/logs.js')
 
+const A_VALID_DEPLOY_ID = 'a'.repeat(24)
+
 const makeCommand = () =>
   ({
     netlify: {
@@ -58,5 +60,26 @@ describe('logsCommand deploy auto-selection', () => {
 
     expect(findLatestFinishedDeployMock).toHaveBeenCalledOnce()
     expect(fetchDeployHistoricalLogsMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('logsCommand --deploy-id', () => {
+  it('rejects an invalid deploy id', async () => {
+    await expect(logsCommand({ source: ['deploy'], deployId: 'not-a-deploy-id' }, makeCommand())).rejects.toThrow(
+      'Invalid --deploy-id value: not-a-deploy-id. Expected a deploy ID.',
+    )
+  })
+
+  it('rejects --deploy-id combined with --url', async () => {
+    await expect(
+      logsCommand({ source: ['deploy'], deployId: A_VALID_DEPLOY_ID, url: 'https://example.netlify.app' }, makeCommand()),
+    ).rejects.toThrow('--deploy-id cannot be used together with --url.')
+  })
+
+  it('fetches historical logs for the given deploy id', async () => {
+    await logsCommand({ source: ['deploy'], deployId: A_VALID_DEPLOY_ID, since: '1h' }, makeCommand())
+
+    expect(fetchDeployHistoricalLogsMock).toHaveBeenCalledTimes(1)
+    expect(fetchDeployHistoricalLogsMock.mock.calls[0]?.[0]).toMatchObject({ deployId: A_VALID_DEPLOY_ID })
   })
 })


### PR DESCRIPTION
Stacked on #8477.

Adds `-d, --deploy-id <deploy-id>` to `netlify logs` — view logs for a specific deploy (including failed builds) as an alternative to `--url`.

```bash
netlify logs --source deploy --deploy-id <deploy-id> --since 7d
```

Successful command:

<img width="1543" height="320" alt="image" src="https://github.com/user-attachments/assets/f756e85f-c4f8-43ae-a5bc-d923d5c72203" />
<img width="1788" height="301" alt="image" src="https://github.com/user-attachments/assets/f52ddf5d-9925-4a9c-a431-129573a31358" />

Unsuccessful commands:

<img width="1788" height="184" alt="image" src="https://github.com/user-attachments/assets/d522eef5-fa9b-4527-80b6-f72149a7729a" />

*Note*: When testing this I felt it was better to *not* need the `--since` for a specific deploy ID, however, I left it in as per @serhalp's comment in the original large PR: https://github.com/netlify/cli/pull/8452

<img width="698" height="136" alt="image" src="https://github.com/user-attachments/assets/66165a64-ed1c-4166-978c-0a37cfd03e91" />
