### PR TITLE
fix(logs): keep the deploy stream resilient to failed state checks

### DIFF
--- a/src/commands/logs/logs.ts
+++ b/src/commands/logs/logs.ts
@@ -401,7 +401,9 @@ export const runFollowMode = async ({
   if (sources.includes('deploy')) {
     const deployStreamId = deployTargeted ? deployId : await findCurrentBuildingDeploy(client, siteId)
     if (deployStreamId) {
-      const finished = deployTargeted ? await isDeployFinished(client, siteId, deployStreamId) : false
+      const finished = deployTargeted
+        ? await isDeployFinished(client, siteId, deployStreamId).catch(() => false)
+        : false
       streamDeploy(
         siteId,
         deployStreamId,

--- a/src/commands/logs/sources/deploy.ts
+++ b/src/commands/logs/sources/deploy.ts
@@ -137,6 +137,17 @@ export const streamDeploy = (
     }, ms)
   }
 
+  // Closing a still-connecting socket emits an error; handle it (and any other
+  // socket error) so it never surfaces as an unhandled event. The `close` event
+  // that follows runs the cleanup below.
+  ws.on('error', () => {
+    clearTimeout(closeTimer)
+  })
+
+  if (closeWhenIdleMs !== undefined) {
+    scheduleClose(DEPLOY_STREAM_START_TIMEOUT_MS)
+  }
+
   ws.on('open', () => {
     ws.send(
       JSON.stringify({
@@ -145,9 +156,6 @@ export const streamDeploy = (
         access_token: accessToken,
       }),
     )
-    if (closeWhenIdleMs !== undefined) {
-      scheduleClose(DEPLOY_STREAM_START_TIMEOUT_MS)
-    }
   })
 
   ws.on('message', (data: string) => {

--- a/src/commands/logs/sources/deploy.ts
+++ b/src/commands/logs/sources/deploy.ts
@@ -137,9 +137,6 @@ export const streamDeploy = (
     }, ms)
   }
 
-  // Closing a still-connecting socket emits an error; handle it (and any other
-  // socket error) so it never surfaces as an unhandled event. The `close` event
-  // that follows runs the cleanup below.
   ws.on('error', () => {
     clearTimeout(closeTimer)
   })

--- a/tests/unit/commands/logs/deploy.test.ts
+++ b/tests/unit/commands/logs/deploy.test.ts
@@ -329,6 +329,29 @@ describe('streamDeploy', () => {
     }
   })
 
+  it('closes after the start timeout even if the socket never opens', () => {
+    vi.useFakeTimers()
+    try {
+      streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), vi.fn(), { closeWhenIdleMs: 3_000 })
+      const [ws] = sockets
+
+      vi.advanceTimersByTime(20_000)
+
+      expect(ws.closed).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('handles a socket error without throwing (e.g. closed while connecting)', () => {
+    streamDeploy('site-1', 'deploy-1', 'token-1', vi.fn(), vi.fn(), { closeWhenIdleMs: 3_000 })
+    const [ws] = sockets
+
+    expect(() =>
+      ws.emit('error', new Error('WebSocket was closed before the connection was established')),
+    ).not.toThrow()
+  })
+
   it('does not idle-close when closeWhenIdleMs is not set', () => {
     vi.useFakeTimers()
     try {

--- a/tests/unit/commands/logs/logs.test.ts
+++ b/tests/unit/commands/logs/logs.test.ts
@@ -5,13 +5,14 @@ const findLatestFinishedDeployMock = vi.fn<(...args: unknown[]) => Promise<strin
 const findLatestReadyDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
 const streamDeployMock = vi.fn<(...args: unknown[]) => void>()
 const findCurrentBuildingDeployMock = vi.fn<(...args: unknown[]) => Promise<string | undefined>>()
+const isDeployFinishedMock = vi.fn<(...args: unknown[]) => Promise<boolean>>()
 
 vi.mock('../../../../src/commands/logs/sources/deploy.js', () => ({
   fetchDeployHistoricalLogs: (...args: unknown[]) => fetchDeployHistoricalLogsMock(...args),
   findCurrentBuildingDeploy: (...args: unknown[]) => findCurrentBuildingDeployMock(...args),
   findLatestFinishedDeploy: (...args: unknown[]) => findLatestFinishedDeployMock(...args),
   findLatestReadyDeploy: (...args: unknown[]) => findLatestReadyDeployMock(...args),
-  isDeployFinished: () => Promise.resolve(false),
+  isDeployFinished: (...args: unknown[]) => isDeployFinishedMock(...args),
   streamDeploy: (...args: unknown[]) => {
     streamDeployMock(...args)
   },
@@ -56,6 +57,7 @@ beforeEach(() => {
   findLatestReadyDeployMock.mockReset().mockResolvedValue('ready-deploy')
   streamDeployMock.mockClear()
   findCurrentBuildingDeployMock.mockReset().mockResolvedValue('building-deploy')
+  isDeployFinishedMock.mockReset().mockResolvedValue(false)
 })
 
 describe('logsCommand deploy auto-selection', () => {
@@ -131,5 +133,14 @@ describe('runFollowMode deploy targeting', () => {
     await runFollowMode(followArgs({ deployId: undefined, deployTargeted: false }))
 
     expect(streamDeployMock).not.toHaveBeenCalled()
+  })
+
+  it('still streams the targeted deploy when the completion check fails', async () => {
+    isDeployFinishedMock.mockRejectedValue(new Error('api down'))
+
+    await runFollowMode(followArgs({ deployId: 'target-deploy', deployTargeted: true }))
+
+    expect(streamDeployMock).toHaveBeenCalledTimes(1)
+    expect(streamDeployMock.mock.calls[0]?.[1]).toBe('target-deploy')
   })
 })


### PR DESCRIPTION
Follow-up to the logs stack (all merged). Addresses two CodeRabbit findings on #8481:

- **runFollowMode** (`logs.ts`): a rejected `isDeployFinished` check dropped a targeted deploy stream (a regression once the completion check was added). Treat a failed check as unfinished so streaming continues, matching the untargeted path.
- **streamDeploy** (`deploy.ts`): the safety timeout was armed inside the `open` handler, so a socket that never opens could hang past the start timeout. Arm it when the socket is created instead.

Tests: added a rejection case for the targeted-follow path and a "never opens" case for the start timeout. No behavior change for the happy paths.
