### PR TITLE
fix(logs): stream the targeted deploy in --follow

### DIFF
--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -169,6 +169,7 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
   }
 
   let deployId: string | undefined
+  let deployTargeted = false
   if (options.deployId) {
     const explicitDeployId = (options.deployId as string).trim()
     if (!DEPLOY_ID_RE.test(explicitDeployId)) {
@@ -178,9 +179,11 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
       return logAndThrowError('--deploy-id cannot be used together with --url.')
     }
     deployId = explicitDeployId
+    deployTargeted = true
   } else if (options.url) {
     try {
       deployId = await resolveDeployIdFromUrl(options.url as string, client, siteId, siteInfo)
+      deployTargeted = deployId !== undefined
     } catch (error) {
       const message = (error as Error).message
       if (message.includes("doesn't seem to match") && siteInfo.name) {
@@ -269,6 +272,7 @@ export const logsCommand = async (options: OptionValues, command: BaseCommand) =
     siteId,
     accessToken: client.accessToken,
     deployId,
+    deployTargeted,
     functionNames,
     edgeFunctionNames,
     levelsToPrint,
@@ -362,12 +366,13 @@ const runHistoricalMode = async ({
   }
 }
 
-const runFollowMode = async ({
+export const runFollowMode = async ({
   sources,
   client,
   siteId,
   accessToken,
   deployId,
+  deployTargeted,
   functionNames,
   edgeFunctionNames,
   levelsToPrint,
@@ -378,6 +383,7 @@ const runFollowMode = async ({
   siteId: string
   accessToken: string | null | undefined
   deployId?: string
+  deployTargeted: boolean
   functionNames: string[]
   edgeFunctionNames: string[]
   levelsToPrint: string[]
@@ -390,10 +396,10 @@ const runFollowMode = async ({
     printEntry(entry, levelsToPrint, json, assignColor(key))
   }
 
-  if (sources.includes('deploy') && deployId) {
-    const buildingDeployId = await findCurrentBuildingDeploy(client, siteId)
-    if (buildingDeployId) {
-      streamDeploy(siteId, buildingDeployId, accessToken, onEntry, () => {
+  if (sources.includes('deploy')) {
+    const deployStreamId = deployTargeted ? deployId : await findCurrentBuildingDeploy(client, siteId)
+    if (deployStreamId) {
+      streamDeploy(siteId, deployStreamId, accessToken, onEntry, () => {
         if (!json) {
           log(chalk.dim('Deploy stream closed.'))
         }

--- a/tests/unit/commands/logs/logs.test.ts
+++ b/tests/unit/commands/logs/logs.test.ts
@@ -3,14 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const fetchDeployHistoricalLogsMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>()
 const findLatestFinishedDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
 const findLatestReadyDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
+const streamDeployMock = vi.fn<(...args: unknown[]) => void>()
+const findCurrentBuildingDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
 
 vi.mock('../../../../src/commands/logs/sources/deploy.js', () => ({
   fetchDeployHistoricalLogs: (...args: unknown[]) => fetchDeployHistoricalLogsMock(...args),
-  findCurrentBuildingDeploy: vi.fn(),
+  findCurrentBuildingDeploy: (...args: unknown[]) => findCurrentBuildingDeployMock(...args),
   findLatestFinishedDeploy: (...args: unknown[]) => findLatestFinishedDeployMock(...args),
   findLatestReadyDeploy: (...args: unknown[]) => findLatestReadyDeployMock(...args),
   isDeployFinished: () => Promise.resolve(false),
-  streamDeploy: vi.fn(),
+  streamDeploy: (...args: unknown[]) => {
+    streamDeployMock(...args)
+  },
 }))
 
 vi.mock('../../../../src/commands/logs/sources/edge-functions.js', () => ({
@@ -18,7 +22,7 @@ vi.mock('../../../../src/commands/logs/sources/edge-functions.js', () => ({
   streamEdgeFunctions: vi.fn(),
 }))
 
-const { logsCommand } = await import('../../../../src/commands/logs/logs.js')
+const { logsCommand, runFollowMode } = await import('../../../../src/commands/logs/logs.js')
 
 const A_VALID_DEPLOY_ID = 'a'.repeat(24)
 
@@ -31,10 +35,27 @@ const makeCommand = () =>
     },
   }) as never
 
+type FollowArgs = Parameters<typeof runFollowMode>[0]
+
+const followArgs = (overrides: Partial<FollowArgs>): FollowArgs => ({
+  sources: ['deploy'],
+  client: {} as never,
+  siteId: 'site-1',
+  accessToken: 'token-1',
+  deployTargeted: false,
+  functionNames: [],
+  edgeFunctionNames: [],
+  levelsToPrint: ['info', 'warn', 'error', 'debug', 'trace', 'fatal'],
+  json: false,
+  ...overrides,
+})
+
 beforeEach(() => {
   fetchDeployHistoricalLogsMock.mockReset().mockResolvedValue([])
   findLatestFinishedDeployMock.mockReset().mockResolvedValue('finished-deploy')
   findLatestReadyDeployMock.mockReset().mockResolvedValue('ready-deploy')
+  streamDeployMock.mockClear()
+  findCurrentBuildingDeployMock.mockReset().mockResolvedValue('building-deploy')
 })
 
 describe('logsCommand deploy auto-selection', () => {
@@ -84,5 +105,31 @@ describe('logsCommand --deploy-id', () => {
 
     expect(fetchDeployHistoricalLogsMock).toHaveBeenCalledTimes(1)
     expect(fetchDeployHistoricalLogsMock.mock.calls[0]?.[0]).toMatchObject({ deployId: A_VALID_DEPLOY_ID })
+  })
+})
+
+describe('runFollowMode deploy targeting', () => {
+  it('streams the explicitly targeted deploy without looking up the building deploy', async () => {
+    await runFollowMode(followArgs({ deployId: 'target-deploy', deployTargeted: true }))
+
+    expect(findCurrentBuildingDeployMock).not.toHaveBeenCalled()
+    expect(streamDeployMock).toHaveBeenCalledTimes(1)
+    expect(streamDeployMock.mock.calls[0]?.[1]).toBe('target-deploy')
+  })
+
+  it('falls back to the current building deploy when nothing is targeted', async () => {
+    await runFollowMode(followArgs({ deployId: 'latest-deploy', deployTargeted: false }))
+
+    expect(findCurrentBuildingDeployMock).toHaveBeenCalledOnce()
+    expect(streamDeployMock).toHaveBeenCalledTimes(1)
+    expect(streamDeployMock.mock.calls[0]?.[1]).toBe('building-deploy')
+  })
+
+  it('streams nothing when no deploy is building and none is targeted', async () => {
+    findCurrentBuildingDeployMock.mockResolvedValue(undefined)
+
+    await runFollowMode(followArgs({ deployId: undefined, deployTargeted: false }))
+
+    expect(streamDeployMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Stacked on #8479.

In `--follow`, stream the explicitly targeted deploy (`--deploy-id` / `--url`) instead of ignoring it and streaming the current building deploy. 

Falls back to the building deploy only when nothing was targeted.

<img width="1645" height="456" alt="image" src="https://github.com/user-attachments/assets/64ed16a2-c10b-4601-8b91-53cc5c6f4b0b" />


*Note:* Currently, if a deploy is targeted and it is a finished deploy, the command doesn't exit at "Site is live". The next PR in the stack will attempt to address this.