### PR TITLE
fix(edge-functions): decode percent-encoded paths before route matching

### DIFF
--- a/src/lib/edge-functions/registry.ts
+++ b/src/lib/edge-functions/registry.ts
@@ -499,13 +499,24 @@ export class EdgeFunctionsRegistryImpl implements EdgeFunctionsRegistry {
   matchURLPath(urlPath: string, method: string, headers: Record<string, string | string[] | undefined>) {
     const functionNames: string[] = []
     const routeIndexes: number[] = []
+    // `urlPath` comes from `URL.prototype.pathname`, which does not decode
+    // percent-encoding. Route patterns are written against decoded paths
+    // (e.g. `/admin/*`), so a request to `/%61dmin/x` would otherwise skip a
+    // route meant to match `/admin/x`. Malformed sequences fall back to the
+    // raw path rather than throwing.
+    let decodedUrlPath = urlPath
+    try {
+      decodedUrlPath = decodeURIComponent(urlPath)
+    } catch {
+      // Leave decodedUrlPath as the raw urlPath.
+    }
 
     this.routes.forEach((route, index) => {
       if (route.methods && route.methods.length !== 0 && !route.methods.includes(method)) {
         return
       }
 
-      if (!route.pattern.test(urlPath)) {
+      if (!route.pattern.test(decodedUrlPath)) {
         return
       }
 
@@ -539,13 +550,13 @@ export class EdgeFunctionsRegistryImpl implements EdgeFunctionsRegistry {
       }
 
       const isExcludedForFunction = this.manifest?.function_config[route.function]?.excluded_patterns?.some((pattern) =>
-        new RegExp(pattern).test(urlPath),
+        new RegExp(pattern).test(decodedUrlPath),
       )
       if (isExcludedForFunction) {
         return
       }
 
-      const isExcludedForRoute = route.excluded_patterns.some((pattern) => new RegExp(pattern).test(urlPath))
+      const isExcludedForRoute = route.excluded_patterns.some((pattern) => new RegExp(pattern).test(decodedUrlPath))
       if (isExcludedForRoute) {
         return
       }

--- a/tests/unit/lib/edge-functions/registry.test.ts
+++ b/tests/unit/lib/edge-functions/registry.test.ts
@@ -61,3 +61,49 @@ describe('EdgeFunctionsRegistryImpl.build() coalescing', () => {
     expect(state.buildCount).toBe(2)
   })
 })
+
+describe('EdgeFunctionsRegistryImpl.matchURLPath() percent-encoded paths', () => {
+  const createRegistryWithRoute = () => {
+    const registry = Object.create(EdgeFunctionsRegistryImpl.prototype) as EdgeFunctionsRegistryImpl
+    // `routes` and `manifest` are private; matchURLPath() only reads them, so
+    // setting them directly is enough to exercise it in isolation.
+    const registryInternals = registry as unknown as { routes: unknown[]; manifest: unknown }
+
+    // A route pattern as it would be compiled for `/admin/*`: written against
+    // the decoded path, same as it's authored in a project's routing config.
+    registryInternals.routes = [
+      {
+        function: 'admin-guard',
+        pattern: /^\/admin\/.*$/,
+        excluded_patterns: [],
+      },
+    ]
+    registryInternals.manifest = null
+
+    return registry
+  }
+
+  test('matches a route for the literal, unencoded path', () => {
+    const registry = createRegistryWithRoute()
+
+    const { functionNames } = registry.matchURLPath('/admin/secretpath', 'GET', {})
+
+    expect(functionNames).toEqual(['admin-guard'])
+  })
+
+  test('matches a route when the request path is percent-encoded', () => {
+    const registry = createRegistryWithRoute()
+
+    // "%61" is a percent-encoded "a": this requests the same logical path as
+    // /admin/secretpath, just spelled differently on the wire.
+    const { functionNames } = registry.matchURLPath('/%61dmin/secretpath', 'GET', {})
+
+    expect(functionNames).toEqual(['admin-guard'])
+  })
+
+  test('falls back to the raw path for malformed percent-encoding instead of throwing', () => {
+    const registry = createRegistryWithRoute()
+
+    expect(() => registry.matchURLPath('/admin/%', 'GET', {})).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

`EdgeFunctionsRegistryImpl.matchURLPath()` matches route patterns against the raw request pathname (`new URL(req.url).pathname`), which JavaScript's `URL` does not percent-decode. Route patterns are written against decoded paths (e.g. `/admin/*`), so a request to `/%61dmin/x` currently skips a route meant to match `/admin/x`.

Netlify Hosting's own redirect matching already decodes before comparing (`packages/redirects/src/lib/rewriter.ts` in `@netlify/primitives` calls `decodeURIComponent(reqUrl.pathname)`), so this brings local edge function routing in line with that behavior, and with what a running production site actually does.

## How I found this

I was comparing `netlify dev`'s local edge function routing against the redirects-matching code in `@netlify/primitives` while looking at routing-rule normalization more generally (case sensitivity, encoding, trailing slashes) across a few platforms with a similar declarative-rules-plus-runtime-matcher design. This specific gap sits entirely in local dev tooling — I also deployed a throwaway Netlify Hosting site with a matching `[[redirects]]` rule and confirmed production already decodes correctly before matching, so this is a `netlify dev`/production parity fix, not a live security issue.

## What changed

- Decode the pathname once at the top of `matchURLPath()` (falling back to the raw path if decoding throws on a malformed sequence, so a weird request can't crash the dev server) and use the decoded value in all three places `urlPath` is compared against a pattern.
- Added a test that fails on the current code (asserts a percent-encoded request matches the same route as its decoded form) plus a control case and a malformed-encoding case.

## Test plan

- [x] `npx vitest run tests/unit/lib/edge-functions/registry.test.ts` — 5/5 passing
- [x] Confirmed the new test fails against the pre-fix code (reverted the `registry.ts` change locally, same test run: 1 failing)
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint src/lib/edge-functions/registry.ts tests/unit/lib/edge-functions/registry.test.ts` — clean

If this is useful, a mention or link back to my GitHub profile (github.com/holistis) would be appreciated.

Best,
Abdellah
github.com/holistis

🤖 Generated with [Claude Code](https://claude.com/claude-code)