### PR TITLE
fix(logs): close the deploy stream when replaying a finished deploy

### DIFF
--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -21,6 +21,7 @@ import {
   findCurrentBuildingDeploy,
   findLatestFinishedDeploy,
   findLatestReadyDeploy,
+  isDeployFinished,
   streamDeploy,
 } from './sources/deploy.js'
 import { fetchEdgeFunctionHistoricalLogs, streamEdgeFunctions } from './sources/edge-functions.js'
@@ -35,6 +36,7 @@ import {
 type Source = 'functions' | 'edge-functions' | 'deploy'
 const VALID_SOURCES: Source[] = ['functions', 'edge-functions', 'deploy']
 const DEFAULT_SINCE = '10m'
+const DEPLOY_STREAM_IDLE_CLOSE_MS = 3_000
 
 const parseSources = (rawSources: string[]): Source[] => {
   const sources: Source[] = []
@@ -399,11 +401,19 @@ export const runFollowMode = async ({
   if (sources.includes('deploy')) {
     const deployStreamId = deployTargeted ? deployId : await findCurrentBuildingDeploy(client, siteId)
     if (deployStreamId) {
-      streamDeploy(siteId, deployStreamId, accessToken, onEntry, () => {
-        if (!json) {
-          log(chalk.dim('Deploy stream closed.'))
-        }
-      })
+      const finished = deployTargeted ? await isDeployFinished(client, siteId, deployStreamId) : false
+      streamDeploy(
+        siteId,
+        deployStreamId,
+        accessToken,
+        onEntry,
+        () => {
+          if (!json) {
+            log(chalk.dim('Deploy stream closed.'))
+          }
+        },
+        { closeWhenIdleMs: finished ? DEPLOY_STREAM_IDLE_CLOSE_MS : undefined },
+      )
     }
   }
 

--- a/src/commands/logs/sources/deploy.ts
+++ b/src/commands/logs/sources/deploy.ts
@@ -13,6 +13,7 @@ interface DeployLogMessage {
 }
 
 const DEPLOY_LOG_REPLAY_TIMEOUT_MS = 30_000
+const DEPLOY_STREAM_START_TIMEOUT_MS = 20_000
 
 const parseDeployLogTimestamp = (message: DeployLogMessage): number | undefined => {
   if (!message.ts) {
@@ -124,8 +125,17 @@ export const streamDeploy = (
   accessToken: string | null | undefined,
   onEntry: (entry: LogEntry) => void,
   onClose: () => void,
+  { closeWhenIdleMs }: { closeWhenIdleMs?: number } = {},
 ): (() => void) => {
   const ws = getWebSocket('wss://socketeer.services.netlify.com/build/logs')
+
+  let closeTimer: ReturnType<typeof setTimeout> | undefined
+  const scheduleClose = (ms: number) => {
+    clearTimeout(closeTimer)
+    closeTimer = setTimeout(() => {
+      ws.close()
+    }, ms)
+  }
 
   ws.on('open', () => {
     ws.send(
@@ -135,6 +145,9 @@ export const streamDeploy = (
         access_token: accessToken,
       }),
     )
+    if (closeWhenIdleMs !== undefined) {
+      scheduleClose(DEPLOY_STREAM_START_TIMEOUT_MS)
+    }
   })
 
   ws.on('message', (data: string) => {
@@ -143,6 +156,9 @@ export const streamDeploy = (
       return
     }
     onEntry(toLogEntry(message, parseDeployLogTimestamp(message) ?? Date.now()))
+    if (closeWhenIdleMs !== undefined) {
+      scheduleClose(closeWhenIdleMs)
+    }
 
     if (isEndOfBuild(message)) {
       ws.close()
@@ -150,10 +166,12 @@ export const streamDeploy = (
   })
 
   ws.on('close', () => {
+    clearTimeout(closeTimer)
     onClose()
   })
 
   return () => {
+    clearTimeout(closeTimer)
     ws.close()
   }
 }
@@ -174,4 +192,9 @@ export const findLatestFinishedDeploy = async (client: NetlifyAPI, siteId: strin
   const deploys = (await client.listSiteDeploys({ siteId, per_page: 10 })) as { id: string; state: string }[]
   const finished = deploys.find((deploy) => FINISHED_DEPLOY_STATES.has(deploy.state))
   return finished?.id
+}
+
+export const isDeployFinished = async (client: NetlifyAPI, siteId: string, deployId: string): Promise<boolean> => {
+  const deploy = (await client.getSiteDeploy({ siteId, deployId })) as { state?: unknown }
+  return typeof deploy.state === 'string' && FINISHED_DEPLOY_STATES.has(deploy.state)
 }

--- a/tests/unit/commands/logs/deploy.test.ts
+++ b/tests/unit/commands/logs/deploy.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../../../src/utils/websockets/index.js', () => ({
   getWebSocket: (url: string) => getWebSocketMock(url),
 }))
 
-const { fetchDeployHistoricalLogs, findLatestFinishedDeploy, findLatestReadyDeploy, streamDeploy } =
+const { fetchDeployHistoricalLogs, findLatestFinishedDeploy, findLatestReadyDeploy, isDeployFinished, streamDeploy } =
   await import('../../../../src/commands/logs/sources/deploy.js')
 
 const FROM = Date.parse('2026-01-01T00:00:00.000Z')
@@ -274,5 +274,86 @@ describe('streamDeploy', () => {
     ws.emit('message', JSON.stringify({ type: 'report', section: 'building' }))
     expect(ws.closed).toBe(true)
     expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes after going idle when closeWhenIdleMs is set', () => {
+    vi.useFakeTimers()
+    try {
+      const onClose = vi.fn()
+      streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), onClose, { closeWhenIdleMs: 3_000 })
+      const [ws] = sockets
+
+      ws.emit('open')
+      ws.emit('message', JSON.stringify({ ts: '2026-01-01T00:05:00.000Z', message: 'replayed line' }))
+      expect(ws.closed).toBe(false)
+
+      vi.advanceTimersByTime(3_000)
+      expect(ws.closed).toBe(true)
+      expect(onClose).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not arm the short idle timer until the first message arrives', () => {
+    vi.useFakeTimers()
+    try {
+      streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), vi.fn(), { closeWhenIdleMs: 3_000 })
+      const [ws] = sockets
+
+      ws.emit('open')
+      // a slow first message (longer than the idle window) must not close the stream early
+      vi.advanceTimersByTime(10_000)
+      expect(ws.closed).toBe(false)
+
+      ws.emit('message', JSON.stringify({ message: 'first line' }))
+      vi.advanceTimersByTime(3_000)
+      expect(ws.closed).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('closes after the start timeout when no message ever arrives', () => {
+    vi.useFakeTimers()
+    try {
+      streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), vi.fn(), { closeWhenIdleMs: 3_000 })
+      const [ws] = sockets
+
+      ws.emit('open')
+      vi.advanceTimersByTime(20_000)
+
+      expect(ws.closed).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not idle-close when closeWhenIdleMs is not set', () => {
+    vi.useFakeTimers()
+    try {
+      streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), vi.fn())
+      const [ws] = sockets
+
+      ws.emit('open')
+      ws.emit('message', JSON.stringify({ message: 'live line' }))
+      vi.advanceTimersByTime(60_000)
+
+      expect(ws.closed).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('isDeployFinished', () => {
+  it.each(['ready', 'error', 'cancelled'])('returns true for the %s state', async (state) => {
+    const client = { getSiteDeploy: vi.fn().mockResolvedValue({ state }) } as never
+    expect(await isDeployFinished(client, 'site-1', 'deploy-1')).toBe(true)
+  })
+
+  it('returns false for an in-progress deploy', async () => {
+    const client = { getSiteDeploy: vi.fn().mockResolvedValue({ state: 'building' }) } as never
+    expect(await isDeployFinished(client, 'site-1', 'deploy-1')).toBe(false)
   })
 })


### PR DESCRIPTION
Stacked on #8480.

## Problem

`--follow` on an already-finished deploy hangs. 

Socketeer replays the stored log then holds the socket open, and for a **successful** deploy it may never send the `report`/`building` marker that `streamDeploy` closes on. This results in the stream never ending and not printing "Deploy stream closed."

## Fix

When following a **targeted** deploy (`--deploy-id`/`--url`) that **is finished** (`ready`/`error`/`cancelled`) close the stream once the replay goes idle. Live builds are unchanged.

### `scheduleClose` machinery (`streamDeploy`)

`streamDeploy` takes an optional `{ closeWhenIdleMs }`. When it's set (replay mode), a single `closeTimer` drives auto-close through one helper:

```ts
const scheduleClose = (ms) => { clearTimeout(closeTimer); closeTimer = setTimeout(() => ws.close(), ms) }
```

- **on connect** → `scheduleClose(DEPLOY_STREAM_START_TIMEOUT_MS)` (20s) — a no-message safety cap so it never hangs if socketeer stays silent.
- **on the first message** → `scheduleClose(closeWhenIdleMs)` (3s), replacing the 20s cap — so a slow start (up to 20s before the first line) can't cause an empty, premature close.
- **each subsequent message** → re-`scheduleClose(3s)` — quick exit once the replay stops.
- **on close / teardown** → `clearTimeout(closeTimer)`.

When `closeWhenIdleMs` is `undefined` (a live build), no timer is armed and behavior is unchanged (closes only on the terminal build report).

Why: closing too early drops log lines, closing too late only delays the exit. The idle timer is only armed *after* the first message, and a longer cap guards the no-output case.

## Tests

`netlify logs --follow --source deploy --deploy-id 6a9a953eed6f7867a85e8dd3` - where the deploy ID has finished:

<img width="1663" height="486" alt="image" src="https://github.com/user-attachments/assets/07b2426b-c4f6-4bbb-bddb-73f27d622c56" />

